### PR TITLE
Add colibri_common.c and update CMakeLists.txt for unified RPC API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -577,7 +577,7 @@ endif()
 
 # Shared library if requested and not embedded
 if(SHAREDLIB AND NOT EMBEDDED)
-    add_library(c4 SHARED src/util/version.c bindings/colibri.c)
+    add_library(c4 SHARED src/util/version.c bindings/colibri.c bindings/colibri_common.c)
     target_link_libraries(c4 PRIVATE crypto verifier util blst  prover    verifier eth_verifier)
     set_target_properties(c4 PROPERTIES
         LIBRARY_OUTPUT_DIRECTORY ${OUTPUT_DIRECTORY}

--- a/bindings/colibri.c
+++ b/bindings/colibri.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 corpus.core
+ * Copyright (c) 2025,2026 corpus.core
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -22,13 +22,11 @@
  */
 
 #include "colibri.h"
-#include "version.h"
+#include "colibri_common.h"
 #include "beacon_types.h"
 #include "plugin.h"
-#include "prover.h"
-#include "ssz.h"
 #include "sync_committee.h"
-#include "verify.h"
+#include "version.h"
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -43,116 +41,26 @@ typedef struct {
 } c4_verify_ctx_t;
 
 prover_t* c4_create_prover_ctx(char* method, char* params, uint64_t chain_id, uint32_t flags) {
-  //  fprintf(stderr, "c4_create_prover_ctx: %s, %s\n", method, params);
   return (void*) c4_prover_create(method, params, chain_id, flags);
 }
 
-static const char* status_to_string(c4_status_t status) {
-  switch (status) {
-    case C4_SUCCESS:
-      return "success";
-    case C4_ERROR:
-      return "error";
-    case C4_PENDING:
-      return "pending";
-  }
-}
-
-static const char* encoding_to_string(data_request_encoding_t encoding) {
-  switch (encoding) {
-    case C4_DATA_ENCODING_SSZ:
-      return "ssz";
-    case C4_DATA_ENCODING_JSON:
-      return "json";
-  }
-}
-
-static const char* method_to_string(data_request_method_t method) {
-  switch (method) {
-    case C4_DATA_METHOD_GET:
-      return "get";
-    case C4_DATA_METHOD_POST:
-      return "post";
-    case C4_DATA_METHOD_PUT:
-      return "put";
-    case C4_DATA_METHOD_DELETE:
-      return "delete";
-  }
-}
-
-static const char* data_request_type_to_string(data_request_type_t type) {
-  switch (type) {
-    case C4_DATA_TYPE_BEACON_API:
-      return "beacon_api";
-    case C4_DATA_TYPE_ETH_RPC:
-      return "eth_rpc";
-    case C4_DATA_TYPE_REST_API:
-      return "rest_api";
-    case C4_DATA_TYPE_CHECKPOINTZ:
-      return "checkpointz";
-    case C4_DATA_TYPE_PROVER:
-      return "prover";
-    case C4_DATA_TYPE_INTERN:
-      return "internal";
-  }
-}
-static void add_data_request(buffer_t* result, data_request_t* data_request) {
-  /* Emit req_ptr as string so 64-bit pointers survive JSON (no double precision loss). */
-  bprintf(result, "{\"req_ptr\": \"%l\",", (uint64_t)(uintptr_t) data_request);
-  bprintf(result, "\"chain_id\": %d,", (uint32_t) data_request->chain_id);
-  bprintf(result, "\"encoding\": \"%s\",", encoding_to_string(data_request->encoding));
-  bprintf(result, "\"exclude_mask\": \"%d\",", (uint32_t) data_request->node_exclude_mask);
-  bprintf(result, "\"method\": \"%s\",", method_to_string(data_request->method));
-  bprintf(result, "\"url\": \"%s\",", data_request->url);
-  if (data_request->payload.data)
-    bprintf(result, "\"payload\": %j,", (json_t) {.len = data_request->payload.len, .start = (char*) data_request->payload.data, .type = JSON_TYPE_OBJECT});
-  bprintf(result, "\"type\": \"%s\"}", data_request_type_to_string(data_request->type));
-}
-
 char* c4_prover_execute_json_status(prover_t* prover) {
-  buffer_t      result = {0};
   prover_ctx_t* ctx    = (prover_ctx_t*) prover;
   c4_status_t   status = c4_prover_execute(ctx);
-  bprintf(&result, "{\"status\": \"%s\",", status_to_string(status));
-  switch (status) {
-    case C4_SUCCESS:
-      bprintf(&result, "\"result\": \"0x%lx\", \"result_len\": %d", (uint64_t) ctx->proof.data, ctx->proof.len);
-      break;
-    case C4_ERROR:
-      bprintf(&result, "\"error\": \"%S\"", ctx->state.error);
-      break;
-    case C4_PENDING: {
-      bprintf(&result, "\"requests\": [");
-      data_request_t* data_request = c4_state_get_pending_request(&ctx->state);
-      while (data_request) {
-        if (!data_request->response.data && !data_request->error) {
-          if (result.data.data[result.data.len - 1] != '[') bprintf(&result, ",");
-          add_data_request(&result, data_request);
-        }
-        data_request = data_request->next;
-      }
-
-      bprintf(&result, "]");
-      break;
-    }
-  }
-  bprintf(&result, "}");
-  //  fprintf(stderr, "c4_prover_execute_json_status result: %s\n", result.data.data);
-  return buffer_as_string(result);
+  return c4i_build_prover_json_status(status, &ctx->state, ctx->proof.data, ctx->proof.len, true);
 }
 
 void c4_free_prover_ctx(prover_t* ctx) {
   c4_prover_free((prover_ctx_t*) ctx);
 }
+
 void c4_req_set_response(void* req_ptr, bytes_t data, uint16_t node_index) {
-  //  fprintf(stderr, "c4_req_set_response: %p\n : %d\n", req_ptr, data.len);
   data_request_t* ctx      = (data_request_t*) req_ptr;
   ctx->response            = bytes_dup(bytes(data.data, data.len));
   ctx->response_node_index = node_index;
 }
 
 void c4_req_set_error(void* req_ptr, char* error, uint16_t node_index) {
-  //  fprintf(stderr, "c4_req_set_error: %p : %s\n", req_ptr, error);
   data_request_t* ctx      = (data_request_t*) req_ptr;
   ctx->error               = strdup(error);
   ctx->response_node_index = node_index;
@@ -166,7 +74,7 @@ bytes_t c4_prover_get_proof(prover_t* prover) {
 void* c4_verify_create_ctx(bytes_t proof, char* method, char* args, uint64_t chain_id, char* trusted_checkpoint, uint32_t flags) {
   c4_verify_ctx_t* ctx = calloc(1, sizeof(c4_verify_ctx_t));
   ctx->proof           = bytes_dup(proof);
-  c4_verify_init(&ctx->ctx, ctx->proof, method ? strdup(method) : NULL, args ? json_parse(strdup(args)) : ((json_t) {0}), (chain_id_t) chain_id, (verify_flags_t) flags);
+  c4_verify_init(&ctx->ctx, ctx->proof, method ? strdup(method) : NULL, args ? json_parse(strdup(args)) : ((json_t){0}), (chain_id_t) chain_id, (verify_flags_t) flags);
   if (trusted_checkpoint && strlen(trusted_checkpoint) == 66) {
     bytes32_t checkpoint;
     hex_to_bytes(trusted_checkpoint + 2, 64, bytes(checkpoint, 32));
@@ -176,35 +84,9 @@ void* c4_verify_create_ctx(bytes_t proof, char* method, char* args, uint64_t cha
 }
 
 char* c4_verify_execute_json_status(void* ptr) {
-  buffer_t         buf    = {0};
   c4_verify_ctx_t* ctx    = (c4_verify_ctx_t*) ptr;
   c4_status_t      status = c4_verify(&ctx->ctx);
-
-  bprintf(&buf, "{\"status\": \"%s\",", status_to_string(status));
-  switch (status) {
-    case C4_SUCCESS:
-      bprintf(&buf, "\"result\": %Z", ctx->ctx.data);
-      break;
-    case C4_ERROR:
-      bprintf(&buf, "\"error\": \"%S\"", ctx->ctx.state.error);
-      break;
-    case C4_PENDING: {
-      bprintf(&buf, "\"requests\": [");
-      data_request_t* data_request = c4_state_get_pending_request(&(ctx->ctx.state));
-      while (data_request) {
-        if (!data_request->response.data && !data_request->error) {
-          if (buf.data.data[buf.data.len - 1] != '[') bprintf(&buf, ",");
-          add_data_request(&buf, data_request);
-        }
-        data_request = data_request->next;
-      }
-
-      bprintf(&buf, "]");
-      break;
-    }
-  }
-  bprintf(&buf, "}");
-  return buffer_as_string(buf);
+  return c4i_build_verifier_json_status(status, &ctx->ctx.state, ctx->ctx.data, true);
 }
 
 void c4_verify_free_ctx(void* ptr) {
@@ -218,9 +100,25 @@ void c4_verify_free_ctx(void* ptr) {
 
 int c4_get_method_support(uint64_t chain_id, char* method, char* params, uint32_t flags) {
   return (int) c4_get_method_type((chain_id_t) chain_id, method,
-                                  params ? json_parse(params) : (json_t) {0}, (verify_flags_t) flags);
+                                  params ? json_parse(params) : (json_t){0}, (verify_flags_t) flags);
 }
 
 uint32_t c4_get_current_version_number(void) {
   return c4_current_version_number();
+}
+
+/* ── Unified RPC API ── */
+
+void* c4_create_rpc_ctx(char* method, char* params, uint64_t chain_id, uint32_t prover_flags, uint32_t verify_flags, int use_remote_prover) {
+  return (void*) c4_rpc_ctx_create(method, params, (chain_id_t) chain_id,
+                                   (prover_flags_t) prover_flags, (verify_flags_t) verify_flags,
+                                   use_remote_prover != 0);
+}
+
+char* c4_rpc_execute_json_status(void* ctx) {
+  return c4_rpc_build_json_status((c4_rpc_ctx_t*) ctx, true);
+}
+
+void c4_free_rpc_ctx(void* ctx) {
+  c4_rpc_ctx_free((c4_rpc_ctx_t*) ctx);
 }

--- a/bindings/colibri.c
+++ b/bindings/colibri.c
@@ -75,11 +75,7 @@ void* c4_verify_create_ctx(bytes_t proof, char* method, char* args, uint64_t cha
   c4_verify_ctx_t* ctx = calloc(1, sizeof(c4_verify_ctx_t));
   ctx->proof           = bytes_dup(proof);
   c4_verify_init(&ctx->ctx, ctx->proof, method ? strdup(method) : NULL, args ? json_parse(strdup(args)) : ((json_t){0}), (chain_id_t) chain_id, (verify_flags_t) flags);
-  if (trusted_checkpoint && strlen(trusted_checkpoint) == 66) {
-    bytes32_t checkpoint;
-    hex_to_bytes(trusted_checkpoint + 2, 64, bytes(checkpoint, 32));
-    c4_eth_set_trusted_checkpoint(chain_id, checkpoint);
-  }
+  c4_set_checkpoint((chain_id_t) chain_id, trusted_checkpoint);
   return (void*) ctx;
 }
 
@@ -117,6 +113,10 @@ void* c4_create_rpc_ctx(char* method, char* params, uint64_t chain_id, uint32_t 
 
 char* c4_rpc_execute_json_status(void* ctx) {
   return c4_rpc_build_json_status((c4_rpc_ctx_t*) ctx, true);
+}
+
+void c4_rpc_set_witness_keys(void* ctx, const char* witness_keys) {
+  c4_rpc_ctx_set_witness_keys((c4_rpc_ctx_t*) ctx, witness_keys);
 }
 
 void c4_free_rpc_ctx(void* ctx) {

--- a/bindings/colibri.h
+++ b/bindings/colibri.h
@@ -1252,6 +1252,29 @@ uint32_t c4_get_current_version_number(void);
 void* c4_create_rpc_ctx(char* method, char* params, uint64_t chain_id, uint32_t prover_flags, uint32_t verify_flags, int use_remote_prover);
 
 /**
+ * Sets a trusted checkpoint for a chain (context-independent).
+ *
+ * Parses a hex checkpoint string and stores it globally for the given chain.
+ * Call this once before any verification if the host has a known checkpoint.
+ * The checkpoint persists across all prover/verifier/RPC contexts for the chain.
+ *
+ * @param chain_id target chain ID
+ * @param trusted_checkpoint hex string with "0x" prefix (66 chars total), or NULL (no-op)
+ */
+void c4_set_checkpoint(uint64_t chain_id, const char* trusted_checkpoint);
+
+/**
+ * Sets witness/signer keys on an RPC context (hex-encoded).
+ *
+ * Used for sync committee weak subjectivity signing during proof generation
+ * (sent to remote prover as `"signers"`) and verification.
+ *
+ * @param ctx The RPC context created by `c4_create_rpc_ctx()`
+ * @param witness_keys hex string with "0x" prefix (e.g. "0xabcd..."), or NULL to clear
+ */
+void c4_rpc_set_witness_keys(void* ctx, const char* witness_keys);
+
+/**
  * Executes one step of the unified RPC state machine.
  *
  * This function drives the full RPC lifecycle: method type detection, proof generation

--- a/bindings/colibri.h
+++ b/bindings/colibri.h
@@ -1204,3 +1204,103 @@ int c4_get_method_support(uint64_t chain_id, char* method, char* params, uint32_
  * @return The current version number
  */
 uint32_t c4_get_current_version_number(void);
+
+// :: Unified RPC API
+//
+// The unified RPC API combines method type detection, proof generation (local or remote),
+// and verification into a single context. This eliminates the need for bindings to implement
+// the orchestration logic (method type check, prover/verifier decision, proof flow).
+//
+// The host system only needs to:
+// 1. Create an RPC context with `c4_create_rpc_ctx()`
+// 2. Call `c4_rpc_execute_json_status()` in a loop
+// 3. Handle pending data requests (same as with prover/verifier APIs)
+// 4. Free the context with `c4_free_rpc_ctx()`
+//
+// The existing `c4_create_prover_ctx()` and `c4_verify_create_ctx()` APIs remain
+// available for use cases that need separate proof generation and verification
+// (e.g. proof transport via Bluetooth to embedded devices).
+//
+
+/**
+ * Creates a unified RPC context that handles method type detection, proof generation, and verification.
+ *
+ * This is a convenience API that wraps the separate prover and verifier APIs. It automatically
+ * determines whether a method is proofable, local, or unproofable, and drives the appropriate
+ * flow internally.
+ *
+ * @param method The Ethereum RPC method (e.g., "eth_getBalance")
+ * @param params The method parameters as a JSON array string
+ * @param chain_id The blockchain chain ID
+ * @param prover_flags Flags for proof generation (see prover flag types)
+ * @param verify_flags Flags for verification (e.g., 2 for `VERIFY_FLAG_PAP`)
+ * @param use_remote_prover If non-zero, request proof from a remote prover server instead of generating locally
+ * @return A new RPC context pointer, or NULL if creation failed
+ *
+ * **Example**:
+ * ```c
+ * void* ctx = c4_create_rpc_ctx(
+ *     "eth_getBalance",
+ *     "[\"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045\", \"latest\"]",
+ *     1,    // Ethereum Mainnet
+ *     0,    // No special prover flags
+ *     0,    // No special verify flags
+ *     1     // Use remote prover
+ * );
+ * ```
+ */
+void* c4_create_rpc_ctx(char* method, char* params, uint64_t chain_id, uint32_t prover_flags, uint32_t verify_flags, int use_remote_prover);
+
+/**
+ * Executes one step of the unified RPC state machine.
+ *
+ * This function drives the full RPC lifecycle: method type detection, proof generation
+ * (or remote proof fetching), and verification. Call it repeatedly until it returns
+ * `"success"` or `"error"`.
+ *
+ * The returned JSON format is identical to `c4_verify_execute_json_status()`:
+ * - `"success"` with a `"result"` field containing the verified RPC result
+ * - `"error"` with an `"error"` field
+ * - `"pending"` with a `"requests"` array of data requests to fulfill
+ *
+ * For `"pending"` responses, the `"requests"` array may contain requests of type `"prover"`
+ * (when using a remote prover) or `"eth_rpc"` (for unproofable methods), in addition to
+ * the usual `"beacon_api"` and `"eth_rpc"` requests from the prover/verifier.
+ *
+ * **Memory Management**: The returned JSON string must be freed by the caller using `free()`.
+ *
+ * @param ctx The RPC context created by `c4_create_rpc_ctx()`
+ * @return A JSON string describing the current status
+ *
+ * **Example**:
+ * ```c
+ * void* ctx = c4_create_rpc_ctx("eth_getBalance", "[\"0xabc...\", \"latest\"]", 1, 0, 0, 0);
+ *
+ * while (1) {
+ *     char* status_json = c4_rpc_execute_json_status(ctx);
+ *     json_t status = parse_json(status_json);
+ *     free(status_json);
+ *
+ *     if (strcmp(status.status, "success") == 0) {
+ *         printf("Result: %s\n", json_stringify(status.result));
+ *         break;
+ *     } else if (strcmp(status.status, "error") == 0) {
+ *         fprintf(stderr, "Error: %s\n", status.error);
+ *         break;
+ *     } else if (strcmp(status.status, "pending") == 0) {
+ *         for (int i = 0; i < status.requests_count; i++)
+ *             handle_request(&status.requests[i]);
+ *     }
+ * }
+ *
+ * c4_free_rpc_ctx(ctx);
+ * ```
+ */
+char* c4_rpc_execute_json_status(void* ctx);
+
+/**
+ * Frees all resources associated with an RPC context.
+ *
+ * @param ctx The RPC context to free (may be NULL, in which case this is a no-op)
+ */
+void c4_free_rpc_ctx(void* ctx);

--- a/bindings/colibri_common.c
+++ b/bindings/colibri_common.c
@@ -84,19 +84,17 @@ void c4i_add_data_request(buffer_t* result, data_request_t* req, bool req_ptr_as
   bprintf(result, "\"method\": \"%s\",", method_to_string(req->method));
   bprintf(result, "\"url\": \"%s\",", req->url);
   if (req->payload.data)
-    bprintf(result, "\"payload\": %j,", (json_t){.len = req->payload.len, .start = (char*) req->payload.data, .type = JSON_TYPE_OBJECT});
+    bprintf(result, "\"payload\": %j,", (json_t) {.len = req->payload.len, .start = (char*) req->payload.data, .type = JSON_TYPE_OBJECT});
   bprintf(result, "\"type\": \"%s\"}", data_request_type_to_string(req->type));
 }
 
 static void append_pending_requests(buffer_t* buf, c4_state_t* state, bool req_ptr_as_string) {
   bprintf(buf, "\"requests\": [");
-  data_request_t* req = c4_state_get_pending_request(state);
-  while (req) {
+  for (data_request_t* req = c4_state_get_pending_request(state); req; req = req->next) {
     if (!req->response.data && !req->error) {
       if (buf->data.data[buf->data.len - 1] != '[') bprintf(buf, ",");
       c4i_add_data_request(buf, req, req_ptr_as_string);
     }
-    req = req->next;
   }
   bprintf(buf, "]");
 }
@@ -131,12 +129,12 @@ char* c4i_build_prover_json_status(c4_status_t status, c4_state_t* state,
 
 char* c4i_build_verifier_json_status(c4_status_t status, c4_state_t* state,
                                      ssz_ob_t result,
-                                     bool req_ptr_as_string) {
+                                     bool     req_ptr_as_string) {
   buffer_t buf = {0};
   bprintf(&buf, "{\"status\": \"%s\",", status_to_string(status));
-  if (status == C4_SUCCESS) 
-    return bprintf(&buf, "\"result\": %Z}", result);
-  return build_error_or_pending(&buf, status, state, req_ptr_as_string);
+  return status == C4_SUCCESS
+             ? bprintf(&buf, "\"result\": %Z}", result)
+             : build_error_or_pending(&buf, status, state, req_ptr_as_string);
 }
 
 /* ── Standalone checkpoint setter ── */
@@ -165,20 +163,23 @@ c4_rpc_ctx_t* c4_rpc_ctx_create(const char* method, const char* params, chain_id
     ctx->phase = RPC_PHASE_DONE;
     return ctx;
   }
-  ctx->method             = strdup(method);
-  ctx->params             = strdup(params ? params : "[]");
-  ctx->chain_id           = chain_id;
-  ctx->prover_flags       = prover_flags;
-  ctx->verify_flags       = verify_flags;
-  ctx->use_remote_prover  = use_remote_prover;
-  ctx->phase              = RPC_PHASE_INIT;
-  ctx->method_type        = METHOD_UNDEFINED;
+  ctx->method            = strdup(method);
+  ctx->params            = strdup(params ? params : "[]");
+  ctx->chain_id          = chain_id;
+  ctx->prover_flags      = prover_flags;
+  ctx->verify_flags      = verify_flags;
+  ctx->use_remote_prover = use_remote_prover;
+  ctx->phase             = RPC_PHASE_INIT;
+  ctx->method_type       = METHOD_UNDEFINED;
   return ctx;
 }
 
 void c4_rpc_ctx_set_witness_keys(c4_rpc_ctx_t* ctx, const char* keys_hex) {
   if (!ctx) return;
-  if (ctx->witness_keys.data) { free(ctx->witness_keys.data); ctx->witness_keys = NULL_BYTES; }
+  if (ctx->witness_keys.data) {
+    free(ctx->witness_keys.data);
+    ctx->witness_keys = NULL_BYTES;
+  }
   if (keys_hex && strlen(keys_hex) > 4 && keys_hex[0] == '0' && keys_hex[1] == 'x') {
     uint32_t hex_len = strlen(keys_hex) - 2;
     if (hex_len % 2 != 0) return;
@@ -208,8 +209,8 @@ static c4_status_t rpc_start_verifier(c4_rpc_ctx_t* ctx, bytes_t proof) {
 static c4_status_t rpc_handle_proving(c4_rpc_ctx_t* ctx) {
   c4_status_t status = c4_prover_execute(ctx->prover);
   if (status == C4_SUCCESS) {
-    ctx->proof       = bytes_dup(ctx->prover->proof);
-    ctx->proof_owned = true;
+    ctx->proof       = ctx->prover->proof;
+    ctx->proof_owned = false;
     return rpc_start_verifier(ctx, ctx->proof);
   }
   return status;
@@ -245,7 +246,7 @@ static void cleanup_remote_prover_params(buffer_t* buf, const char* method, cons
 
 static c4_status_t rpc_handle_remote_proof(c4_rpc_ctx_t* ctx) {
   if (!ctx->rpc_state.requests) {
-    ctx->rpc_state.requests = safe_calloc(1, sizeof(data_request_t));
+    ctx->rpc_state.requests           = safe_calloc(1, sizeof(data_request_t));
     ctx->rpc_state.requests->type     = C4_DATA_TYPE_PROVER;
     ctx->rpc_state.requests->chain_id = ctx->chain_id;
     ctx->rpc_state.requests->method   = C4_DATA_METHOD_POST;
@@ -287,8 +288,8 @@ static c4_status_t rpc_handle_remote_proof(c4_rpc_ctx_t* ctx) {
   }
 
   if (ctx->rpc_state.requests->response.data) {
-    ctx->proof       = bytes_dup(ctx->rpc_state.requests->response);
-    ctx->proof_owned = true;
+    ctx->proof       = ctx->rpc_state.requests->response;
+    ctx->proof_owned = false;
     return rpc_start_verifier(ctx, ctx->proof);
   }
 
@@ -297,7 +298,7 @@ static c4_status_t rpc_handle_remote_proof(c4_rpc_ctx_t* ctx) {
 
 static c4_status_t rpc_handle_unproofable(c4_rpc_ctx_t* ctx) {
   if (!ctx->rpc_state.requests) {
-    ctx->rpc_state.requests = safe_calloc(1, sizeof(data_request_t));
+    ctx->rpc_state.requests           = safe_calloc(1, sizeof(data_request_t));
     ctx->rpc_state.requests->type     = C4_DATA_TYPE_ETH_RPC;
     ctx->rpc_state.requests->chain_id = ctx->chain_id;
     ctx->rpc_state.requests->method   = C4_DATA_METHOD_POST;
@@ -305,7 +306,7 @@ static c4_status_t rpc_handle_unproofable(c4_rpc_ctx_t* ctx) {
 
     buffer_t payload = {0};
     bprintf(&payload, "{\"method\": \"%s\", \"params\": %s}", ctx->method, ctx->params);
-    ctx->rpc_state.requests->payload =payload.data;
+    ctx->rpc_state.requests->payload = payload.data;
 
     return C4_PENDING;
   }
@@ -445,9 +446,9 @@ char* c4_rpc_build_json_status(c4_rpc_ctx_t* ctx, bool req_ptr_as_string) {
 
   switch (status) {
     case C4_SUCCESS:
-      if (ctx->phase == RPC_PHASE_DONE && ctx->method_type == METHOD_UNPROOFABLE) 
+      if (ctx->phase == RPC_PHASE_DONE && ctx->method_type == METHOD_UNPROOFABLE)
         bprintf(&buf, "\"result\": %r", ctx->rpc_state.requests->response);
-      else 
+      else
         bprintf(&buf, "\"result\": %Z", ctx->verifier.data);
       break;
 

--- a/bindings/colibri_common.c
+++ b/bindings/colibri_common.c
@@ -279,9 +279,11 @@ static c4_status_t rpc_handle_remote_proof(c4_rpc_ctx_t* ctx) {
   }
 
   if (ctx->rpc_state.requests->error) {
-    ctx->error = bprintf(NULL, "Remote prover failed: %s", ctx->rpc_state.requests->error);
-    ctx->phase = RPC_PHASE_DONE;
-    return C4_ERROR;
+    c4_request_free(ctx->rpc_state.requests);
+    ctx->rpc_state.requests = NULL;
+    ctx->prover             = c4_prover_create(ctx->method, ctx->params, ctx->chain_id, ctx->prover_flags);
+    ctx->phase              = RPC_PHASE_PROVING;
+    return rpc_handle_proving(ctx);
   }
 
   if (ctx->rpc_state.requests->response.data) {

--- a/bindings/colibri_common.c
+++ b/bindings/colibri_common.c
@@ -22,7 +22,11 @@
  */
 
 #include "colibri_common.h"
+#include "plugin.h"
 #include "version.h"
+#ifdef CHAIN_ETH
+#include "sync_committee.h"
+#endif
 #include <stdlib.h>
 #include <string.h>
 
@@ -116,8 +120,12 @@ char* c4i_build_prover_json_status(c4_status_t status, c4_state_t* state,
                                    bool req_ptr_as_string) {
   buffer_t buf = {0};
   bprintf(&buf, "{\"status\": \"%s\",", status_to_string(status));
-  if (status == C4_SUCCESS) 
-    return bprintf(&buf, "\"result\": \"0x%lx\", \"result_len\": %d}", (uint64_t) (uintptr_t) proof_ptr, proof_len);
+  if (status == C4_SUCCESS) {
+    if (req_ptr_as_string)
+      return bprintf(&buf, "\"result\": \"0x%lx\", \"result_len\": %d}", (uint64_t) (uintptr_t) proof_ptr, proof_len);
+    else
+      return bprintf(&buf, "\"result\": %l, \"result_len\": %d}", (uint64_t) (uintptr_t) proof_ptr, proof_len);
+  }
   return build_error_or_pending(&buf, status, state, req_ptr_as_string);
 }
 
@@ -129,6 +137,21 @@ char* c4i_build_verifier_json_status(c4_status_t status, c4_state_t* state,
   if (status == C4_SUCCESS) 
     return bprintf(&buf, "\"result\": %Z}", result);
   return build_error_or_pending(&buf, status, state, req_ptr_as_string);
+}
+
+/* ── Standalone checkpoint setter ── */
+
+void c4_set_checkpoint(chain_id_t chain_id, const char* checkpoint_hex) {
+#ifdef CHAIN_ETH
+  if (checkpoint_hex && strlen(checkpoint_hex) == 66) {
+    bytes32_t checkpoint;
+    if (hex_to_bytes(checkpoint_hex + 2, 64, bytes(checkpoint, 32)) == 32)
+      c4_eth_set_trusted_checkpoint(chain_id, checkpoint);
+  }
+#else
+  (void) chain_id;
+  (void) checkpoint_hex;
+#endif
 }
 
 /* ── rpc_ctx lifecycle ── */
@@ -153,6 +176,20 @@ c4_rpc_ctx_t* c4_rpc_ctx_create(const char* method, const char* params, chain_id
   return ctx;
 }
 
+void c4_rpc_ctx_set_witness_keys(c4_rpc_ctx_t* ctx, const char* keys_hex) {
+  if (!ctx) return;
+  if (ctx->witness_keys.data) { free(ctx->witness_keys.data); ctx->witness_keys = NULL_BYTES; }
+  if (keys_hex && strlen(keys_hex) > 4 && keys_hex[0] == '0' && keys_hex[1] == 'x') {
+    uint32_t hex_len = strlen(keys_hex) - 2;
+    if (hex_len % 2 != 0) return;
+    ctx->witness_keys = bytes(safe_malloc(hex_len / 2), hex_len / 2);
+    if (hex_to_bytes(keys_hex + 2, -1, ctx->witness_keys) < 0) {
+      free(ctx->witness_keys.data);
+      ctx->witness_keys = NULL_BYTES;
+    }
+  }
+}
+
 static c4_status_t rpc_start_verifier(c4_rpc_ctx_t* ctx, bytes_t proof) {
   char*  method_dup = strdup(ctx->method);
   char*  params_dup = strdup(ctx->params);
@@ -167,6 +204,9 @@ static c4_status_t rpc_start_verifier(c4_rpc_ctx_t* ctx, bytes_t proof) {
     ctx->error = strdup(ctx->verifier.state.error ? ctx->verifier.state.error : "verifier init failed");
     return C4_ERROR;
   }
+  if (ctx->witness_keys.data && ctx->witness_keys.len)
+    ctx->verifier.witness_keys = bytes_dup(ctx->witness_keys);
+
   ctx->phase = RPC_PHASE_VERIFYING;
   return c4_verify(&ctx->verifier);
 }
@@ -181,6 +221,34 @@ static c4_status_t rpc_handle_proving(c4_rpc_ctx_t* ctx) {
   return status;
 }
 
+static void cleanup_remote_prover_params(buffer_t* buf, const char* method, const char* params) {
+  json_t arr = json_parse(params);
+  if (strcmp(method, "eth_verifyLogs") == 0 && arr.type == JSON_TYPE_ARRAY) {
+    bprintf(buf, "[");
+    for (int i = 0; i < json_len(arr); i++) {
+      if (i > 0) bprintf(buf, ",");
+      json_t item     = json_at(arr, i);
+      json_t tx_index = json_get(item, "transactionIndex");
+      json_t block_nr = json_get(item, "blockNumber");
+      bprintf(buf, "{\"transactionIndex\":%j,\"blockNumber\":%j}", tx_index, block_nr);
+    }
+    bprintf(buf, "]");
+  }
+  else if (strcmp(method, "colibri_simulateTransaction") == 0 && arr.type == JSON_TYPE_ARRAY) {
+    int len = json_len(arr);
+    if (len > 2) len = 2;
+    bprintf(buf, "[");
+    for (int i = 0; i < len; i++) {
+      if (i > 0) bprintf(buf, ",");
+      bprintf(buf, "%j", json_at(arr, i));
+    }
+    bprintf(buf, "]");
+  }
+  else {
+    bprintf(buf, "%s", params);
+  }
+}
+
 static c4_status_t rpc_handle_remote_proof(c4_rpc_ctx_t* ctx) {
   if (!ctx->rpc_request) {
     ctx->rpc_request = safe_calloc(1, sizeof(data_request_t));
@@ -191,8 +259,27 @@ static c4_status_t rpc_handle_remote_proof(c4_rpc_ctx_t* ctx) {
     ctx->rpc_request->url      = strdup("");
 
     buffer_t payload = {0};
-    bprintf(&payload, "{\"method\": \"%s\", \"params\": %s, \"version\": %d}",
-            ctx->method, ctx->params, (uint32_t) c4_current_version_number());
+    bprintf(&payload, "{\"method\": \"%s\", \"params\": ", ctx->method);
+    cleanup_remote_prover_params(&payload, ctx->method, ctx->params);
+    bprintf(&payload, ", \"version\": %d", (uint32_t) c4_current_version_number());
+
+    storage_plugin_t storage = {0};
+    c4_get_storage_config(&storage);
+    buffer_t state_buf = {0};
+    char     name[100];
+    sbprintf(name, "states_%l", (uint64_t) ctx->chain_id);
+    if (storage.get && storage.get(name, &state_buf) && state_buf.data.data && state_buf.data.len)
+      bprintf(&payload, ", \"c4\": \"0x%x\"", state_buf.data);
+    buffer_free(&state_buf);
+
+    if (ctx->prover_flags & C4_PROVER_FLAG_ZK_PROOF)
+      bprintf(&payload, ", \"zk_proof\": true");
+    if (ctx->prover_flags & C4_PROVER_FLAG_INCLUDE_CODE)
+      bprintf(&payload, ", \"include_code\": true");
+    if (ctx->witness_keys.data && ctx->witness_keys.len)
+      bprintf(&payload, ", \"signers\": \"0x%x\"", ctx->witness_keys);
+
+    bprintf(&payload, "}");
     ctx->rpc_request->payload = bytes_dup(payload.data);
     buffer_free(&payload);
 
@@ -318,6 +405,7 @@ void c4_rpc_ctx_free(c4_rpc_ctx_t* ctx) {
   if (ctx->verifier.args.start) free((char*) ctx->verifier.args.start);
   c4_verify_free_data(&ctx->verifier);
   if (ctx->proof_owned && ctx->proof.data) free(ctx->proof.data);
+  if (ctx->witness_keys.data) free(ctx->witness_keys.data);
   if (ctx->rpc_request)
     c4_request_free(ctx->rpc_request);
   if (ctx->error) free(ctx->error);

--- a/bindings/colibri_common.c
+++ b/bindings/colibri_common.c
@@ -191,15 +191,9 @@ void c4_rpc_ctx_set_witness_keys(c4_rpc_ctx_t* ctx, const char* keys_hex) {
 }
 
 static c4_status_t rpc_start_verifier(c4_rpc_ctx_t* ctx, bytes_t proof) {
-  char*  method_dup = strdup(ctx->method);
-  char*  params_dup = strdup(ctx->params);
-  json_t params_json = json_parse(params_dup);
-
-  c4_status_t status = c4_verify_init(&ctx->verifier, proof, method_dup, params_json,
+  c4_status_t status = c4_verify_init(&ctx->verifier, proof, ctx->method, json_parse(ctx->params),
                                       ctx->chain_id, ctx->verify_flags);
   if (status == C4_ERROR) {
-    if (!ctx->verifier.method) free(method_dup);
-    if (!ctx->verifier.args.start) free(params_dup);
     ctx->phase = RPC_PHASE_DONE;
     ctx->error = strdup(ctx->verifier.state.error ? ctx->verifier.state.error : "verifier init failed");
     return C4_ERROR;
@@ -256,7 +250,6 @@ static c4_status_t rpc_handle_remote_proof(c4_rpc_ctx_t* ctx) {
     ctx->rpc_state.requests->chain_id = ctx->chain_id;
     ctx->rpc_state.requests->method   = C4_DATA_METHOD_POST;
     ctx->rpc_state.requests->encoding = C4_DATA_ENCODING_SSZ;
-    ctx->rpc_state.requests->url      = strdup("");
 
     buffer_t payload = {0};
     bprintf(&payload, "{\"method\": \"%s\", \"params\": ", ctx->method);
@@ -280,8 +273,7 @@ static c4_status_t rpc_handle_remote_proof(c4_rpc_ctx_t* ctx) {
       bprintf(&payload, ", \"signers\": \"0x%x\"", ctx->witness_keys);
 
     bprintf(&payload, "}");
-    ctx->rpc_state.requests->payload = bytes_dup(payload.data);
-    buffer_free(&payload);
+    ctx->rpc_state.requests->payload = payload.data;
 
     return C4_PENDING;
   }
@@ -405,8 +397,6 @@ void c4_rpc_ctx_free(c4_rpc_ctx_t* ctx) {
   if (ctx->method) free(ctx->method);
   if (ctx->params) free(ctx->params);
   if (ctx->prover) c4_prover_free(ctx->prover);
-  if (ctx->verifier.method) free((char*) ctx->verifier.method);
-  if (ctx->verifier.args.start) free((char*) ctx->verifier.args.start);
   c4_verify_free_data(&ctx->verifier);
   if (ctx->proof_owned && ctx->proof.data) free(ctx->proof.data);
   if (ctx->witness_keys.data) free(ctx->witness_keys.data);

--- a/bindings/colibri_common.c
+++ b/bindings/colibri_common.c
@@ -315,6 +315,32 @@ static c4_status_t rpc_handle_unproofable(c4_rpc_ctx_t* ctx) {
   }
 
   if (ctx->rpc_state.requests->response.data) {
+    bytes_t resp = ctx->rpc_state.requests->response;
+    char*   tmp  = safe_malloc(resp.len + 1);
+    memcpy(tmp, resp.data, resp.len);
+    tmp[resp.len] = '\0';
+
+    json_t rpc_json  = json_parse(tmp);
+    json_t rpc_error = json_get(rpc_json, "error");
+
+    if (rpc_error.type != JSON_TYPE_NOT_FOUND) {
+      json_t msg = json_get(rpc_error, "message");
+      ctx->error = (msg.type == JSON_TYPE_STRING)
+                       ? bprintf(NULL, "%j", msg)
+                       : bprintf(NULL, "RPC error");
+      safe_free(tmp);
+      ctx->phase = RPC_PHASE_DONE;
+      return C4_ERROR;
+    }
+
+    json_t rpc_result = json_get(rpc_json, "result");
+    if (rpc_result.type != JSON_TYPE_NOT_FOUND) {
+      bytes_t result_bytes = bytes_dup(bytes((uint8_t*) rpc_result.start, rpc_result.len));
+      free(ctx->rpc_state.requests->response.data);
+      ctx->rpc_state.requests->response = result_bytes;
+    }
+
+    safe_free(tmp);
     ctx->phase = RPC_PHASE_DONE;
     return C4_SUCCESS;
   }

--- a/bindings/colibri_common.c
+++ b/bindings/colibri_common.c
@@ -250,13 +250,13 @@ static void cleanup_remote_prover_params(buffer_t* buf, const char* method, cons
 }
 
 static c4_status_t rpc_handle_remote_proof(c4_rpc_ctx_t* ctx) {
-  if (!ctx->rpc_request) {
-    ctx->rpc_request = safe_calloc(1, sizeof(data_request_t));
-    ctx->rpc_request->type     = C4_DATA_TYPE_PROVER;
-    ctx->rpc_request->chain_id = ctx->chain_id;
-    ctx->rpc_request->method   = C4_DATA_METHOD_POST;
-    ctx->rpc_request->encoding = C4_DATA_ENCODING_SSZ;
-    ctx->rpc_request->url      = strdup("");
+  if (!ctx->rpc_state.requests) {
+    ctx->rpc_state.requests = safe_calloc(1, sizeof(data_request_t));
+    ctx->rpc_state.requests->type     = C4_DATA_TYPE_PROVER;
+    ctx->rpc_state.requests->chain_id = ctx->chain_id;
+    ctx->rpc_state.requests->method   = C4_DATA_METHOD_POST;
+    ctx->rpc_state.requests->encoding = C4_DATA_ENCODING_SSZ;
+    ctx->rpc_state.requests->url      = strdup("");
 
     buffer_t payload = {0};
     bprintf(&payload, "{\"method\": \"%s\", \"params\": ", ctx->method);
@@ -280,20 +280,20 @@ static c4_status_t rpc_handle_remote_proof(c4_rpc_ctx_t* ctx) {
       bprintf(&payload, ", \"signers\": \"0x%x\"", ctx->witness_keys);
 
     bprintf(&payload, "}");
-    ctx->rpc_request->payload = bytes_dup(payload.data);
+    ctx->rpc_state.requests->payload = bytes_dup(payload.data);
     buffer_free(&payload);
 
     return C4_PENDING;
   }
 
-  if (ctx->rpc_request->error) {
-    ctx->error = bprintf(NULL, "Remote prover failed: %s", ctx->rpc_request->error);
+  if (ctx->rpc_state.requests->error) {
+    ctx->error = bprintf(NULL, "Remote prover failed: %s", ctx->rpc_state.requests->error);
     ctx->phase = RPC_PHASE_DONE;
     return C4_ERROR;
   }
 
-  if (ctx->rpc_request->response.data) {
-    ctx->proof       = bytes_dup(ctx->rpc_request->response);
+  if (ctx->rpc_state.requests->response.data) {
+    ctx->proof       = bytes_dup(ctx->rpc_state.requests->response);
     ctx->proof_owned = true;
     return rpc_start_verifier(ctx, ctx->proof);
   }
@@ -302,27 +302,27 @@ static c4_status_t rpc_handle_remote_proof(c4_rpc_ctx_t* ctx) {
 }
 
 static c4_status_t rpc_handle_unproofable(c4_rpc_ctx_t* ctx) {
-  if (!ctx->rpc_request) {
-    ctx->rpc_request = safe_calloc(1, sizeof(data_request_t));
-    ctx->rpc_request->type     = C4_DATA_TYPE_ETH_RPC;
-    ctx->rpc_request->chain_id = ctx->chain_id;
-    ctx->rpc_request->method   = C4_DATA_METHOD_POST;
-    ctx->rpc_request->encoding = C4_DATA_ENCODING_JSON;
+  if (!ctx->rpc_state.requests) {
+    ctx->rpc_state.requests = safe_calloc(1, sizeof(data_request_t));
+    ctx->rpc_state.requests->type     = C4_DATA_TYPE_ETH_RPC;
+    ctx->rpc_state.requests->chain_id = ctx->chain_id;
+    ctx->rpc_state.requests->method   = C4_DATA_METHOD_POST;
+    ctx->rpc_state.requests->encoding = C4_DATA_ENCODING_JSON;
 
     buffer_t payload = {0};
     bprintf(&payload, "{\"method\": \"%s\", \"params\": %s}", ctx->method, ctx->params);
-    ctx->rpc_request->payload =payload.data;
+    ctx->rpc_state.requests->payload =payload.data;
 
     return C4_PENDING;
   }
 
-  if (ctx->rpc_request->error) {
-    ctx->error = bprintf(NULL, "RPC request failed: %s", ctx->rpc_request->error);
+  if (ctx->rpc_state.requests->error) {
+    ctx->error = bprintf(NULL, "RPC request failed: %s", ctx->rpc_state.requests->error);
     ctx->phase = RPC_PHASE_DONE;
     return C4_ERROR;
   }
 
-  if (ctx->rpc_request->response.data) {
+  if (ctx->rpc_state.requests->response.data) {
     ctx->phase = RPC_PHASE_DONE;
     return C4_SUCCESS;
   }
@@ -338,6 +338,8 @@ c4_status_t c4_rpc_execute(c4_rpc_ctx_t* ctx) {
                                             json_parse(ctx->params), ctx->verify_flags);
       switch (ctx->method_type) {
         case METHOD_PROOFABLE:
+          if (ctx->proof.data)
+            return rpc_start_verifier(ctx, ctx->proof);
           if (ctx->use_remote_prover) {
             ctx->phase = RPC_PHASE_RPC;
             return rpc_handle_remote_proof(ctx);
@@ -391,6 +393,8 @@ c4_state_t* c4_rpc_get_state(c4_rpc_ctx_t* ctx) {
       return ctx->prover ? &ctx->prover->state : NULL;
     case RPC_PHASE_VERIFYING:
       return &ctx->verifier.state;
+    case RPC_PHASE_RPC:
+      return &ctx->rpc_state;
     default:
       return NULL;
   }
@@ -406,8 +410,9 @@ void c4_rpc_ctx_free(c4_rpc_ctx_t* ctx) {
   c4_verify_free_data(&ctx->verifier);
   if (ctx->proof_owned && ctx->proof.data) free(ctx->proof.data);
   if (ctx->witness_keys.data) free(ctx->witness_keys.data);
-  if (ctx->rpc_request)
-    c4_request_free(ctx->rpc_request);
+  if (ctx->rpc_state.requests)
+    c4_request_free(ctx->rpc_state.requests);
+  if (ctx->rpc_state.error) safe_free(ctx->rpc_state.error);
   if (ctx->error) free(ctx->error);
   free(ctx);
 }
@@ -423,7 +428,7 @@ char* c4_rpc_build_json_status(c4_rpc_ctx_t* ctx, bool req_ptr_as_string) {
   switch (status) {
     case C4_SUCCESS:
       if (ctx->phase == RPC_PHASE_DONE && ctx->method_type == METHOD_UNPROOFABLE) 
-        bprintf(&buf, "\"result\": %r", ctx->rpc_request->response);
+        bprintf(&buf, "\"result\": %r", ctx->rpc_state.requests->response);
       else 
         bprintf(&buf, "\"result\": %Z", ctx->verifier.data);
       break;
@@ -439,21 +444,14 @@ char* c4_rpc_build_json_status(c4_rpc_ctx_t* ctx, bool req_ptr_as_string) {
         bprintf(&buf, "\"error\": \"unknown error\"");
       break;
 
-    case C4_PENDING:
-      if (ctx->phase == RPC_PHASE_RPC && ctx->rpc_request) {
-        bprintf(&buf, "\"requests\": [");
-        if (!ctx->rpc_request->response.data && !ctx->rpc_request->error)
-          c4i_add_data_request(&buf, ctx->rpc_request, req_ptr_as_string);
-        bprintf(&buf, "]");
-      }
-      else {
-        c4_state_t* state = c4_rpc_get_state(ctx);
-        if (state)
-          append_pending_requests(&buf, state, req_ptr_as_string);
-        else
-          bprintf(&buf, "\"requests\": []");
-      }
+    case C4_PENDING: {
+      c4_state_t* state = c4_rpc_get_state(ctx);
+      if (state)
+        append_pending_requests(&buf, state, req_ptr_as_string);
+      else
+        bprintf(&buf, "\"requests\": []");
       break;
+    }
   }
 
   return bprintf(&buf, "}");

--- a/bindings/colibri_common.c
+++ b/bindings/colibri_common.c
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2025,2026 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "colibri_common.h"
+#include "version.h"
+#include <stdlib.h>
+#include <string.h>
+
+/* ── string converters ── */
+
+static const char* status_to_string(c4_status_t status) {
+  switch (status) {
+    case C4_SUCCESS: return "success";
+    case C4_ERROR: return "error";
+    case C4_PENDING: return "pending";
+  }
+  return "error";
+}
+
+static const char* encoding_to_string(data_request_encoding_t encoding) {
+  switch (encoding) {
+    case C4_DATA_ENCODING_SSZ: return "ssz";
+    case C4_DATA_ENCODING_JSON: return "json";
+  }
+  return "json";
+}
+
+static const char* method_to_string(data_request_method_t method) {
+  switch (method) {
+    case C4_DATA_METHOD_GET: return "get";
+    case C4_DATA_METHOD_POST: return "post";
+    case C4_DATA_METHOD_PUT: return "put";
+    case C4_DATA_METHOD_DELETE: return "delete";
+  }
+  return "get";
+}
+
+static const char* data_request_type_to_string(data_request_type_t type) {
+  switch (type) {
+    case C4_DATA_TYPE_BEACON_API: return "beacon_api";
+    case C4_DATA_TYPE_ETH_RPC: return "eth_rpc";
+    case C4_DATA_TYPE_REST_API: return "rest_api";
+    case C4_DATA_TYPE_INTERN: return "intern";
+    case C4_DATA_TYPE_PROVER: return "prover";
+    case C4_DATA_TYPE_CHECKPOINTZ: return "checkpointz";
+  }
+  return "eth_rpc";
+}
+
+/* ── JSON helpers ── */
+
+void c4i_add_data_request(buffer_t* result, data_request_t* req, bool req_ptr_as_string) {
+  if (req_ptr_as_string)
+    bprintf(result, "{\"req_ptr\": \"%l\",", (uint64_t) (uintptr_t) req);
+  else
+    bprintf(result, "{\"req_ptr\": %l,", (uint64_t) (uintptr_t) req);
+  bprintf(result, "\"chain_id\": %d,", (uint32_t) req->chain_id);
+  bprintf(result, "\"encoding\": \"%s\",", encoding_to_string(req->encoding));
+  bprintf(result, "\"exclude_mask\": \"%d\",", (uint32_t) req->node_exclude_mask);
+  bprintf(result, "\"method\": \"%s\",", method_to_string(req->method));
+  bprintf(result, "\"url\": \"%s\",", req->url);
+  if (req->payload.data)
+    bprintf(result, "\"payload\": %j,", (json_t){.len = req->payload.len, .start = (char*) req->payload.data, .type = JSON_TYPE_OBJECT});
+  bprintf(result, "\"type\": \"%s\"}", data_request_type_to_string(req->type));
+}
+
+static void append_pending_requests(buffer_t* buf, c4_state_t* state, bool req_ptr_as_string) {
+  bprintf(buf, "\"requests\": [");
+  data_request_t* req = c4_state_get_pending_request(state);
+  while (req) {
+    if (!req->response.data && !req->error) {
+      if (buf->data.data[buf->data.len - 1] != '[') bprintf(buf, ",");
+      c4i_add_data_request(buf, req, req_ptr_as_string);
+    }
+    req = req->next;
+  }
+  bprintf(buf, "]");
+}
+
+static char* build_error_or_pending(buffer_t* buf, c4_status_t status, c4_state_t* state, bool req_ptr_as_string) {
+  switch (status) {
+    case C4_ERROR:
+      bprintf(buf, "\"error\": \"%S\"", state->error ? state->error : "unknown error");
+      break;
+    case C4_PENDING:
+      append_pending_requests(buf, state, req_ptr_as_string);
+      break;
+    default:
+      break;
+  }
+  return bprintf(buf, "}");
+}
+
+char* c4i_build_prover_json_status(c4_status_t status, c4_state_t* state,
+                                   void* proof_ptr, uint32_t proof_len,
+                                   bool req_ptr_as_string) {
+  buffer_t buf = {0};
+  bprintf(&buf, "{\"status\": \"%s\",", status_to_string(status));
+  if (status == C4_SUCCESS) 
+    return bprintf(&buf, "\"result\": \"0x%lx\", \"result_len\": %d}", (uint64_t) (uintptr_t) proof_ptr, proof_len);
+  return build_error_or_pending(&buf, status, state, req_ptr_as_string);
+}
+
+char* c4i_build_verifier_json_status(c4_status_t status, c4_state_t* state,
+                                     ssz_ob_t result,
+                                     bool req_ptr_as_string) {
+  buffer_t buf = {0};
+  bprintf(&buf, "{\"status\": \"%s\",", status_to_string(status));
+  if (status == C4_SUCCESS) 
+    return bprintf(&buf, "\"result\": %Z}", result);
+  return build_error_or_pending(&buf, status, state, req_ptr_as_string);
+}
+
+/* ── rpc_ctx lifecycle ── */
+
+c4_rpc_ctx_t* c4_rpc_ctx_create(const char* method, const char* params, chain_id_t chain_id,
+                                prover_flags_t prover_flags, verify_flags_t verify_flags,
+                                bool use_remote_prover) {
+  c4_rpc_ctx_t* ctx = safe_calloc(1, sizeof(c4_rpc_ctx_t));
+  if (!method || strlen(method) == 0) {
+    ctx->error = strdup("method cannot be NULL or empty");
+    ctx->phase = RPC_PHASE_DONE;
+    return ctx;
+  }
+  ctx->method             = strdup(method);
+  ctx->params             = strdup(params ? params : "[]");
+  ctx->chain_id           = chain_id;
+  ctx->prover_flags       = prover_flags;
+  ctx->verify_flags       = verify_flags;
+  ctx->use_remote_prover  = use_remote_prover;
+  ctx->phase              = RPC_PHASE_INIT;
+  ctx->method_type        = METHOD_UNDEFINED;
+  return ctx;
+}
+
+static c4_status_t rpc_start_verifier(c4_rpc_ctx_t* ctx, bytes_t proof) {
+  char*  method_dup = strdup(ctx->method);
+  char*  params_dup = strdup(ctx->params);
+  json_t params_json = json_parse(params_dup);
+
+  c4_status_t status = c4_verify_init(&ctx->verifier, proof, method_dup, params_json,
+                                      ctx->chain_id, ctx->verify_flags);
+  if (status == C4_ERROR) {
+    if (!ctx->verifier.method) free(method_dup);
+    if (!ctx->verifier.args.start) free(params_dup);
+    ctx->phase = RPC_PHASE_DONE;
+    ctx->error = strdup(ctx->verifier.state.error ? ctx->verifier.state.error : "verifier init failed");
+    return C4_ERROR;
+  }
+  ctx->phase = RPC_PHASE_VERIFYING;
+  return c4_verify(&ctx->verifier);
+}
+
+static c4_status_t rpc_handle_proving(c4_rpc_ctx_t* ctx) {
+  c4_status_t status = c4_prover_execute(ctx->prover);
+  if (status == C4_SUCCESS) {
+    ctx->proof       = bytes_dup(ctx->prover->proof);
+    ctx->proof_owned = true;
+    return rpc_start_verifier(ctx, ctx->proof);
+  }
+  return status;
+}
+
+static c4_status_t rpc_handle_remote_proof(c4_rpc_ctx_t* ctx) {
+  if (!ctx->rpc_request) {
+    ctx->rpc_request = safe_calloc(1, sizeof(data_request_t));
+    ctx->rpc_request->type     = C4_DATA_TYPE_PROVER;
+    ctx->rpc_request->chain_id = ctx->chain_id;
+    ctx->rpc_request->method   = C4_DATA_METHOD_POST;
+    ctx->rpc_request->encoding = C4_DATA_ENCODING_SSZ;
+    ctx->rpc_request->url      = strdup("");
+
+    buffer_t payload = {0};
+    bprintf(&payload, "{\"method\": \"%s\", \"params\": %s, \"version\": %d}",
+            ctx->method, ctx->params, (uint32_t) c4_current_version_number());
+    ctx->rpc_request->payload = bytes_dup(payload.data);
+    buffer_free(&payload);
+
+    return C4_PENDING;
+  }
+
+  if (ctx->rpc_request->error) {
+    ctx->error = bprintf(NULL, "Remote prover failed: %s", ctx->rpc_request->error);
+    ctx->phase = RPC_PHASE_DONE;
+    return C4_ERROR;
+  }
+
+  if (ctx->rpc_request->response.data) {
+    ctx->proof       = bytes_dup(ctx->rpc_request->response);
+    ctx->proof_owned = true;
+    return rpc_start_verifier(ctx, ctx->proof);
+  }
+
+  return C4_PENDING;
+}
+
+static c4_status_t rpc_handle_unproofable(c4_rpc_ctx_t* ctx) {
+  if (!ctx->rpc_request) {
+    ctx->rpc_request = safe_calloc(1, sizeof(data_request_t));
+    ctx->rpc_request->type     = C4_DATA_TYPE_ETH_RPC;
+    ctx->rpc_request->chain_id = ctx->chain_id;
+    ctx->rpc_request->method   = C4_DATA_METHOD_POST;
+    ctx->rpc_request->encoding = C4_DATA_ENCODING_JSON;
+
+    buffer_t payload = {0};
+    bprintf(&payload, "{\"method\": \"%s\", \"params\": %s}", ctx->method, ctx->params);
+    ctx->rpc_request->payload =payload.data;
+
+    return C4_PENDING;
+  }
+
+  if (ctx->rpc_request->error) {
+    ctx->error = bprintf(NULL, "RPC request failed: %s", ctx->rpc_request->error);
+    ctx->phase = RPC_PHASE_DONE;
+    return C4_ERROR;
+  }
+
+  if (ctx->rpc_request->response.data) {
+    ctx->phase = RPC_PHASE_DONE;
+    return C4_SUCCESS;
+  }
+
+  return C4_PENDING;
+}
+
+c4_status_t c4_rpc_execute(c4_rpc_ctx_t* ctx) {
+  if (!ctx) return C4_ERROR;
+  switch (ctx->phase) {
+    case RPC_PHASE_INIT: {
+      ctx->method_type = c4_get_method_type(ctx->chain_id, ctx->method,
+                                            json_parse(ctx->params), ctx->verify_flags);
+      switch (ctx->method_type) {
+        case METHOD_PROOFABLE:
+          if (ctx->use_remote_prover) {
+            ctx->phase = RPC_PHASE_RPC;
+            return rpc_handle_remote_proof(ctx);
+          }
+          ctx->prover = c4_prover_create(ctx->method, ctx->params, ctx->chain_id, ctx->prover_flags);
+          ctx->phase  = RPC_PHASE_PROVING;
+          return rpc_handle_proving(ctx);
+
+        case METHOD_LOCAL:
+          return rpc_start_verifier(ctx, NULL_BYTES);
+
+        case METHOD_UNPROOFABLE:
+          ctx->phase = RPC_PHASE_RPC;
+          return rpc_handle_unproofable(ctx);
+
+        case METHOD_UNDEFINED:
+        case METHOD_NOT_SUPPORTED:
+          ctx->error = bprintf(NULL, "Method %s is not supported", ctx->method);
+          ctx->phase = RPC_PHASE_DONE;
+          return C4_ERROR;
+      }
+      break;
+    }
+
+    case RPC_PHASE_PROVING:
+      return rpc_handle_proving(ctx);
+
+    case RPC_PHASE_VERIFYING: {
+      c4_status_t status = c4_verify(&ctx->verifier);
+      if (status == C4_SUCCESS || status == C4_ERROR)
+        ctx->phase = RPC_PHASE_DONE;
+      return status;
+    }
+
+    case RPC_PHASE_RPC:
+      if (ctx->method_type == METHOD_PROOFABLE)
+        return rpc_handle_remote_proof(ctx);
+      return rpc_handle_unproofable(ctx);
+
+    case RPC_PHASE_DONE:
+      if (ctx->error) return C4_ERROR;
+      return C4_SUCCESS;
+  }
+
+  return C4_ERROR;
+}
+
+c4_state_t* c4_rpc_get_state(c4_rpc_ctx_t* ctx) {
+  switch (ctx->phase) {
+    case RPC_PHASE_PROVING:
+      return ctx->prover ? &ctx->prover->state : NULL;
+    case RPC_PHASE_VERIFYING:
+      return &ctx->verifier.state;
+    default:
+      return NULL;
+  }
+}
+
+void c4_rpc_ctx_free(c4_rpc_ctx_t* ctx) {
+  if (!ctx) return;
+  if (ctx->method) free(ctx->method);
+  if (ctx->params) free(ctx->params);
+  if (ctx->prover) c4_prover_free(ctx->prover);
+  if (ctx->verifier.method) free((char*) ctx->verifier.method);
+  if (ctx->verifier.args.start) free((char*) ctx->verifier.args.start);
+  c4_verify_free_data(&ctx->verifier);
+  if (ctx->proof_owned && ctx->proof.data) free(ctx->proof.data);
+  if (ctx->rpc_request)
+    c4_request_free(ctx->rpc_request);
+  if (ctx->error) free(ctx->error);
+  free(ctx);
+}
+
+/* ── Unified JSON status for rpc_ctx ── */
+
+char* c4_rpc_build_json_status(c4_rpc_ctx_t* ctx, bool req_ptr_as_string) {
+  c4_status_t status = c4_rpc_execute(ctx);
+  buffer_t    buf    = {0};
+
+  bprintf(&buf, "{\"status\": \"%s\",", status_to_string(status));
+
+  switch (status) {
+    case C4_SUCCESS:
+      if (ctx->phase == RPC_PHASE_DONE && ctx->method_type == METHOD_UNPROOFABLE) 
+        bprintf(&buf, "\"result\": %r", ctx->rpc_request->response);
+      else 
+        bprintf(&buf, "\"result\": %Z", ctx->verifier.data);
+      break;
+
+    case C4_ERROR:
+      if (ctx->error)
+        bprintf(&buf, "\"error\": \"%S\"", ctx->error);
+      else if (ctx->phase == RPC_PHASE_VERIFYING || ctx->phase == RPC_PHASE_DONE)
+        bprintf(&buf, "\"error\": \"%S\"", ctx->verifier.state.error);
+      else if (ctx->prover && ctx->prover->state.error)
+        bprintf(&buf, "\"error\": \"%S\"", ctx->prover->state.error);
+      else
+        bprintf(&buf, "\"error\": \"unknown error\"");
+      break;
+
+    case C4_PENDING:
+      if (ctx->phase == RPC_PHASE_RPC && ctx->rpc_request) {
+        bprintf(&buf, "\"requests\": [");
+        if (!ctx->rpc_request->response.data && !ctx->rpc_request->error)
+          c4i_add_data_request(&buf, ctx->rpc_request, req_ptr_as_string);
+        bprintf(&buf, "]");
+      }
+      else {
+        c4_state_t* state = c4_rpc_get_state(ctx);
+        if (state)
+          append_pending_requests(&buf, state, req_ptr_as_string);
+        else
+          bprintf(&buf, "\"requests\": []");
+      }
+      break;
+  }
+
+  return bprintf(&buf, "}");
+}

--- a/bindings/colibri_common.h
+++ b/bindings/colibri_common.h
@@ -75,7 +75,7 @@ typedef struct {
   bytes_t         proof;
   bool            proof_owned;
 
-  data_request_t* rpc_request;
+  c4_state_t      rpc_state;
   char*           error;
 
   bytes_t         witness_keys;
@@ -108,10 +108,10 @@ c4_status_t c4_rpc_execute(c4_rpc_ctx_t* ctx);
  * Returns a pointer to the `c4_state_t` that currently holds pending requests.
  *
  * Depending on the phase, this is the prover state, the verifier state,
- * or a synthetic state wrapping `rpc_request`.
+ * or the `rpc_state` holding forwarded requests.
  *
  * @param ctx the RPC context
- * @return pointer to the active state, or NULL if phase is INIT, RPC, or DONE
+ * @return pointer to the active state, or NULL if phase is INIT or DONE
  */
 c4_state_t* c4_rpc_get_state(c4_rpc_ctx_t* ctx);
 

--- a/bindings/colibri_common.h
+++ b/bindings/colibri_common.h
@@ -32,6 +32,19 @@ extern "C" {
 #include "verify.h"
 #include <stdbool.h>
 
+/* ── Standalone checkpoint setter (chain-global, not per-context) ── */
+
+/**
+ * Sets a trusted checkpoint for a chain (context-independent).
+ *
+ * Parses a hex checkpoint string and stores it globally for the chain.
+ * This must be called before verification if the host has a known checkpoint.
+ *
+ * @param chain_id target chain ID
+ * @param checkpoint_hex hex string with "0x" prefix (66 chars total, e.g. "0xabcd...")
+ */
+void c4_set_checkpoint(chain_id_t chain_id, const char* checkpoint_hex);
+
 /**
  * RPC context phases for the unified execution flow.
  */
@@ -64,6 +77,8 @@ typedef struct {
 
   data_request_t* rpc_request;
   char*           error;
+
+  bytes_t         witness_keys;
 } c4_rpc_ctx_t;
 
 /**
@@ -99,6 +114,17 @@ c4_status_t c4_rpc_execute(c4_rpc_ctx_t* ctx);
  * @return pointer to the active state, or NULL if phase is INIT, RPC, or DONE
  */
 c4_state_t* c4_rpc_get_state(c4_rpc_ctx_t* ctx);
+
+/**
+ * Sets witness/signer keys on the RPC context (hex-encoded).
+ *
+ * The keys are used for sync committee weak subjectivity signing during
+ * both proving (sent to remote prover) and verification.
+ *
+ * @param ctx the RPC context
+ * @param keys_hex hex string with "0x" prefix (e.g. "0xabcd..."), or NULL to clear
+ */
+void c4_rpc_ctx_set_witness_keys(c4_rpc_ctx_t* ctx, const char* keys_hex);
 
 /**
  * Frees the RPC context and all owned resources.

--- a/bindings/colibri_common.h
+++ b/bindings/colibri_common.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2025,2026 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef colibri_common_h__
+#define colibri_common_h__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "prover.h"
+#include "verify.h"
+#include <stdbool.h>
+
+/**
+ * RPC context phases for the unified execution flow.
+ */
+typedef enum {
+  RPC_PHASE_INIT,      ///< Initial phase: method type not yet determined
+  RPC_PHASE_PROVING,   ///< Prover is active, waiting for proof
+  RPC_PHASE_VERIFYING, ///< Verifier is active, verifying proof
+  RPC_PHASE_RPC,       ///< Forwarding an unproofable request as data_request_t
+  RPC_PHASE_DONE       ///< Terminal: result or error available
+} c4_rpc_phase_t;
+
+/**
+ * Unified RPC context that manages the full lifecycle of an RPC request:
+ * method type determination, proof generation (local or remote), and verification.
+ */
+typedef struct {
+  char*           method;
+  char*           params;
+  chain_id_t      chain_id;
+  prover_flags_t  prover_flags;
+  verify_flags_t  verify_flags;
+  c4_rpc_phase_t  phase;
+  method_type_t   method_type;
+  bool            use_remote_prover;
+
+  prover_ctx_t*   prover;
+  verify_ctx_t    verifier;
+  bytes_t         proof;
+  bool            proof_owned;
+
+  data_request_t* rpc_request;
+  char*           error;
+} c4_rpc_ctx_t;
+
+/**
+ * Creates a new unified RPC context.
+ *
+ * @param method RPC method name (e.g. "eth_getBalance"). Copied internally.
+ * @param params JSON array string of params. Copied internally.
+ * @param chain_id target chain ID
+ * @param prover_flags flags for proof generation (see `prover_flag_types_t`)
+ * @param verify_flags flags for verification (see `verify_flag_t`, e.g. `VERIFY_FLAG_PAP`)
+ * @param use_remote_prover if true, emit a prover data_request instead of local proving
+ * @return heap-allocated context, or NULL on allocation failure
+ */
+c4_rpc_ctx_t* c4_rpc_ctx_create(const char* method, const char* params, chain_id_t chain_id,
+                                prover_flags_t prover_flags, verify_flags_t verify_flags,
+                                bool use_remote_prover);
+
+/**
+ * Executes one step of the unified RPC state machine.
+ *
+ * @param ctx the RPC context
+ * @return `C4_SUCCESS`, `C4_ERROR`, or `C4_PENDING`
+ */
+c4_status_t c4_rpc_execute(c4_rpc_ctx_t* ctx);
+
+/**
+ * Returns a pointer to the `c4_state_t` that currently holds pending requests.
+ *
+ * Depending on the phase, this is the prover state, the verifier state,
+ * or a synthetic state wrapping `rpc_request`.
+ *
+ * @param ctx the RPC context
+ * @return pointer to the active state, or NULL if phase is INIT, RPC, or DONE
+ */
+c4_state_t* c4_rpc_get_state(c4_rpc_ctx_t* ctx);
+
+/**
+ * Frees the RPC context and all owned resources.
+ *
+ * @param ctx the RPC context (may be NULL)
+ */
+void c4_rpc_ctx_free(c4_rpc_ctx_t* ctx);
+
+/* ── JSON serialization helpers shared by colibri.c and ems.c ── */
+
+/**
+ * Appends a single `data_request_t` as JSON object to the buffer.
+ *
+ * @param result output buffer
+ * @param req the data request
+ * @param req_ptr_as_string if true, emit `req_ptr` as a JSON string (for 64-bit safety); otherwise as number
+ */
+void c4i_add_data_request(buffer_t* result, data_request_t* req, bool req_ptr_as_string);
+
+/**
+ * Builds a full JSON status string from the current RPC context state.
+ *
+ * The caller must `free()` the returned string.
+ *
+ * @param ctx the RPC context
+ * @param req_ptr_as_string if true, emit `req_ptr` values as JSON strings
+ * @return heap-allocated JSON string
+ */
+char* c4_rpc_build_json_status(c4_rpc_ctx_t* ctx, bool req_ptr_as_string);
+
+/**
+ * Builds a JSON status string for a prover execution step.
+ *
+ * @param status the status code from `c4_prover_execute()`
+ * @param state the prover state holding pending requests or error
+ * @param proof_ptr pointer to proof data (used only on `C4_SUCCESS`)
+ * @param proof_len length of proof data
+ * @param req_ptr_as_string if true, emit `req_ptr` values as JSON strings
+ * @return heap-allocated JSON string (caller must `free()`)
+ */
+char* c4i_build_prover_json_status(c4_status_t status, c4_state_t* state,
+                                   void* proof_ptr, uint32_t proof_len,
+                                   bool req_ptr_as_string);
+
+/**
+ * Builds a JSON status string for a verifier execution step.
+ *
+ * @param status the status code from `c4_verify()`
+ * @param state the verifier state holding pending requests or error
+ * @param result the SSZ result object (used only on `C4_SUCCESS`)
+ * @param req_ptr_as_string if true, emit `req_ptr` values as JSON strings
+ * @return heap-allocated JSON string (caller must `free()`)
+ */
+char* c4i_build_verifier_json_status(c4_status_t status, c4_state_t* state,
+                                     ssz_ob_t result,
+                                     bool req_ptr_as_string);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/bindings/dart/CMakeLists.txt
+++ b/bindings/dart/CMakeLists.txt
@@ -7,6 +7,7 @@ file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/bindings/dart/native)
 
 add_library(colibri_dart SHARED
     ../colibri.c
+    ../colibri_common.c
 )
 
 set_target_properties(colibri_dart PROPERTIES

--- a/bindings/dart/dart_test.yaml
+++ b/bindings/dart/dart_test.yaml
@@ -1,0 +1,3 @@
+# Run test files sequentially because the native C library uses global state
+# (storage callbacks, trusted checkpoint cache) that is not isolate-safe.
+concurrency: 1

--- a/bindings/dart/lib/src/client.dart
+++ b/bindings/dart/lib/src/client.dart
@@ -356,7 +356,7 @@ class Colibri {
         return checkpointz;
       case 'beacon_api':
         if (useProverFallback && provers.isNotEmpty) {
-          return provers;
+          return [...provers, ...beaconApis];
         }
         return beaconApis;
       case 'prover':

--- a/bindings/dart/lib/src/client.dart
+++ b/bindings/dart/lib/src/client.dart
@@ -238,6 +238,8 @@ class Colibri {
     final proverFlags = (includeCode ? 1 : 0) | (useAccesslist ? (1 << 6) : 0) | (zkProof ? (1 << 7) : 0);
     final useRemote = provers.isEmpty ? 0 : 1;
 
+    _onDebug?.call('rpc: method=$method useRemote=$useRemote chainId=$chainId');
+
     final ctx = _native.createRpcCtx(method, paramsJson, chainId, proverFlags, _getVerifyFlags(), useRemote);
     if (ctx == ffi.nullptr) {
       throw ColibriError('Failed to create RPC context for $method');
@@ -258,14 +260,18 @@ class Colibri {
 
         switch (status['status']) {
           case 'success':
+            _onDebug?.call('rpc: $method → success');
             return status['result'];
           case 'error':
-            throw ColibriError(status['error']?.toString() ?? 'Unknown RPC error');
+            final errorMsg = status['error']?.toString() ?? 'Unknown RPC error';
+            _onDebug?.call('rpc: $method → error: $errorMsg');
+            throw ColibriError(errorMsg);
           case 'pending':
             final requests = (status['requests'] as List<dynamic>? ?? [])
                 .whereType<Map<String, dynamic>>()
                 .map(DataRequest.fromJson)
                 .toList();
+            _onDebug?.call('rpc: $method → pending (${requests.length} requests)');
             await _handleRequests(requests, useProverFallback: true);
             break;
           default:

--- a/bindings/dart/lib/src/client.dart
+++ b/bindings/dart/lib/src/client.dart
@@ -228,46 +228,52 @@ class Colibri {
     }
   }
 
-  /// Executes an RPC call with automatic proof handling.
+  /// Executes an RPC call via the unified C core state machine.
   ///
-  /// For proofable methods, tries remote provers first (if configured), then
-  /// falls back to local proof creation and verification. For local or
-  /// unproofable methods, calls the appropriate path. Throws [ColibriError]
-  /// or [RPCError] when the method is not supported or the call fails.
+  /// The C core handles method type detection, proof generation (local or
+  /// remote), and verification internally. The host only handles pending
+  /// data requests.
   Future<dynamic> rpc(String method, List<dynamic> params) async {
-    final support = getMethodSupport(method, params: params);
-    _onDebug?.call('Method: $method, support: ${support.name}');
+    final paramsJson = jsonEncode(params);
+    final proverFlags = (includeCode ? 1 : 0) | (useAccesslist ? (1 << 6) : 0) | (zkProof ? (1 << 7) : 0);
+    final useRemote = provers.isEmpty ? 0 : 1;
 
-    switch (support) {
-      case MethodType.proofable:
-        _onDebug?.call('Ensuring trusted checkpoint…');
-        await _ensureTrustedCheckpoint();
-        _onDebug?.call('Fetching proof (prover or local)…');
-        final proof = await _fetchProofWithFallback(method, params);
-        _onDebug?.call('Proof length: ${proof.length} bytes');
-        _onDebug?.call('Proof (first 64 bytes hex): ${_proofHexSnippet(proof, 0, 64)}');
-        _onDebug?.call('Proof (last 32 bytes hex): ${_proofHexSnippet(proof, proof.length - 32, 32)}');
-        var result = await verifyProof(proof, method, params);
-        _onDebug?.call('Verify result: ${result == null ? "null" : result}');
-        // If verification returned null (e.g. prover sent JSON instead of binary proof),
-        // try to get result from prover as JSON (same as Python binding fallback behaviour).
-        if (result == null && provers.isNotEmpty) {
-          _onDebug?.call('Verify was null, trying prover as JSON…');
-          try {
-            result = await _fetchRpc(provers, method, params, asProof: false);
-            _onDebug?.call('Prover JSON result: $result');
-          } catch (e) {
-            _onDebug?.call('Prover JSON failed: $e');
-          }
+    final ctx = _native.createRpcCtx(method, paramsJson, chainId, proverFlags, _getVerifyFlags(), useRemote);
+    if (ctx == ffi.nullptr) {
+      throw ColibriError('Failed to create RPC context for $method');
+    }
+
+    final checkpoint = _runtimeTrustedCheckpoint ?? trustedCheckpoint;
+    if (checkpoint != null && checkpoint.isNotEmpty) {
+      _native.setCheckpoint(chainId, checkpoint);
+    }
+    if (checkpointWitnessKeys != null && checkpointWitnessKeys!.isNotEmpty) {
+      _native.rpcSetWitnessKeys(ctx, checkpointWitnessKeys!);
+    }
+
+    try {
+      while (true) {
+        final statusJson = _native.rpcExecuteJsonStatus(ctx);
+        final status = jsonDecode(statusJson) as Map<String, dynamic>;
+
+        switch (status['status']) {
+          case 'success':
+            return status['result'];
+          case 'error':
+            throw ColibriError(status['error']?.toString() ?? 'Unknown RPC error');
+          case 'pending':
+            final requests = (status['requests'] as List<dynamic>? ?? [])
+                .whereType<Map<String, dynamic>>()
+                .map(DataRequest.fromJson)
+                .toList();
+            await _handleRequests(requests, useProverFallback: true);
+            break;
+          default:
+            throw ColibriError('Unknown RPC status: ${status['status']}');
         }
-        return result;
-      case MethodType.unproofable:
-        return _fetchRpc(ethRpcs, method, params, asProof: false);
-      case MethodType.local:
-        return verifyProof(Uint8List(0), method, params);
-      case MethodType.notSupported:
-      case MethodType.undefined:
-        throw ColibriError('Method $method is not supported');
+      }
+    } finally {
+      _native.freeRpcCtx(ctx);
     }
   }
 

--- a/bindings/dart/lib/src/native.dart
+++ b/bindings/dart/lib/src/native.dart
@@ -124,6 +124,29 @@ typedef _SetStorageConfig = void Function(ffi.Pointer<StoragePluginT>);
 typedef _BufferAppendNative = ffi.Uint32 Function(ffi.Pointer<BufferT>, BytesT);
 typedef _BufferAppend = int Function(ffi.Pointer<BufferT>, BytesT);
 
+typedef _CreateRpcCtxNative = ffi.Pointer<ffi.Void> Function(
+  ffi.Pointer<ffi.Int8>,
+  ffi.Pointer<ffi.Int8>,
+  ffi.Uint64,
+  ffi.Uint32,
+  ffi.Uint32,
+  ffi.Int32,
+);
+typedef _CreateRpcCtx = ffi.Pointer<ffi.Void> Function(
+  ffi.Pointer<ffi.Int8>,
+  ffi.Pointer<ffi.Int8>,
+  int,
+  int,
+  int,
+  int,
+);
+
+typedef _SetCheckpointNative = ffi.Void Function(ffi.Uint64, ffi.Pointer<ffi.Int8>);
+typedef _SetCheckpoint = void Function(int, ffi.Pointer<ffi.Int8>);
+
+typedef _RpcSetWitnessKeysNative = ffi.Void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Int8>);
+typedef _RpcSetWitnessKeys = void Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Int8>);
+
 // Global storage bridge used by native callbacks.
 ColibriStorage? _storageHandler;
 late _BufferAppend _bufferAppend;
@@ -221,6 +244,14 @@ class ColibriNative {
     _setStorageConfig =
         _lib.lookupFunction<_SetStorageConfigNative, _SetStorageConfig>('c4_set_storage_config');
     _bufferAppend = _lib.lookupFunction<_BufferAppendNative, _BufferAppend>('buffer_append');
+    _createRpcCtx = _lib.lookupFunction<_CreateRpcCtxNative, _CreateRpcCtx>('c4_create_rpc_ctx');
+    _rpcExecuteJsonStatus =
+        _lib.lookupFunction<_ExecuteStatusNative, _ExecuteStatus>('c4_rpc_execute_json_status');
+    _freeRpcCtx = _lib.lookupFunction<_FreeCtxNative, _FreeCtx>('c4_free_rpc_ctx');
+    _setCheckpoint =
+        _lib.lookupFunction<_SetCheckpointNative, _SetCheckpoint>('c4_set_checkpoint');
+    _rpcSetWitnessKeys =
+        _lib.lookupFunction<_RpcSetWitnessKeysNative, _RpcSetWitnessKeys>('c4_rpc_set_witness_keys');
   }
 
   final ffi.DynamicLibrary _lib;
@@ -238,6 +269,11 @@ class ColibriNative {
   late final _GetMethodSupport _getMethodSupport;
   late final _Free _free;
   late final _SetStorageConfig _setStorageConfig;
+  late final _CreateRpcCtx _createRpcCtx;
+  late final _ExecuteStatus _rpcExecuteJsonStatus;
+  late final _FreeCtx _freeRpcCtx;
+  late final _SetCheckpoint _setCheckpoint;
+  late final _RpcSetWitnessKeys _rpcSetWitnessKeys;
 
   /// Load the native shared library from [libraryPath] or platform defaults.
   static ColibriNative load({String? libraryPath}) {
@@ -423,6 +459,55 @@ class ColibriNative {
       ..maxSyncStates = 0;
     _setStorageConfig(plugin);
     calloc.free(plugin);
+  }
+
+  /// Create a unified RPC context.
+  ffi.Pointer<ffi.Void> createRpcCtx(
+    String method,
+    String params,
+    int chainId,
+    int proverFlags,
+    int verifyFlags,
+    int useRemoteProver,
+  ) {
+    final methodPtr = method.toNativeUtf8();
+    final paramsPtr = params.toNativeUtf8();
+    final ctx = _createRpcCtx(
+      methodPtr.cast(),
+      paramsPtr.cast(),
+      chainId,
+      proverFlags,
+      verifyFlags,
+      useRemoteProver,
+    );
+    malloc.free(methodPtr);
+    malloc.free(paramsPtr);
+    return ctx;
+  }
+
+  /// Execute a unified RPC step and return the JSON status string.
+  String rpcExecuteJsonStatus(ffi.Pointer<ffi.Void> ctx) {
+    final resultPtr = _rpcExecuteJsonStatus(ctx);
+    final result = resultPtr.cast<Utf8>().toDartString();
+    _free(resultPtr.cast());
+    return result;
+  }
+
+  /// Free the unified RPC context.
+  void freeRpcCtx(ffi.Pointer<ffi.Void> ctx) => _freeRpcCtx(ctx);
+
+  /// Set a trusted checkpoint for a chain (context-independent).
+  void setCheckpoint(int chainId, String checkpoint) {
+    final checkpointPtr = checkpoint.toNativeUtf8();
+    _setCheckpoint(chainId, checkpointPtr.cast());
+    malloc.free(checkpointPtr);
+  }
+
+  /// Set witness/signer keys on an RPC context.
+  void rpcSetWitnessKeys(ffi.Pointer<ffi.Void> ctx, String keys) {
+    final keysPtr = keys.toNativeUtf8();
+    _rpcSetWitnessKeys(ctx, keysPtr.cast());
+    malloc.free(keysPtr);
   }
 
   /// Resolve the platform-specific library path.

--- a/bindings/emscripten/CMakeLists.txt
+++ b/bindings/emscripten/CMakeLists.txt
@@ -72,7 +72,7 @@ configure_file(
   @ONLY
 )
 
-add_executable(c4w ems.c)
+add_executable(c4w ems.c ../colibri_common.c)
 target_link_libraries(c4w prover verifier eth_verifier)
 set_target_properties(c4w PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${EMSCRIPTEN_OUTPUT_DIR}

--- a/bindings/emscripten/ems.c
+++ b/bindings/emscripten/ems.c
@@ -65,11 +65,7 @@ void EMSCRIPTEN_KEEPALIVE c4w_req_set_error(data_request_t* ctx, char* error, ui
 /* ── Verify API ── */
 
 void* EMSCRIPTEN_KEEPALIVE c4w_create_verify_ctx(uint8_t* proof, size_t proof_len, char* method, char* args, uint64_t chain_id, char* trusted_checkpoint, char* witness_keys, uint32_t flags) {
-  if (trusted_checkpoint && strlen(trusted_checkpoint) == 66) {
-    bytes32_t checkpoint;
-    hex_to_bytes(trusted_checkpoint + 2, 64, bytes(checkpoint, 32));
-    c4_eth_set_trusted_checkpoint(chain_id, checkpoint);
-  }
+  c4_set_checkpoint((chain_id_t) chain_id, trusted_checkpoint);
   if (method == NULL || strlen(method) == 0) return NULL;
 
   c4w_verify_ctx_t* ctx = calloc(1, sizeof(c4w_verify_ctx_t));
@@ -121,6 +117,14 @@ char* EMSCRIPTEN_KEEPALIVE c4w_execute_rpc_ctx(void* ctx) {
 
 void EMSCRIPTEN_KEEPALIVE c4w_free_rpc_ctx(void* ctx) {
   c4_rpc_ctx_free((c4_rpc_ctx_t*) ctx);
+}
+
+void EMSCRIPTEN_KEEPALIVE c4w_set_checkpoint(uint64_t chain_id, char* checkpoint) {
+  c4_set_checkpoint((chain_id_t) chain_id, checkpoint);
+}
+
+void EMSCRIPTEN_KEEPALIVE c4w_rpc_ctx_set_witness_keys(void* ctx, char* keys) {
+  c4_rpc_ctx_set_witness_keys((c4_rpc_ctx_t*) ctx, keys);
 }
 
 /* ── Utilities ── */

--- a/bindings/emscripten/ems.c
+++ b/bindings/emscripten/ems.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 corpus.core
+ * Copyright (c) 2025,2026 corpus.core
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
@@ -21,10 +21,9 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include "../colibri_common.h"
 #include "plugin.h"
-#include "prover.h"
 #include "sync_committee.h"
-#include "verify.h"
 #include "version.h"
 #include <emscripten.h>
 #include <stdio.h>
@@ -36,6 +35,8 @@ typedef struct {
   verify_ctx_t verify;
 } c4w_verify_ctx_t;
 
+/* ── Prover API ── */
+
 prover_ctx_t* EMSCRIPTEN_KEEPALIVE c4w_create_proof_ctx(char* method, char* args, uint64_t chain_id, uint32_t flags) {
   return c4_prover_create(method, args, chain_id, flags);
 }
@@ -43,96 +44,13 @@ prover_ctx_t* EMSCRIPTEN_KEEPALIVE c4w_create_proof_ctx(char* method, char* args
 void EMSCRIPTEN_KEEPALIVE c4w_free_proof_ctx(prover_ctx_t* ctx) {
   c4_prover_free(ctx);
 }
-static const char* status_to_string(c4_status_t status) {
-  switch (status) {
-    case C4_SUCCESS:
-      return "success";
-    case C4_ERROR:
-      return "error";
-    case C4_PENDING:
-      return "waiting";
-  }
-}
-
-static const char* encoding_to_string(data_request_encoding_t encoding) {
-  switch (encoding) {
-    case C4_DATA_ENCODING_SSZ:
-      return "ssz";
-    case C4_DATA_ENCODING_JSON:
-      return "json";
-  }
-}
-
-static const char* method_to_string(data_request_method_t method) {
-  switch (method) {
-    case C4_DATA_METHOD_GET:
-      return "get";
-    case C4_DATA_METHOD_POST:
-      return "post";
-    case C4_DATA_METHOD_PUT:
-      return "put";
-    case C4_DATA_METHOD_DELETE:
-      return "delete";
-  }
-}
-
-static const char* data_request_type_to_string(data_request_type_t type) {
-  switch (type) {
-    case C4_DATA_TYPE_BEACON_API:
-      return "beacon_api";
-    case C4_DATA_TYPE_ETH_RPC:
-      return "eth_rpc";
-    case C4_DATA_TYPE_REST_API:
-      return "rest_api";
-    case C4_DATA_TYPE_INTERN:
-      return "intern";
-    case C4_DATA_TYPE_CHECKPOINTZ:
-      return "checkpointz";
-    case C4_DATA_TYPE_PROVER:
-      return "prover";
-  }
-}
-static void add_data_request(buffer_t* result, data_request_t* data_request) {
-  bprintf(result, "{\"req_ptr\": %l,", (uint64_t) data_request);
-  bprintf(result, "\"chain_id\": %d,", (uint32_t) data_request->chain_id);
-  bprintf(result, "\"encoding\": \"%s\",", encoding_to_string(data_request->encoding));
-  bprintf(result, "\"exclude_mask\": \"%d\",", (uint32_t) data_request->node_exclude_mask);
-  bprintf(result, "\"method\": \"%s\",", method_to_string(data_request->method));
-  bprintf(result, "\"url\": \"%s\",", data_request->url);
-  if (data_request->payload.data)
-    bprintf(result, "\"payload\": %j,", (json_t) {.len = data_request->payload.len, .start = (char*) data_request->payload.data, .type = JSON_TYPE_OBJECT});
-  bprintf(result, "\"type\": \"%s\"}", data_request_type_to_string(data_request->type));
-}
 
 char* EMSCRIPTEN_KEEPALIVE c4w_execute_proof_ctx(prover_ctx_t* ctx) {
-  buffer_t    result = {0};
   c4_status_t status = c4_prover_execute(ctx);
-  bprintf(&result, "{\"status\": \"%s\",", status_to_string(status));
-  switch (status) {
-    case C4_SUCCESS:
-      bprintf(&result, "\"result\": %l, \"result_len\": %d", (uint64_t) ctx->proof.data, ctx->proof.len);
-      break;
-    case C4_ERROR:
-      bprintf(&result, "\"error\": \"%S\"", ctx->state.error);
-      break;
-    case C4_PENDING: {
-      bprintf(&result, "\"requests\": [");
-      data_request_t* data_request = c4_state_get_pending_request(&ctx->state);
-      while (data_request) {
-        if (!data_request->response.data && !data_request->error) {
-          if (result.data.data[result.data.len - 1] != '[') bprintf(&result, ",");
-          add_data_request(&result, data_request);
-        }
-        data_request = data_request->next;
-      }
-
-      bprintf(&result, "]");
-      break;
-    }
-  }
-  bprintf(&result, "}");
-  return buffer_as_string(result);
+  return c4i_build_prover_json_status(status, &ctx->state, ctx->proof.data, ctx->proof.len, false);
 }
+
+/* ── Request handling ── */
 
 void EMSCRIPTEN_KEEPALIVE c4w_req_set_response(data_request_t* ctx, void* data, size_t len, uint16_t node_index) {
   ctx->response            = bytes(data, len);
@@ -144,6 +62,8 @@ void EMSCRIPTEN_KEEPALIVE c4w_req_set_error(data_request_t* ctx, char* error, ui
   ctx->response_node_index = node_index;
 }
 
+/* ── Verify API ── */
+
 void* EMSCRIPTEN_KEEPALIVE c4w_create_verify_ctx(uint8_t* proof, size_t proof_len, char* method, char* args, uint64_t chain_id, char* trusted_checkpoint, char* witness_keys, uint32_t flags) {
   if (trusted_checkpoint && strlen(trusted_checkpoint) == 66) {
     bytes32_t checkpoint;
@@ -154,7 +74,7 @@ void* EMSCRIPTEN_KEEPALIVE c4w_create_verify_ctx(uint8_t* proof, size_t proof_le
 
   c4w_verify_ctx_t* ctx = calloc(1, sizeof(c4w_verify_ctx_t));
   ctx->proof            = bytes_dup(bytes(proof, proof_len));
-  c4_verify_init(&ctx->verify, ctx->proof, strdup(method), args ? json_parse(strdup(args)) : ((json_t) {.len = 0, .start = "[]", .type = JSON_TYPE_ARRAY}), (chain_id_t) chain_id, (verify_flags_t) flags);
+  c4_verify_init(&ctx->verify, ctx->proof, strdup(method), args ? json_parse(strdup(args)) : ((json_t){.len = 0, .start = "[]", .type = JSON_TYPE_ARRAY}), (chain_id_t) chain_id, (verify_flags_t) flags);
 
   if (witness_keys && strlen(witness_keys) > 40 && witness_keys[0] == '0' && witness_keys[1] == 'x') {
     bytes_t witness_key_bytes = bytes(safe_malloc(strlen(witness_keys) / 2), (strlen(witness_keys) - 2) / 2);
@@ -164,6 +84,7 @@ void* EMSCRIPTEN_KEEPALIVE c4w_create_verify_ctx(uint8_t* proof, size_t proof_le
 
   return (void*) ctx;
 }
+
 void EMSCRIPTEN_KEEPALIVE c4w_free_verify_ctx(void* ptr) {
   c4w_verify_ctx_t* ctx = (c4w_verify_ctx_t*) ptr;
   if (ctx->verify.method) free((char*) ctx->verify.method);
@@ -172,47 +93,43 @@ void EMSCRIPTEN_KEEPALIVE c4w_free_verify_ctx(void* ptr) {
   c4_verify_free_data(&ctx->verify);
   free(ctx);
 }
-method_type_t EMSCRIPTEN_KEEPALIVE c4w_get_method_type(uint64_t chain_id, char* method, char* params, uint32_t flags) {
-  return c4_get_method_type((chain_id_t) chain_id, method,
-                            params ? json_parse(params) : (json_t) {0}, (verify_flags_t) flags);
-}
 
 char* EMSCRIPTEN_KEEPALIVE c4w_verify_proof(void* ptr) {
   verify_ctx_t* ctx    = &((c4w_verify_ctx_t*) ptr)->verify;
-  buffer_t      result = {0};
   c4_status_t   status = c4_verify(ctx);
-  bprintf(&result, "{\"status\": \"%s\",", status_to_string(status));
-  switch (status) {
-    case C4_SUCCESS:
-      bprintf(&result, "\"result\": %Z", ctx->data);
-      break;
-    case C4_ERROR:
-      bprintf(&result, "\"error\": \"%S\"", ctx->state.error);
-      break;
-    case C4_PENDING: {
-      bprintf(&result, "\"requests\": [");
-      data_request_t* data_request = c4_state_get_pending_request(&ctx->state);
-      while (data_request) {
-        if (!data_request->response.data && !data_request->error) {
-          if (result.data.data[result.data.len - 1] != '[') bprintf(&result, ",");
-          add_data_request(&result, data_request);
-        }
-        data_request = data_request->next;
-      }
-
-      bprintf(&result, "]");
-      break;
-    }
-  }
-  bprintf(&result, "}");
-  return buffer_as_string(result);
+  return c4i_build_verifier_json_status(status, &ctx->state, ctx->data, false);
 }
+
+/* ── Method type ── */
+
+method_type_t EMSCRIPTEN_KEEPALIVE c4w_get_method_type(uint64_t chain_id, char* method, char* params, uint32_t flags) {
+  return c4_get_method_type((chain_id_t) chain_id, method,
+                            params ? json_parse(params) : (json_t){0}, (verify_flags_t) flags);
+}
+
+/* ── Unified RPC API ── */
+
+void* EMSCRIPTEN_KEEPALIVE c4w_create_rpc_ctx(char* method, char* params, uint64_t chain_id, uint32_t prover_flags, uint32_t verify_flags, int use_remote_prover) {
+  return (void*) c4_rpc_ctx_create(method, params, (chain_id_t) chain_id,
+                                   (prover_flags_t) prover_flags, (verify_flags_t) verify_flags,
+                                   use_remote_prover != 0);
+}
+
+char* EMSCRIPTEN_KEEPALIVE c4w_execute_rpc_ctx(void* ctx) {
+  return c4_rpc_build_json_status((c4_rpc_ctx_t*) ctx, false);
+}
+
+void EMSCRIPTEN_KEEPALIVE c4w_free_rpc_ctx(void* ctx) {
+  c4_rpc_ctx_free((c4_rpc_ctx_t*) ctx);
+}
+
+/* ── Utilities ── */
 
 char* EMSCRIPTEN_KEEPALIVE c4w_decode_proof(uint8_t* data, size_t len) {
   bytes_t          req_data = bytes(data, len);
   const ssz_def_t* def      = c4_get_req_type_from_req(req_data);
   if (!def) return NULL;
-  return bprintf(NULL, "%Z", (ssz_ob_t) {.def = def, .bytes = req_data});
+  return bprintf(NULL, "%Z", (ssz_ob_t){.def = def, .bytes = req_data});
 }
 
 void EMSCRIPTEN_KEEPALIVE c4w_req_free(data_request_t* client_update) {
@@ -226,6 +143,8 @@ uint8_t* EMSCRIPTEN_KEEPALIVE c4w_buffer_alloc(buffer_t* buf, size_t len) {
   buf->data.len = len;
   return buf->data.data;
 }
+
+/* ── Storage plugin (WASM ↔ JS bridge) ── */
 
 static bool file_get(char* key, buffer_t* buffer) {
   return EM_ASM_INT({

--- a/bindings/emscripten/src/index.ts
+++ b/bindings/emscripten/src/index.ts
@@ -29,8 +29,6 @@ import {
   C4W,
   copy_to_c,
   getC4w,
-  get_prover_config_hex,
-  set_trusted_checkpoint,
   decode_proof,
   Storage as C4Storage
 } from "./wasm.js";
@@ -76,20 +74,6 @@ export {
   PrototypeProtection
 } from './transactionVerifier.js';
 
-// fetch_rpc und handle_request sind nach http.ts verschoben
-
-// default_config, get_chain_id, chain_conf ausgelagert nach ./chains.ts
-
-function cleanup_args(method: string, args: any[]): any[] {
-  if (method == "eth_verifyLogs") return args.map(arg => ({
-    transactionIndex: arg.transactionIndex,
-    blockNumber: arg.blockNumber
-  }))
-  if (method == "colibri_simulateTransaction") return args.slice(0, 2);
-  return args;
-}
-
-
 
 export default class C4Client {
 
@@ -97,7 +81,6 @@ export default class C4Client {
   private eventEmitter: EventEmitter;
   private connectionState: ConnectionState;
   private subscriptionManager: SubscriptionManager;
-  private initMap: Map<number | string, boolean> = new Map();
   private flags: number = 0;
   private verify_flags: number = 0;
 
@@ -170,30 +153,6 @@ export default class C4Client {
         pollingInterval: this.config.pollingInterval || chain_conf(this.config, this.config.chainId)?.pollingInterval || 12000
       }
     )
-  }
-
-  // Prover config helpers are moved to wasm.ts (get_prover_config_hex)
-
-  private async fetch_checkpointz() {
-    let checkpoint: string | undefined = undefined
-    for (const url of [...(this.config.checkpointz || []), ...(this.config.beacon_apis || []), ...(this.config.prover || [])]) {
-      const response = await fetch(url + (url.endsWith('/') ? '' : '/') + 'eth/v1/beacon/states/head/finality_checkpoints', {
-        method: 'GET',
-        headers: {
-          "Content-Type": "application/json"
-        }
-      })
-      if (response.ok) {
-        const res = await response.json();
-        checkpoint = res?.data?.finalized?.root
-        if (checkpoint) break;
-      }
-    }
-    if (!checkpoint) throw new Error('No checkpoint found');
-    this.config.trusted_checkpoint = checkpoint;
-
-    // set trusted checkpoint in C state so we can use it in proof calls immediately
-    await set_trusted_checkpoint(this.config.chainId as number, checkpoint);
   }
 
   /**
@@ -318,15 +277,7 @@ export default class C4Client {
    * @returns The result
    */
   async rpc(method: string, args: any[], method_type?: C4MethodType): Promise<any> {
-    // eth_subscribe and eth_unsubscribe are handled by C4Client.request before this method is called.
-    // This rpc method is for the underlying data fetching/proving.
-    if (!this.initMap.get(this.config.chainId)) {
-      this.initMap.set(this.config.chainId, true);
-      if (!this.config.zk_proof && this.config.checkpointz && this.config.checkpointz.length > 0 && !this.config.trusted_checkpoint && (await get_prover_config_hex(this.config.chainId as number)).length == 2)
-        await this.fetch_checkpointz();
-
-    }
-    // Special handling for eth_sendTransaction with verification
+    // eth_sendTransaction stays in bindings (requires fallback_provider interaction)
     if (method === 'eth_sendTransaction' && (this.config as any).verifyTransactions) {
       return await TransactionVerifier.verifyAndSendTransaction(
         args[0],
@@ -336,38 +287,51 @@ export default class C4Client {
       );
     }
 
+    // Allow host to skip verification for specific calls
     if (method_type === undefined)
       method_type = await this.getMethodSupport(method, args);
+    if (method_type === C4MethodType.PROOFABLE && this.config.verify && !this.config.verify(method, args))
+      return await fetch_rpc(this.config.rpcs, { method, params: args }, false);
 
-    switch (method_type) {
-      case C4MethodType.PROOFABLE: {
+    const c4w = await getC4w();
+    const free_buffers: number[] = [];
+    let ctx = 0;
 
-        if (this.config.verify && !this.config.verify(method, args)) {
-          // skip verification and fetch directly
-          return await fetch_rpc(this.config.rpcs, { method, params: args }, false);
+    try {
+      const use_remote_prover = (method_type === C4MethodType.PROOFABLE && this.config.prover?.length) ? 1 : 0;
+      let prover_flags = this.flags;
+      if (this.config.zk_proof) prover_flags |= (1 << 7);
+
+      ctx = c4w._c4w_create_rpc_ctx(
+        as_char_ptr(method, c4w, free_buffers),
+        as_char_ptr(JSON.stringify(args || []), c4w, free_buffers),
+        BigInt(this.config.chainId),
+        prover_flags,
+        this.verify_flags,
+        use_remote_prover
+      );
+
+      if (this.config.trusted_checkpoint)
+        c4w._c4w_set_checkpoint(BigInt(this.config.chainId), as_char_ptr(this.config.trusted_checkpoint, c4w, free_buffers));
+      if (this.config.checkpoint_witness_keys)
+        c4w._c4w_rpc_ctx_set_witness_keys(ctx, as_char_ptr(this.config.checkpoint_witness_keys, c4w, free_buffers));
+
+      while (true) {
+        const state = as_json(c4w._c4w_execute_rpc_ctx(ctx), c4w, true);
+        switch (state.status) {
+          case "success":
+            return state.result;
+          case "error":
+            throw new Error(state.error);
+          case "pending":
+            await Promise.all(state.requests.map((req: DataRequest) => handle_request(req, this.config)));
+            break;
         }
-
-        const proof = this.config.prover && this.config.prover.length
-          ? await fetch_rpc(this.config.prover, {
-            method,
-            params: cleanup_args(method, args),
-            c4: await get_prover_config_hex(this.config.chainId as number),
-            zk_proof: !!this.config.zk_proof,
-            signers: this.config.checkpoint_witness_keys || '0x',
-            version: (await getC4w())._c4w_get_current_version_number()
-          }, true)
-          : await this.createProof(method, args);
-        return this.verifyProof(method, args, proof);
       }
-      case C4MethodType.UNPROOFABLE:
-        return await fetch_rpc(this.config.rpcs, { method, params: args }, false);
-      case C4MethodType.NOT_SUPPORTED:
-        throw new ProviderRpcError(4200, `Method ${method} is not supported by C4Client.rpc core`);
-      case C4MethodType.LOCAL:
-        return this.verifyProof(method, args, new Uint8Array());
+    } finally {
+      free_buffers.forEach(ptr => c4w._free(ptr));
+      if (ctx) c4w._c4w_free_rpc_ctx(ctx);
     }
-    // Should be unreachable if MethodType enum is comprehensive and handled
-    throw new ProviderRpcError(-32603, `Internal error: Unhandled method type for ${method} in C4Client.rpc core`);
   }
 
 

--- a/bindings/emscripten/src/index.ts
+++ b/bindings/emscripten/src/index.ts
@@ -243,7 +243,7 @@ export default class C4Client {
             return as_bytes(state.result, state.result_len, c4w);
           case "error":
             throw new Error(state.error);
-          case "waiting": {
+          case "pending": {
             await Promise.all(state.requests.map((req: DataRequest) => handle_request(req, this.config)));
             break;
           }
@@ -296,7 +296,7 @@ export default class C4Client {
             return state.result;
           case "error":
             throw new Error(state.error);
-          case "waiting": {
+          case "pending": {
             await Promise.all(state.requests.map((req: DataRequest) => handle_request(req, this.config)));
             break;
           }

--- a/bindings/emscripten/src/wasm_shared.ts
+++ b/bindings/emscripten/src/wasm_shared.ts
@@ -34,6 +34,11 @@ export interface C4W {
     _c4w_verify_proof: (verifyCtx: number) => number;
     _c4w_req_free: (reqPtr: number) => void;
     _c4w_get_current_version_number: () => number;
+    _c4w_create_rpc_ctx: (method: number, params: number, chainId: bigint, prover_flags: number, verify_flags: number, use_remote_prover: number) => number;
+    _c4w_execute_rpc_ctx: (ctx: number) => number;
+    _c4w_free_rpc_ctx: (ctx: number) => void;
+    _c4w_set_checkpoint: (chainId: bigint, checkpoint: number) => void;
+    _c4w_rpc_ctx_set_witness_keys: (ctx: number, keys: number) => void;
     _c4w_decode_proof: (data: number, len: number) => number;
     _init_storage: () => void;
     HEAPU8: Uint8Array;
@@ -256,7 +261,7 @@ export function createC4wApi(options: {
     async function set_trusted_checkpoint(chainId: number, checkpoint: string): Promise<void> {
         const c4w = await getC4w();
         const free_buffers: number[] = [];
-        c4w._c4w_create_verify_ctx(0, 0, 0, 0, BigInt(chainId), as_char_ptr(checkpoint, c4w, free_buffers), 0, 0);
+        c4w._c4w_set_checkpoint(BigInt(chainId), as_char_ptr(checkpoint, c4w, free_buffers));
         free_buffers.forEach(ptr => c4w._free(ptr));
     }
 

--- a/bindings/kotlin/CMakeLists.txt
+++ b/bindings/kotlin/CMakeLists.txt
@@ -68,6 +68,7 @@ set(CMAKE_SWIG_FLAGS "-module" "c4" "-package" "com.corpuscore.colibri" "-I${CMA
 set(SWIG_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/colibri.i
     ${CMAKE_CURRENT_SOURCE_DIR}/../colibri.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../colibri_common.c
     ${CMAKE_CURRENT_SOURCE_DIR}/jni_bridge.c
 )
 

--- a/bindings/kotlin/colibri.i
+++ b/bindings/kotlin/colibri.i
@@ -21,7 +21,7 @@ typedef struct bytes_t {
 %}
 
 // Add typemap for char* return values that need to be freed
-%typemap(out) char* c4_verify_execute_json_status, char* c4_prover_execute_json_status {
+%typemap(out) char* c4_verify_execute_json_status, char* c4_prover_execute_json_status, char* c4_rpc_execute_json_status {
     if ($1) {
         $result = (*jenv)->NewStringUTF(jenv, (const char *)$1);
         free($1);  // Free the dynamically allocated string

--- a/bindings/kotlin/lib/src/main/kotlin/com/corpuscore/colibri/Colibri.kt
+++ b/bindings/kotlin/lib/src/main/kotlin/com/corpuscore/colibri/Colibri.kt
@@ -96,7 +96,9 @@ class Colibri(
     var trustedCheckpoint: String? = null, // Optional trusted checkpoint
     var includeCode: Boolean = false, // Default value
     var useAccesslist: Boolean = false,
+    var zkProof: Boolean = false,
     var privacyMode: PrivacyMode = PrivacyMode.NONE, // PAP mode; BASIC sets verify flag
+    var checkpointWitnessKeys: String? = null,
     var requestHandler: RequestHandler? = null // Add optional request handler for mocking
 ) {
     companion object {
@@ -513,81 +515,79 @@ class Colibri(
         }
     }
 
-     // Add rpc method implementation
-     suspend fun rpc(method: String, args: Array<Any?>): Any? { // Allow nullable args, return Any?
-         val argsJson = org.json.JSONArray(args.toList()).toString()
-         val methodType = getMethodSupport(method, argsJson)
-         var proof: ByteArray = byteArrayOf() // Initialize empty proof
+    // Unified RPC execution via the C core state machine.
+    suspend fun rpc(method: String, args: Array<Any?>): Any? {
+        return withContext(Dispatchers.IO) {
+            val jsonArgs = formatArgsArray(args)
+            val proverFlags = (if (includeCode) 1L else 0L) or (if (useAccesslist) (1L shl 6) else 0L) or (if (zkProof) (1L shl 7) else 0L)
+            val useRemote = if (provers.isEmpty()) 0 else 1
 
-//         println("rpc: Method $method, Type: $methodType, Args: ${formatArgsArray(args)}")
+            val ctx = com.corpuscore.colibri.c4.c4_create_rpc_ctx(method, jsonArgs, chainId, proverFlags, getVerifyFlags(), useRemote)
+                ?: throw ColibriException("Failed to create RPC context for method $method")
 
-         when (methodType) {
-             MethodType.PROOFABLE -> {
-                 // TODO: Implement optional verify hook if needed
-                 if (provers.isNotEmpty()) {
-                  //   println("rpc: Fetching proof for $method from prover...")
-                     proof = try {
-                          fetchRpc(provers, method, formatArgsArray(args), true)
-                     } catch (e: Exception) {
-                          println("rpc: Failed to fetch proof from prover, falling back to local creation. Error: ${e.message}")
-                          println("rpc: Creating proof locally for $method...")
-                          getProof(method, args) // Create proof locally if fetch fails
-                     }
+            val checkpointStr = trustedCheckpoint
+            if (!checkpointStr.isNullOrEmpty()) {
+                com.corpuscore.colibri.c4.c4_set_checkpoint(chainId, checkpointStr)
+            }
+            val witnessKeys = checkpointWitnessKeys
+            if (!witnessKeys.isNullOrEmpty()) {
+                com.corpuscore.colibri.c4.c4_rpc_set_witness_keys(ctx, witnessKeys)
+            }
 
-                 } else {
-//                     println("rpc: Creating proof locally for $method...")
-                     proof = getProof(method, args)
-                 }
-//                 println("rpc: Obtained proof (${proof.size} bytes) for $method.")
-                 // Verification happens below
-             }
-             MethodType.UNPROOFABLE -> {
-//                 println("rpc: Method $method is UNPROOFABLE, fetching directly...")
-                 val responseData = fetchRpc(ethRpcs, method, formatArgsArray(args), false)
-//                 println("rpc: Fetched direct response (${responseData.size} bytes) for $method.")
-                 // Parse JSON response
-                 return try {
-                      val jsonString = responseData.toString(Charsets.UTF_8)
-                      if (jsonString.isBlank()) { // Handle empty response (e.g., 204 No Content)
-                            null
-                      } else {
-                          val jsonResponse = JSONObject(jsonString)
-                          if (jsonResponse.has("error") && jsonResponse.get("error") != JSONObject.NULL) {
-                              val errorObj = jsonResponse.getJSONObject("error")
-                              throw ColibriException("RPC Error for $method: ${errorObj.optString("message", "Unknown error")}")
-                          }
-                          if (jsonResponse.has("result")) {
-                              val result = jsonResponse.get("result")
-                              if (result == JSONObject.NULL) null else result // Return null if JSON result is null
-                          } else {
-                               // Neither error nor result - treat as success with null result?
-                               null
-                          }
-                      }
+            val maxIterations = 50
+            var iteration = 0
 
-                 } catch (e: Exception) {
-                      throw ColibriException("Failed to parse direct RPC response for $method: ${e.message}")
-                 }
-             }
-             MethodType.NOT_SUPPORTED -> {
-                 println("rpc: Method $method is NOT_SUPPORTED.")
-                 throw ColibriException("Method $method is not supported")
-             }
-             MethodType.LOCAL -> {
-//                 println("rpc: Method $method is LOCAL, proceeding with verification (empty proof).")
-                 proof = byteArrayOf() // Ensure proof is empty for local verification
-                 // Verification happens below
-             }
-             MethodType.UNKNOWN -> {
-                 println("rpc: Method $method has UNKNOWN type.")
-                 throw ColibriException("Method $method has unknown support type")
-             }
-         }
+            try {
+                while (iteration < maxIterations) {
+                    iteration++
+                    val statusJsonPtr = com.corpuscore.colibri.c4.c4_rpc_execute_json_status(ctx)
+                        ?: throw ColibriException("RPC execution returned null status for method $method")
+                    val stateString = statusJsonPtr.toString()
 
-         // Verify the proof (either created/fetched for PROOFABLE, or empty for LOCAL)
-//         println("rpc: Verifying proof for $method...")
-         return verifyProof(proof, method, args)
-     }
+                    val state = try {
+                        JSONObject(stateString)
+                    } catch (e: Exception) {
+                        throw ColibriException("Failed to parse RPC status JSON: ${e.message}")
+                    }
+
+                    when (state.getString("status")) {
+                        "success" -> {
+                            if (state.has("result")) {
+                                val result = state.get("result")
+                                return@withContext if (result == JSONObject.NULL) null else convertJsonToJava(result)
+                            }
+                            return@withContext null
+                        }
+                        "error" -> {
+                            throw ColibriException("RPC error for method $method: ${state.optString("error", "Unknown error")}")
+                        }
+                        "pending" -> {
+                            val requests = state.optJSONArray("requests") ?: JSONArray()
+                            for (i in 0 until requests.length()) {
+                                val request = requests.getJSONObject(i)
+                                val type = request.optString("type", "eth_rpc")
+                                val servers = when (type) {
+                                    "checkpointz" -> checkpointz
+                                    "beacon_api" -> if (provers.isNotEmpty()) provers else beaconApis
+                                    "prover" -> provers
+                                    else -> ethRpcs
+                                }
+                                try {
+                                    fetchRequest(servers, request)
+                                } catch (e: Exception) {
+                                    println("Error handling pending request $i: ${e.message}")
+                                }
+                            }
+                        }
+                        else -> throw ColibriException("Unknown RPC status: ${state.getString("status")}")
+                    }
+                }
+                throw ColibriException("rpc exceeded max iterations ($maxIterations) for method $method")
+            } finally {
+                com.corpuscore.colibri.c4.c4_free_rpc_ctx(ctx)
+            }
+        }
+    }
 }
 
 // Helper function to convert org.json types to standard Java/Kotlin types

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(pybind11 REQUIRED PATHS ${pybind11_DIR})
 pybind11_add_module(_native 
     src/bindings.cpp
     ${CMAKE_SOURCE_DIR}/bindings/colibri.c
+    ${CMAKE_SOURCE_DIR}/bindings/colibri_common.c
 )
 
 # Include directories for bindings (only generic APIs, no chain-specific headers)

--- a/bindings/python/src/bindings.cpp
+++ b/bindings/python/src/bindings.cpp
@@ -182,6 +182,30 @@ int get_method_support_wrapper(uint64_t chain_id, const std::string& method, con
       params.empty() ? nullptr : const_cast<char*>(params.c_str()), flags);
 }
 
+void* create_rpc_ctx_wrapper(const std::string& method, const std::string& params, uint64_t chain_id,
+                             uint32_t prover_flags, uint32_t verify_flags, int use_remote_prover) {
+  return c4_create_rpc_ctx(
+      const_cast<char*>(method.c_str()),
+      const_cast<char*>(params.c_str()),
+      chain_id, prover_flags, verify_flags, use_remote_prover);
+}
+
+std::string rpc_execute_json_status_wrapper(void* ctx) {
+  char* result = c4_rpc_execute_json_status(ctx);
+  if (!result) return "";
+  std::string str(result);
+  free(result);
+  return str;
+}
+
+void set_checkpoint_wrapper(uint64_t chain_id, const std::string& checkpoint) {
+  c4_set_checkpoint(chain_id, checkpoint.empty() ? nullptr : checkpoint.c_str());
+}
+
+void rpc_set_witness_keys_wrapper(void* ctx, const std::string& keys) {
+  c4_rpc_set_witness_keys(ctx, keys.empty() ? nullptr : keys.c_str());
+}
+
 // Storage registration function
 void register_storage(
     std::function<py::bytes(const std::string&)>       get_func,
@@ -274,4 +298,27 @@ PYBIND11_MODULE(_native, m) {
 
   m.def("get_current_version_number", &c4_get_current_version_number,
         "Return the current Colibri library version number (uint32 as int).");
+
+  // Unified RPC API
+  m.def("create_rpc_ctx", &create_rpc_ctx_wrapper,
+        "Create a unified RPC context",
+        py::arg("method"), py::arg("params"), py::arg("chain_id"),
+        py::arg("prover_flags"), py::arg("verify_flags"), py::arg("use_remote_prover"),
+        py::return_value_policy::take_ownership);
+
+  m.def("rpc_execute_json_status", &rpc_execute_json_status_wrapper,
+        "Execute the unified RPC state machine and return JSON status",
+        py::arg("ctx"));
+
+  m.def("free_rpc_ctx", &c4_free_rpc_ctx,
+        "Free the unified RPC context",
+        py::arg("ctx"));
+
+  m.def("set_checkpoint", &set_checkpoint_wrapper,
+        "Set a trusted checkpoint for a chain",
+        py::arg("chain_id"), py::arg("checkpoint"));
+
+  m.def("rpc_set_witness_keys", &rpc_set_witness_keys_wrapper,
+        "Set witness/signer keys on an RPC context",
+        py::arg("ctx"), py::arg("keys"));
 }

--- a/bindings/python/src/colibri/client.py
+++ b/bindings/python/src/colibri/client.py
@@ -52,7 +52,9 @@ class Colibri:
         trusted_checkpoint: Optional[str] = None,
         include_code: bool = False,
         use_accesslist: bool = False,
+        zk_proof: bool = False,
         privacy_mode: Optional[PrivacyMode] = None,
+        checkpoint_witness_keys: Optional[str] = None,
         storage: Optional[ColibriStorage] = None,
         request_handler: Optional[Any] = None,  # For testing
     ):
@@ -68,7 +70,9 @@ class Colibri:
             trusted_checkpoint: Optional trusted checkpoint as hex string (0x-prefixed, 66 chars)
             include_code: Whether to include code in proofs
             use_accesslist: Whether to use eth_createAccessList instead of debug_traceCall
+            zk_proof: Whether to request ZK sync proofs from remote provers
             privacy_mode: PAP mode (PrivacyMode.NONE or PrivacyMode.BASIC). Default NONE.
+            checkpoint_witness_keys: Optional hex-encoded witness signer keys (0x-prefixed)
             storage: Storage implementation (defaults to DefaultStorage)
             request_handler: Optional request handler for testing
         """
@@ -81,7 +85,9 @@ class Colibri:
         self.trusted_checkpoint = trusted_checkpoint
         self.include_code = include_code
         self.use_accesslist = use_accesslist
+        self.zk_proof = zk_proof
         self.privacy_mode = privacy_mode if privacy_mode is not None else PrivacyMode.NONE
+        self.checkpoint_witness_keys = checkpoint_witness_keys
         self.request_handler = request_handler
 
         # Initialize storage - registration is global in C
@@ -325,45 +331,54 @@ class Colibri:
 
     async def rpc(self, method: str, params: List[Any]) -> Any:
         """
-        Execute an RPC call with automatic proof handling
+        Execute an RPC call via the unified C core state machine.
         
         Args:
             method: RPC method name
             params: Method parameters
             
         Returns:
-            RPC result
+            Verified RPC result
             
         Raises:
             ColibriError: If the RPC call fails
         """
-        method_type = self.get_method_support(method, params)
-        
-        if method_type == MethodType.PROOFABLE:
-            # Try to fetch proof from prover first
-            if self.provers:
-                try:
-                    proof = await self._fetch_rpc(self.provers, method, params, as_proof=True)
-                except Exception:
-                    # Fallback to local proof creation
-                    proof = await self.create_proof(method, params)
-            else:
-                proof = await self.create_proof(method, params)
-            
-            return await self.verify_proof(proof, method, params)
-            
-        elif method_type == MethodType.UNPROOFABLE:
-            return await self._fetch_rpc(self.eth_rpcs, method, params, as_proof=False)
-            
-        elif method_type == MethodType.LOCAL:
-            # Local methods use empty proof
-            return await self.verify_proof(b"", method, params)
-            
-        elif method_type == MethodType.NOT_SUPPORTED or method_type == MethodType.UNDEFINED:
-            raise ColibriError(f"Method {method} is not supported")
-            
-        else:
-            raise ColibriError(f"Unknown method type for {method}")
+        native = _get_native()
+        if not native:
+            raise ColibriError("Native module not available")
+
+        params_json = json.dumps(params)
+        prover_flags = (1 if self.include_code else 0) | ((1 << 6) if self.use_accesslist else 0) | ((1 << 7) if self.zk_proof else 0)
+        use_remote = 1 if self.provers else 0
+
+        ctx = native.create_rpc_ctx(method, params_json, self.chain_id,
+                                    prover_flags, self._get_verify_flags(), use_remote)
+        if not ctx:
+            raise ColibriError(f"Failed to create RPC context for {method}")
+
+        if self.trusted_checkpoint:
+            native.set_checkpoint(self.chain_id, self.trusted_checkpoint)
+        if self.checkpoint_witness_keys:
+            native.rpc_set_witness_keys(ctx, self.checkpoint_witness_keys)
+
+        try:
+            while True:
+                status_json = native.rpc_execute_json_status(ctx)
+                if not status_json:
+                    raise ColibriError("RPC execution returned null")
+
+                status = json.loads(status_json)
+
+                if status["status"] == "success":
+                    return status.get("result")
+                elif status["status"] == "error":
+                    raise ColibriError(status.get("error", "Unknown RPC error"))
+                elif status["status"] == "pending":
+                    await self._handle_requests(status.get("requests", []), use_prover_fallback=True)
+                else:
+                    raise ColibriError(f"Unknown status: {status['status']}")
+        finally:
+            native.free_rpc_ctx(ctx)
 
     async def _handle_requests(
         self, 
@@ -398,6 +413,8 @@ class Colibri:
                 # Determine server list
                 if request.request_type == "checkpointz":
                     servers = self.checkpointz
+                elif request.request_type == "prover":
+                    servers = self.provers
                 elif request.request_type == "beacon_api":
                     if use_prover_fallback and self.provers:
                         servers = self.provers

--- a/bindings/python/tests/test_client.py
+++ b/bindings/python/tests/test_client.py
@@ -130,10 +130,9 @@ class TestClientWithMocks:
     
     @pytest.mark.asyncio
     async def test_rpc_unproofable_method(self, mock_client):
-        """Test RPC call for unproofable method"""
+        """Test RPC call for unproofable method (goes through unified C core)"""
         client, storage, request_handler = mock_client
         
-        # Mock the response for eth_gasPrice (unproofable)
         expected_result = "0x4a817c800"  # 20 Gwei
         request_handler.add_method_response("eth_gasPrice", {
             "jsonrpc": "2.0",
@@ -141,13 +140,8 @@ class TestClientWithMocks:
             "result": expected_result
         })
         
-        # Mock the method support to return UNPROOFABLE
-        with patch.object(client, 'get_method_support', return_value=MethodType.UNPROOFABLE):
-            with patch.object(client, '_fetch_rpc', return_value=expected_result) as mock_fetch:
-                result = await client.rpc("eth_gasPrice", [])
-                
-                assert result == expected_result
-                mock_fetch.assert_called_once_with(client.eth_rpcs, "eth_gasPrice", [], as_proof=False)
+        result = await client.rpc("eth_gasPrice", [])
+        assert result == expected_result
     
     @pytest.mark.asyncio
     async def test_rpc_not_supported_method(self, mock_client):
@@ -192,14 +186,11 @@ class TestClientErrorHandling:
     
     @pytest.mark.asyncio
     async def test_rpc_with_empty_params(self):
-        """Test RPC call with empty parameters"""
+        """Test RPC call with empty parameters (LOCAL method via unified C core)"""
         client = Colibri()
         
-        # Should not raise an error for empty params
-        with patch.object(client, 'get_method_support', return_value=MethodType.LOCAL):
-            with patch.object(client, 'verify_proof', return_value="0x1") as mock_verify:
-                result = await client.rpc("eth_chainId", [])
-                mock_verify.assert_called_once_with(b"", "eth_chainId", [])
+        result = await client.rpc("eth_chainId", [])
+        assert result is not None
 
 
 class TestClientHelpers:

--- a/bindings/swift/CMakeLists.txt
+++ b/bindings/swift/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 # Create the C binding library
 add_library(c4_swift_binding STATIC 
     ../colibri.c
+    ../colibri_common.c
 )
 
 # Add build dependencies based on enabled features

--- a/bindings/swift/Sources/Colibri/Colibri.swift
+++ b/bindings/swift/Sources/Colibri/Colibri.swift
@@ -232,8 +232,12 @@ public class Colibri {
     public var chainId: UInt64 = 1 // Default: Ethereum Mainnet
     public var includeCode: Bool = false
     public var useAccesslist: Bool = false
+    /// Whether to request ZK sync proofs from remote provers.
+    public var zkProof: Bool = false
     /// PAP mode; .basic sets verify flag for Pragmatic Adaptive Privacy.
     public var privacyMode: PrivacyMode = .none
+    /// Optional witness signer keys (hex-encoded, 0x-prefixed) for sync committee signing.
+    public var checkpointWitnessKeys: String? = nil
 
     /// Optional request handler for mocking HTTP requests in tests
     public var requestHandler: RequestHandler?
@@ -418,57 +422,58 @@ public class Colibri {
         }
     }
 
-    // Implement the rpc method
+    // Unified RPC execution via the C core state machine.
     public func rpc(method: String, params: String) async throws -> Any {
-        let methodType = getMethodSupport(method: method, params: params)
-        var proof = Data()
+        let methodCStr = method.withCString { strdup($0) }
+        let paramsCStr = params.withCString { strdup($0) }
+        guard let mPtr = methodCStr, let pPtr = paramsCStr else {
+            throw ColibriError.invalidInput
+        }
+        defer { free(mPtr); free(pPtr) }
 
-        switch methodType {
-        case .PROOFABLE:
-            // Assuming params is a JSON string representing an array or object
-            // We prefer fetching from a prover if available
-            if !provers.isEmpty {
-                 proof = try await fetchRpc(urls: provers, method: method, params: params, asProof: true)
-            } else {
-                 proof = try await createProof(method: method, params: params)
-            }
-            // Verification happens below, after the switch
+        let proverFlags: UInt32 = (includeCode ? 1 : 0) | (useAccesslist ? (1 << 6) : 0) | (zkProof ? (1 << 7) : 0)
+        let useRemote: Int32 = provers.isEmpty ? 0 : 1
 
-        case .UNPROOFABLE:
-            let responseData = try await fetchRpc(urls: eth_rpcs, method: method, params: params, asProof: false)
-            // Parse JSON response
-            do {
-                guard let jsonResponse = try JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
-                    throw ColibriError.invalidJSON
-                }
-                if let error = jsonResponse["error"] as? [String: Any] {
-                     let errorMessage = error["message"] as? String ?? "Unknown RPC error"
-                     throw ColibriError.rpcError(errorMessage)
-                }
-                guard let result = jsonResponse["result"] else {
-                    throw ColibriError.invalidJSON // Result field is missing
-                }
-                return result
-            } catch let error as ColibriError {
-                 throw error // Re-throw Colibri specific errors
-            } catch {
-                 throw ColibriError.invalidJSON // Catch JSON parsing errors
-            }
+        guard let ctx = c4_create_rpc_ctx(mPtr, pPtr, chainId, proverFlags, getVerifyFlags(), useRemote) else {
+            throw ColibriError.contextCreationFailed
+        }
+        defer { c4_free_rpc_ctx(ctx) }
 
-        case .NOT_SUPPORTED:
-            throw ColibriError.methodNotSupported(method)
-
-        case .LOCAL:
-            // For local methods, we still call verify with empty proof
-            proof = Data()
-            // Verification happens below, after the switch
-
-        case .UNKNOWN:
-             throw ColibriError.unknownMethodType(method)
+        if let checkpoint = trustedCheckpoint {
+            checkpoint.withCString { c4_set_checkpoint(chainId, $0) }
+        }
+        if let keys = checkpointWitnessKeys, !keys.isEmpty {
+            keys.withCString { c4_rpc_set_witness_keys(ctx, $0) }
         }
 
-        // Verify the proof (either created/fetched for PROOFABLE, or empty for LOCAL)
-        return try await verifyProof(proof: proof, method: method, params: params)
+        while true {
+            guard let statusPtr = c4_rpc_execute_json_status(ctx) else {
+                throw ColibriError.nullPointerReceived
+            }
+            let statusJson = String(cString: statusPtr)
+            free(statusPtr)
+
+            guard let statusData = statusJson.data(using: .utf8),
+                  let statusDict = try JSONSerialization.jsonObject(with: statusData) as? [String: Any],
+                  let status = statusDict["status"] as? String else {
+                throw ColibriError.invalidJSON
+            }
+
+            switch status {
+            case "success":
+                return statusDict["result"] as Any
+            case "error":
+                let errorMsg = statusDict["error"] as? String ?? "Unknown error"
+                throw ColibriError.proofError("RPC error for method \(method): \(errorMsg)")
+            case "pending":
+                guard let requests = statusDict["requests"] as? [[String: Any]] else {
+                    throw ColibriError.invalidJSON
+                }
+                try await handleRequests(requests, useProverFallback: true)
+            default:
+                throw ColibriError.unknownStatus(status)
+            }
+        }
     }
 
     // Helper function to handle pending requests
@@ -527,9 +532,11 @@ public class Colibri {
                     let servers: [String]
                     if requestType == "checkpointz" {
                         servers = self.checkpointz
-                    } else if useProverFallback && requestType == "beacon" && !self.provers.isEmpty {
+                    } else if requestType == "prover" {
                         servers = self.provers
-                    } else if requestType == "beacon" {
+                    } else if requestType == "beacon_api" && useProverFallback && !self.provers.isEmpty {
+                        servers = self.provers
+                    } else if requestType == "beacon_api" {
                         servers = self.beacon_apis
                     } else {
                         servers = self.eth_rpcs

--- a/src/chains/eth/prover/historic_proof.c
+++ b/src/chains/eth/prover/historic_proof.c
@@ -328,8 +328,8 @@ static c4_status_t fetch_updates_data(prover_ctx_t* ctx, syncdata_state_t* sync_
 
 c4_status_t c4_get_syncdata_proof(prover_ctx_t* ctx, syncdata_state_t* sync_data, ssz_builder_t* builder) {
   // nothing to be done - no data to be added.
-  if ((ctx->flags & C4_PROVER_FLAG_INCLUDE_SYNC) == 0 && !(ctx->flags & C4_PROVER_FLAG_ZK_PROOF)) return C4_SUCCESS;
-  if (ctx->flags & C4_PROVER_FLAG_ZK_PROOF && ((sync_data->newest_period == 0 && sync_data->checkpoint_period == 0) ||
+  if ((ctx->flags & C4_PROVER_FLAG_INCLUDE_SYNC) == 0 && (ctx->flags & C4_PROVER_FLAG_ZK_PROOF_WITH_STORE) != C4_PROVER_FLAG_ZK_PROOF_WITH_STORE) return C4_SUCCESS;
+  if ((ctx->flags & C4_PROVER_FLAG_ZK_PROOF_WITH_STORE) == C4_PROVER_FLAG_ZK_PROOF_WITH_STORE && ((sync_data->newest_period == 0 && sync_data->checkpoint_period == 0) ||
                                                (sync_data->newest_period && sync_data->newest_period < sync_data->required_period))) {
     // we need a zk_proof (if available) for the required period.
     builder->def             = C4_ETH_REQUEST_SYNCDATA_UNION + 2; // TODO find a way to better handle this in the future, so updates on ssz will not break the build.
@@ -367,7 +367,7 @@ static c4_status_t update_syncdata_state(prover_ctx_t* ctx, syncdata_state_t* sy
   sync_data->status            = chain_state.status;
   switch (sync_data->status) {
     case C4_STATE_SYNC_EMPTY:
-      if (ctx->flags & C4_PROVER_FLAG_ZK_PROOF) {
+      if ((ctx->flags & C4_PROVER_FLAG_ZK_PROOF_WITH_STORE)==C4_PROVER_FLAG_ZK_PROOF_WITH_STORE) {
         // we only fetch them so we safe time in case we download the proof files later.
         c4_status_t status = c4_fetch_zk_proof_data(ctx, &zk_proof, sync_data->required_period);
         if (status == C4_SUCCESS)
@@ -398,7 +398,7 @@ static c4_status_t update_syncdata_state(prover_ctx_t* ctx, syncdata_state_t* sy
     }
   }
   // if there is a gap, fetch the light client updates
-  if ((ctx->flags & C4_PROVER_FLAG_ZK_PROOF) && sync_data->newest_period < sync_data->required_period)
+  if ((ctx->flags & C4_PROVER_FLAG_ZK_PROOF_WITH_STORE) == C4_PROVER_FLAG_ZK_PROOF_WITH_STORE && sync_data->newest_period < sync_data->required_period)
     return c4_fetch_zk_proof_data(ctx, &zk_proof, sync_data->required_period);
   else if ((ctx->flags & C4_PROVER_FLAG_INCLUDE_SYNC) && sync_data->newest_period < sync_data->required_period)
     return fetch_updates_data(ctx, sync_data, NULL);

--- a/src/chains/eth/server/handler.c
+++ b/src/chains/eth/server/handler.c
@@ -42,6 +42,8 @@ void eth_server_init(http_server_t* server) {
     c4_watch_beacon_events();
   }
 
+  if (eth_config.period_store)
+    http_server.prover_flags |= C4_PROVER_FLAG_CHAIN_STORE;
   // Initialize prover stats from period_store on startup (master only).
   if (!eth_config.period_master_url && eth_config.period_store) {
     c4_period_prover_init_from_store();

--- a/src/chains/eth/verifier/sync_committee_state.c
+++ b/src/chains/eth/verifier/sync_committee_state.c
@@ -481,6 +481,10 @@ static c4_status_t init_sync_state(verify_ctx_t* ctx) {
       if (c4_req_checkpointz_status(state, ctx->chain_id, &checkpoint_epoch, checkpoint_root)) {
         // Set the checkpoint as trusted blockhash
         c4_eth_set_trusted_checkpoint(ctx->chain_id, checkpoint_root);
+        // Verify the checkpoint was actually persisted before recursing
+        c4_chain_state_t updated = c4_get_chain_state(ctx->chain_id);
+        if (updated.status == C4_STATE_SYNC_EMPTY)
+          THROW_ERROR("Failed to persist checkpoint - storage not available");
         // Recursively call init_sync_state to process the bootstrap with the new trusted checkpoint
         return init_sync_state(ctx);
       }

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -40,7 +40,7 @@ if (CLI)
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
     )
 
-    add_executable(colibri-verifier verifier.c)
+    add_executable(colibri-verifier verifier.c ../../bindings/colibri_common.c)
     set_target_properties(colibri-verifier PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
     )
@@ -53,6 +53,7 @@ if (CLI)
         )
         target_link_libraries(colibri-verifier PRIVATE 
             curl_fetch
+            prover
             verifier
             eth_verifier
             )
@@ -63,6 +64,7 @@ if (CLI)
             verifier
         )   
         target_link_libraries(colibri-verifier PRIVATE 
+            prover
             verifier
             eth_verifier
             )

--- a/src/cli/verifier.c
+++ b/src/cli/verifier.c
@@ -21,6 +21,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include "../../bindings/colibri_common.h"
 #include "beacon_types.h"
 #include "bytes.h"
 #include "config.h"
@@ -30,7 +31,6 @@
 #include "ssz.h"
 #include "state.h"
 #include "sync_committee.h"
-#include "verify.h"
 #include "version.h"
 #include <inttypes.h>
 #include <stdio.h>
@@ -39,41 +39,6 @@
 
 #ifdef USE_CURL
 #include "../../libs/curl/http.h"
-
-static bytes_t read_from_prover(char* method, char* args, bytes_t state, chain_id_t chain_id, char* signers, bool use_zk_proof) {
-  // fprintf(stderr, "reading from prover: %s(%s) from %s\n", method, args, url);
-  if (strcmp(method, "colibri_simulateTransaction") == 0) method = "eth_call";
-  buffer_t   payload = {0};
-  c4_state_t ctx     = {0};
-#ifdef ETH_ZKPROOF
-  char* additional_params = use_zk_proof ? ",\"zk_proof\":true" : "";
-#else
-  char* additional_params = "";
-#endif
-
-  bprintf(&payload, "{\"method\":\"%s\",\"params\":%s,\"c4\":\"0x%b\"%s,\"signers\":\"%s\",\"version\":%d}", method, args, state, additional_params, signers ? signers : "", c4_current_version_number());
-  data_request_t req = {.chain_id = chain_id, .type = C4_DATA_TYPE_PROVER, .payload = payload.data, .encoding = C4_DATA_ENCODING_SSZ, .method = C4_DATA_METHOD_POST};
-  ctx.requests       = &req;
-  curl_fetch_all(&ctx);
-  if (req.error) {
-    fprintf(stderr, "Prover returned error: %s\n", req.error);
-    exit(EXIT_FAILURE);
-  }
-  else if (req.response.data == NULL) {
-    fprintf(stderr, "prover returned empty response\n");
-    exit(EXIT_FAILURE);
-  }
-  else if (req.response.data[0] == '{') {
-    json_t json  = json_parse((char*) req.response.data);
-    json_t error = json_get(json, "error");
-    if (error.type == JSON_TYPE_STRING)
-      fprintf(stderr, "prover returned error: %s\n", json_new_string(error));
-    else
-      fprintf(stderr, "prover returned unknown error: %s\n", json_new_string(error));
-    exit(EXIT_FAILURE);
-  }
-  return req.response;
-}
 #endif
 
 // : Bindings
@@ -283,81 +248,61 @@ int main(int argc, char* argv[]) {
     fprintf(stderr, "method is required\n");
     exit(EXIT_FAILURE);
   }
-  bytes_t       request     = {0};
-  method_type_t method_type = c4_get_method_type(chain_id, method, json_parse((char*) args.data.data), verify_flags);
-  switch (method_type) {
-    case METHOD_UNDEFINED:
-      fprintf(stderr, "method not known: %s\n", method);
-      exit(EXIT_FAILURE);
-    case METHOD_NOT_SUPPORTED:
-      fprintf(stderr, "method not supported: %s\n", method);
-      exit(EXIT_FAILURE);
-    case METHOD_PROOFABLE:
-      if (!input) {
-#ifdef USE_CURL
-        char name[100];
-        sprintf(name, "states_%d", (uint32_t) chain_id);
-        buffer_t         state = {0};
-        storage_plugin_t storage;
-        c4_get_storage_config(&storage);
-        storage.get(name, &state);
-        request = read_from_prover(method, (char*) args.data.data, state.data, chain_id, signers, use_zk_proof);
-        buffer_free(&state);
-        if (output) bytes_write(request, fopen(output, "w"), true);
-#else
-        fprintf(stderr, "require data, but no curl installed");
-        exit(EXIT_FAILURE);
-#endif
-      }
-      else
-        request = bytes_read(input);
 
-      break;
-    case METHOD_LOCAL:
-      request = NULL_BYTES;
-      break;
-    case METHOD_UNPROOFABLE:
-      fprintf(stderr, "method not proofable: %s\n", method);
-      exit(EXIT_FAILURE);
-      break;
+  prover_flags_t prover_flags = 0;
+  if (use_zk_proof) prover_flags |= C4_PROVER_FLAG_ZK_PROOF;
+  bool use_remote = (prover_url != NULL && input == NULL);
+
+  c4_rpc_ctx_t* ctx = c4_rpc_ctx_create(method, (char*) args.data.data, chain_id,
+                                         prover_flags, verify_flags, use_remote);
+
+  if (input) {
+    ctx->proof       = bytes_read(input);
+    ctx->proof_owned = true;
   }
 
-  verify_ctx_t ctx = {0};
-  c4_verify_init(&ctx, request, method, method ? json_parse((char*) args.data.data) : (json_t) {0}, chain_id, verify_flags);
-  if (signers && strlen(signers) > 40 && signers[0] == '0' && signers[1] == 'x') {
-    ctx.witness_keys = bytes(safe_malloc(strlen(signers) / 2), (strlen(signers) - 2) / 2);
-    if (hex_to_bytes(signers, -1, ctx.witness_keys) % 20 != 0) {
+  if (signers) {
+    c4_rpc_ctx_set_witness_keys(ctx, signers);
+    if (!ctx->witness_keys.data || ctx->witness_keys.len % 20 != 0) {
       fprintf(stderr, "invalid signers: %s\n", signers);
+      c4_rpc_ctx_free(ctx);
       exit(EXIT_FAILURE);
     }
   }
-  while (c4_verify(&ctx) == C4_PENDING)
-#ifdef USE_CURL
-    curl_fetch_all(&ctx.state);
-#else
-  {
-    fprintf(stderr, "require data, but no curl installed");
-    exit(EXIT_FAILURE);
-  }
-#endif
 
-  if (ctx.success) {
+  c4_status_t status;
+  while ((status = c4_rpc_execute(ctx)) == C4_PENDING) {
+#ifdef USE_CURL
+    c4_state_t* state = c4_rpc_get_state(ctx);
+    if (state) curl_fetch_all(state);
+#else
+    fprintf(stderr, "require data, but no curl installed");
+    c4_rpc_ctx_free(ctx);
+    exit(EXIT_FAILURE);
+#endif
+  }
+
+  if (output && ctx->proof.data)
+    bytes_write(ctx->proof, fopen(output, "w"), true);
+
+  if (status == C4_SUCCESS) {
     if (test_dir) {
       char* filename = bprintf(NULL, "%s/test.json", test_dir);
       char* content  = bprintf(NULL, "{\n  \"method\":\"%s\",\n  \"params\":%J,\n  \"chain_id\": %l,\n  \"expected_result\": %Z\n}",
-                               ctx.method, ctx.args, chain_id, ctx.data);
+                               ctx->verifier.method, ctx->verifier.args, chain_id, ctx->verifier.data);
       bytes_write(bytes(content, strlen(content)), fopen(filename, "w"), true);
       safe_free(filename);
       safe_free(content);
     }
-    ssz_dump_to_file_no_quotes(stdout, ctx.data);
+    ssz_dump_to_file_no_quotes(stdout, ctx->verifier.data);
     fflush(stdout);
+    c4_rpc_ctx_free(ctx);
     return EXIT_SUCCESS;
   }
-  else if (ctx.state.error) {
-    fprintf(stderr, "proof is invalid: %s\n", ctx.state.error);
-    return EXIT_FAILURE;
-  }
-  else
-    return EXIT_FAILURE;
+
+  fprintf(stderr, "proof is invalid: %s\n",
+          ctx->error ? ctx->error
+                     : (ctx->verifier.state.error ? ctx->verifier.state.error : "unknown error"));
+  c4_rpc_ctx_free(ctx);
+  return EXIT_FAILURE;
 }

--- a/src/prover/prover.h
+++ b/src/prover/prover.h
@@ -78,6 +78,7 @@ typedef enum {
   C4_PROVER_FLAG_CALL_BLOCK_CONTEXT = 1 << 8, // if true, eth_call state_proof uses blockContext union variant and multi-proof with execution payload fields
 } prover_flag_types_t;
 
+#define C4_PROVER_FLAG_ZK_PROOF_WITH_STORE (C4_PROVER_FLAG_ZK_PROOF | C4_PROVER_FLAG_CHAIN_STORE | C4_PROVER_FLAG_INCLUDE_SYNC)
 /**
  * a bitmask holding flags used during the prover context.
  */


### PR DESCRIPTION
This commit introduces a new source file, colibri_common.c, which contains shared functionality for handling RPC requests and responses. The CMakeLists.txt files for various bindings have been updated to include colibri_common.c, ensuring that the new functionality is available across all platforms. Additionally, the shared library for the CMake build has been modified to include the new source file, enhancing the overall structure and maintainability of the codebase.