### PR TITLE
fix(eth/evmone): route calls to P256VERIFY and mark 0x100 warm (EIP-7951)

### DIFF
--- a/src/chains/eth/precompiles/precompiles.h
+++ b/src/chains/eth/precompiles/precompiles.h
@@ -59,6 +59,18 @@ typedef enum {
 pre_result_t eth_execute_precompile(const uint8_t* address, const bytes_t input, buffer_t* output, uint64_t* gas_used);
 
 /**
+ * @brief Tests whether `address` (20 bytes) is recognised as an Ethereum precompile address.
+ *
+ * Mirrors the address-range checks performed by `eth_execute_precompile`:
+ *   - classic 1-byte precompiles with `address[0..18] == 0` and `address[19]` in `0x01..0x14`;
+ *   - EIP-7951 `P256VERIFY` at `0x0000…0100` (`address[18]==0x01`, `address[19]==0x00`).
+ *
+ * Returns `true` even for entries whose implementation may be compiled out (e.g. KZG/BN128);
+ * in that case `eth_execute_precompile` will return `PRE_NOT_SUPPORTED` rather than dispatching.
+ */
+bool eth_is_precompile_address(const uint8_t* address);
+
+/**
  * Inject the trusted-setup G2^tau point (compressed, 96 bytes) for the KZG precompile.
  * Allows runtime provisioning (e.g., in WASM) when not embedded at build time.
  * @param comp96 96-byte compressed G2^tau (tau^1) in big-endian format

--- a/src/chains/eth/precompiles/precompiles_basic.c
+++ b/src/chains/eth/precompiles/precompiles_basic.c
@@ -286,6 +286,13 @@ const precompile_func_t precompile_fn[] = {
     pre_bls12_map_fp2_to_g2, // 0x11
 };
 
+bool eth_is_precompile_address(const uint8_t* address) {
+  if (!bytes_all_zero(bytes(address, 18))) return false;
+  if (address[18] == 0x00 && address[19] >= 1 && address[19] <= PRECOMPILE_FN_COUNT) return true;
+  if (address[18] == 0x01 && address[19] == 0x00) return true; // EIP-7951 P256VERIFY
+  return false;
+}
+
 pre_result_t eth_execute_precompile(const uint8_t* address, const bytes_t input, buffer_t* output, uint64_t* gas_used) {
   if (!bytes_all_zero(bytes(address, 18))) return PRE_INVALID_ADDRESS;
   if (address[18] == 0x00) {

--- a/src/chains/eth/verifier/call_evmone.c
+++ b/src/chains/eth/verifier/call_evmone.c
@@ -348,7 +348,7 @@ static void host_call(void* context, const struct evmone_message* msg, const uin
   debug_print_address("code from", &msg->code_address);
   EVM_LOG("call gas: %l, depth: %d, is_static: %s", (size_t) msg->gas, msg->depth, msg->is_static ? "true" : "false");
 
-  if (bytes_all_zero(bytes(msg->code_address.bytes, 19)) && msg->code_address.bytes[19]) {
+  if (eth_is_precompile_address(msg->code_address.bytes)) {
     buffer_t     output     = {0};
     uint64_t     gas_used   = 0;
     pre_result_t pre_result = eth_execute_precompile(msg->code_address.bytes, bytes(msg->input_data, msg->input_size), &output, &gas_used);
@@ -519,9 +519,13 @@ static int host_access_account(void* context, const evmc_address* addr) {
   evmone_context_t* root = context_root(ctx);
   debug_print_address("access_account", addr);
 
-  // precompiles 1-9 are always warm (EIP-2929)
+  // precompiles 1-9 are always warm (EIP-2929); EIP-7951 adds P256VERIFY at 0x0000…0100
   if (bytes_all_zero(bytes(addr->bytes, 19)) && addr->bytes[19] >= 1 && addr->bytes[19] <= 9) {
     EVM_LOG("access_account: WARM (precompile)");
+    return EVMONE_ACCESS_WARM;
+  }
+  if (bytes_all_zero(bytes(addr->bytes, 18)) && addr->bytes[18] == 0x01 && addr->bytes[19] == 0x00) {
+    EVM_LOG("access_account: WARM (P256VERIFY)");
     return EVMONE_ACCESS_WARM;
   }
 
@@ -704,7 +708,7 @@ INTERNAL c4_status_t eth_run_call_evmone_with_events(verify_ctx_t* ctx, evm_call
   set_message(&message, tx, &buffer);
 
   // special handling for precompiles
-  if (bytes_all_zero(bytes(to, 19)) && to[19]) {
+  if (eth_is_precompile_address(to)) {
     buffer_t     output         = {0};
     uint64_t     precompile_gas = 0;
     pre_result_t pre_result     = eth_execute_precompile(to, bytes(message.input_data, message.input_size), &output, &precompile_gas);


### PR DESCRIPTION
## Summary
Follow-up to #258. Two call sites in `call_evmone.c` still used the old single-byte precompile detection (`address[0..18]==0 && address[19]!=0`), which rejects EIP-7951 `P256VERIFY` at `0x0000…0100` (byte 19 is zero). Consequently, any EVM call to `0x100` fell through to regular contract-code execution instead of dispatching to the precompile. Same issue in the EIP-2929 warm-access list.

### Changes
- new helper `eth_is_precompile_address()` that mirrors `eth_execute_precompile()` dispatch ranges (classic 1-byte slots plus `0x0000…0100`).
- both precompile-dispatch sites in `call_evmone.c` go through the helper.
- additive extension of the EIP-2929 warm-access precompile list with `0x0000…0100` per EIP-7951.

### Tests
Full `ctest` run (40/40 pass) on `build/default`; existing `test_eth_precompiles` still green.
