### PR TITLE
feat(server): expose Compute-Units HTTP header for upstream billing

### DIFF
--- a/.github/workflows/bindings-python.yml
+++ b/.github/workflows/bindings-python.yml
@@ -175,7 +175,10 @@ jobs:
           
           cd ..\..
           echo Configuring CMake...
-          cmake -S . -B build -DC4_PYTHON=ON -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 17 2022"
+          REM Let CMake pick the installed Visual Studio generator automatically.
+          REM Hard-coding "Visual Studio 17 2022" breaks whenever the windows-latest
+          REM image moves to a newer Visual Studio (e.g. VS 2026 / "Visual Studio 18 2026").
+          cmake -S . -B build -DC4_PYTHON=ON -DCMAKE_BUILD_TYPE=Release
           if %errorlevel% neq 0 (
             echo CMake configuration failed with error %errorlevel%
             echo Current directory: %cd%

--- a/src/prover/prover.h
+++ b/src/prover/prover.h
@@ -133,7 +133,8 @@ typedef struct {
 #ifdef HTTP_SERVER
   uint32_t client_type; // client type for the prover (for beacon API only)
 #endif
-  uint32_t version; // the version of the requesting client
+  uint32_t version;       // the version of the requesting client
+  uint64_t compute_units; // accumulated compute units for this request. Filled by prover implementations and consumed by the server to emit the `Compute-Units` HTTP response header (used by an upstream load balancer for API-key billing).
 
 #ifdef PROVER_TRACE
   // Collected finished spans (consumed by server); and currently open span

--- a/src/server/handle_proof.c
+++ b/src/server/handle_proof.c
@@ -262,9 +262,8 @@ static void respond(request_t* req, bytes_t result, int status, char* content_ty
   }
   else {
     char hdr[64];
-    int  hdr_len = snprintf(hdr, sizeof(hdr), "Compute-Units: %" PRIu64 "\r\n", compute_units);
-    c4_http_respond_ex(req->client, status, content_type, result,
-                       hdr_len > 0 ? bytes((uint8_t*) hdr, (uint32_t) hdr_len) : NULL_BYTES);
+    sbprintf(hdr, "Compute-Units: %l\r\n", compute_units);
+    c4_http_respond_ex(req->client, status, content_type, result, bytes((uint8_t*) hdr, (uint32_t) strlen(hdr)));
   }
 }
 

--- a/src/server/handle_proof.c
+++ b/src/server/handle_proof.c
@@ -228,8 +228,12 @@ static void c4_tracing_flush_prover_spans(trace_span_t* parent, prover_ctx_t* ct
  * Sends the prover response to the client or to a parent callback.
  *
  * Two modes:
- * 1. DIRECT (parent_cb == NULL): Sends HTTP response directly to client
- * 2. CALLBACK (parent_cb != NULL): Calls parent_cb with result
+ * 1. DIRECT (parent_cb == NULL): Sends HTTP response directly to client, including
+ *    a `Compute-Units` header so an upstream load balancer can forward the value
+ *    to API-key based billing without the server itself knowing about API keys.
+ * 2. CALLBACK (parent_cb != NULL): Calls parent_cb with result. `compute_units` is
+ *    intentionally not propagated to the parent because internal verifier sub-requests
+ *    are not subject to billing.
  *
  * When in callback mode:
  * - Used when the prover is called as a sub-request from the verifier
@@ -241,8 +245,9 @@ static void c4_tracing_flush_prover_spans(trace_span_t* parent, prover_ctx_t* ct
  * @param result Result bytes (proof or error message)
  * @param status HTTP status code
  * @param content_type Content-Type for direct HTTP response
+ * @param compute_units accumulated compute units for billing; emitted as `Compute-Units` header in DIRECT mode
  */
-static void respond(request_t* req, bytes_t result, int status, char* content_type) {
+static void respond(request_t* req, bytes_t result, int status, char* content_type, uint64_t compute_units) {
   if (req->parent_cb && req->parent_ctx) {
     // CALLBACK MODE: Call parent_cb instead of responding directly
     data_request_t* data = (data_request_t*) safe_calloc(1, sizeof(data_request_t));
@@ -255,8 +260,12 @@ static void respond(request_t* req, bytes_t result, int status, char* content_ty
     }
     req->parent_cb(req->client, req->parent_ctx, data);
   }
-  else
-    c4_http_respond(req->client, status, content_type, result);
+  else {
+    char hdr[64];
+    int  hdr_len = snprintf(hdr, sizeof(hdr), "Compute-Units: %" PRIu64 "\r\n", compute_units);
+    c4_http_respond_ex(req->client, status, content_type, result,
+                       hdr_len > 0 ? bytes((uint8_t*) hdr, (uint32_t) hdr_len) : NULL_BYTES);
+  }
 }
 
 // --- executed in worker-thread ---
@@ -435,7 +444,7 @@ void c4_prover_handle_request(request_t* req) {
       log_info(MAGENTA("::[ OK ]") "%s " GRAY(" (%d bytes in %l ms) :: #%lx"),
                c4_req_info(C4_DATA_TYPE_INTERN, req_path, req_payload),
                ctx->proof.len, (uint64_t) (current_ms() - req->start_time), client_ptr);
-      respond(req, ctx->proof, 200, "application/octet-stream");
+      respond(req, ctx->proof, 200, "application/octet-stream", ctx->compute_units);
       prover_request_free(req);
       return;
 
@@ -447,7 +456,7 @@ void c4_prover_handle_request(request_t* req) {
 
       buffer_t buf = {0};
       bprintf(&buf, "{\"error\":\"%s\"}", ctx->state.error);
-      respond(req, buf.data, 500, "application/json");
+      respond(req, buf.data, 500, "application/json", ctx->compute_units);
       buffer_free(&buf);
       prover_request_free(req);
       return;
@@ -461,7 +470,7 @@ void c4_prover_handle_request(request_t* req) {
       else {
         // stop here, we don't have anything to do
         char* error = "{\"error\":\"Internal prover error: no prover available\"}";
-        respond(req, bytes((uint8_t*) error, strlen(error)), 500, "application/json");
+        respond(req, bytes((uint8_t*) error, strlen(error)), 500, "application/json", ctx->compute_units);
         if (req->trace_root) {
           tracing_span_tag_str(req->trace_root, "status", "error");
           tracing_span_tag_str(req->trace_root, "error", "Internal prover error: no prover available");

--- a/src/server/http_server.c
+++ b/src/server/http_server.c
@@ -551,6 +551,10 @@ void c4_write_error_response(client_t* client, int status, const char* error) {
 }
 
 void c4_http_respond(client_t* client, int status, char* content_type, bytes_t body) {
+  c4_http_respond_ex(client, status, content_type, body, NULL_BYTES);
+}
+
+void c4_http_respond_ex(client_t* client, int status, char* content_type, bytes_t body, bytes_t extra_headers) {
   // Only decrement if on_message_complete was reached for this request cycle
   if (client && client->message_complete_reached) {
     http_server.stats.open_requests--;
@@ -579,16 +583,25 @@ void c4_http_respond(client_t* client, int status, char* content_type, bytes_t b
   }
 
   char     tmp[500];
-  uv_buf_t uvbuf[2]; // Declared to be filled
+  uv_buf_t uvbuf[4]; // [0]=status+fixed headers, [1]=extra headers, [2]=header block terminator, [3]=body
 
   const char* conn_header_val = llhttp_should_keep_alive(&client->parser) ? "keep-alive" : "close";
 
+  // Status line plus fixed headers, ending with the CRLF that terminates the "Connection:" header line.
   uvbuf[0].base = tmp;
-  uvbuf[0].len  = snprintf(tmp, sizeof(tmp), "HTTP/1.1 %d %s\r\nContent-Type: %s\r\nContent-Length: %d\r\nConnection: %s\r\n\r\n",
+  uvbuf[0].len  = snprintf(tmp, sizeof(tmp), "HTTP/1.1 %d %s\r\nContent-Type: %s\r\nContent-Length: %d\r\nConnection: %s\r\n",
                            status, status_text(status), content_type, body.len, conn_header_val);
 
-  uvbuf[1].base = (char*) body.data;
-  uvbuf[1].len  = body.len;
+  // Caller-provided headers are emitted verbatim. Each line must already be CRLF-terminated.
+  uvbuf[1].base = (char*) (extra_headers.data ? extra_headers.data : (uint8_t*) "");
+  uvbuf[1].len  = extra_headers.len;
+
+  // Empty line that ends the HTTP header block.
+  uvbuf[2].base = "\r\n";
+  uvbuf[2].len  = 2;
+
+  uvbuf[3].base = (char*) body.data;
+  uvbuf[3].len  = body.len;
 
   // Set client->being_closed based on the connection header *before* the write attempt.
   // This informs on_write_complete whether to close or reset for keep-alive.
@@ -602,7 +615,7 @@ void c4_http_respond(client_t* client, int status, char* content_type, bytes_t b
   uv_write_t* write_req = &client->write_req;
   write_req->data       = client; // Ensure client is associated with write_req for on_write_complete
 
-  int result = uv_write(write_req, (uv_stream_t*) &client->handle, uvbuf, 2, on_write_complete);
+  int result = uv_write(write_req, (uv_stream_t*) &client->handle, uvbuf, 4, on_write_complete);
 
   if (result < 0) {
     log_error("Failed to write HTTP response for client 0x%lx: %s",

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -323,6 +323,28 @@ void c4_init_curl(uv_timer_t* timer);
 void c4_cleanup_curl();
 void c4_on_new_connection(uv_stream_t* server, int status);
 void c4_http_respond(client_t* client, int status, char* content_type, bytes_t body);
+/**
+ * Like `c4_http_respond`, but allows the caller to inject additional response headers.
+ *
+ * The extra header buffer is forwarded as-is. Each header line MUST already be terminated
+ * with `\r\n`; the function appends the empty line that terminates the header block.
+ * Pass `NULL_BYTES` (or `{0}`) to omit extra headers -- in that case the output is byte-identical to `c4_http_respond`.
+ *
+ * Example:
+ *
+ * ```c
+ * char hdr[64];
+ * int  n = snprintf(hdr, sizeof(hdr), "Compute-Units: %llu\r\n", (unsigned long long) units);
+ * c4_http_respond_ex(client, 200, "application/octet-stream", body, bytes((uint8_t*) hdr, (uint32_t) n));
+ * ```
+ *
+ * @param client       the client to respond to
+ * @param status       HTTP status code
+ * @param content_type Content-Type header value
+ * @param body         response body
+ * @param extra_headers additional CRLF-terminated header lines, or `NULL_BYTES` for none
+ */
+void c4_http_respond_ex(client_t* client, int status, char* content_type, bytes_t body, bytes_t extra_headers);
 void c4_write_error_response(client_t* client, int status, const char* error);
 void c4_http_server_on_close_callback(uv_handle_t* handle); // Cleanup callback for closing client connections
 void c4_register_http_handler(http_handler handler);


### PR DESCRIPTION
## Summary

The Colibri server should remain free of API-key/billing logic. Instead this PR exposes the data that an upstream load balancer needs in order to bill API-key holders for the cost of a `/proof` request: the **Compute-Units**. The load balancer can then forward `Compute-Units` (together with the API key extracted from the request) to the API-key management system.

This PR only adds the plumbing -- the actual per-method compute-unit calculation lands in a follow-up.

### Changes

- **`prover_ctx_t`** (`src/prover/prover.h`): new `uint64_t compute_units` field. Zero-initialized via `safe_calloc`, to be populated by chain-specific prover implementations in a follow-up PR.
- **`c4_http_respond_ex`** (`src/server/http_server.c` / `src/server/server.h`): new variant of `c4_http_respond` that accepts an additional CRLF-terminated header buffer (`bytes_t`). Implemented via a **4-slot `uv_buf_t` vector write** (`status+fixed headers | extra headers | CRLF | body`), so arbitrary extra headers cannot overflow the existing 500-byte status-line buffer.
  - `c4_http_respond` is now a thin wrapper passing `NULL_BYTES` -- output is byte-identical to before for all other handlers (`/health`, `/verify`, `/rpc`, `/metrics`, `/openapi.yaml`, ...).
- **`handle_proof.c`**: `respond()` now takes `compute_units` and emits `Compute-Units: <n>\r\n`. All three call sites (success / error / internal-error) updated. The **CALLBACK mode** used by verifier sub-requests intentionally does *not* forward the value -- internal calls are not subject to billing.

### Architecture

```
Client --POST /proof--> Load Balancer --forward--> Colibri Server
                              |                          |
                              |  <-- 200 OK + Compute-Units: N --
                              |
                              v
                       API-Key Mgmt   (units=N, key=X-API-Key)
```

## Test plan

- [x] `cmake --build build/default` -- clean build.
- [x] `ctest --test-dir build/default` -- 40/40 pass, including `test_server` which exercises the HTTP response path.
- [ ] Manual smoke test: `curl -i -X POST -d '{"method":"eth_chainId","params":[]}' http://localhost:8080/proof | head` -- verify `Compute-Units: 0` appears in the header block.

## Out of scope (follow-up)

- Concrete computation of `compute_units` per chain/method (eth/op).
- Forwarding `compute_units` to `parent_ctx`/`data_request_t` for verifier sub-requests (not relevant for the API-key billing use case).