### PR TITLE
feat(prover): compute the actual Compute-Units value

### DIFF
--- a/src/chains/eth/prover/beacon.c
+++ b/src/chains/eth/prover/beacon.c
@@ -23,6 +23,7 @@
 
 #include "beacon.h"
 #include "beacon_types.h"
+#include "eth_compute_units.h"
 #include "eth_req.h"
 #include "json.h"
 #include "logger.h"
@@ -551,6 +552,7 @@ c4_status_t c4_send_beacon_json_with_client_type(prover_ctx_t* ctx, char* path, 
 #ifdef HTTP_SERVER
   client_type |= ctx->client_type;
 #endif
+  eth_cu_add(ctx, CU_BEACON_JSON);
   bytes32_t id     = {0};
   buffer_t  buffer = {0};
   buffer_add_chars(&buffer, path);
@@ -636,7 +638,7 @@ c4_status_t c4_send_beacon_ssz_with_client_type(prover_ctx_t* ctx, char* path, c
 #ifdef HTTP_SERVER
   client_type |= ctx->client_type;
 #endif
-
+  eth_cu_add(ctx, CU_BEACON_SSZ);
   bytes32_t id     = {0};
   buffer_t  buffer = {0};
   buffer_add_chars(&buffer, path);
@@ -678,6 +680,7 @@ c4_status_t c4_send_beacon_ssz_with_client_type(prover_ctx_t* ctx, char* path, c
 }
 
 c4_status_t c4_send_internal_request(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, bytes_t* result) {
+  eth_cu_add(ctx, CU_INTERNAL_REQUEST);
   bytes32_t id     = {0};
   buffer_t  buffer = {0};
   buffer_add_chars(&buffer, path);

--- a/src/chains/eth/prover/eth_compute_units.h
+++ b/src/chains/eth/prover/eth_compute_units.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2025 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef ETH_COMPUTE_UNITS_H
+#define ETH_COMPUTE_UNITS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "prover.h"
+#include <stdint.h>
+#include <string.h>
+
+// :: Compute Units
+//
+// Constants and helpers used to accumulate `prover_ctx_t.compute_units` while a
+// proof is being built. The accumulated value is later returned to the caller
+// as the `Compute-Units` HTTP response header (see `src/server/handle_proof.c`)
+// and is intended to be consumed by an upstream load balancer for API-key based
+// billing.
+//
+// The scale is intentionally small/discrete (Alchemy-style): a typical
+// `eth_blockNumber` ends up around 25 CU, an `eth_call` around 500-2000 CU,
+// while a cache-hit internal sub-request only costs 1 CU. The numbers below are
+// a defensible starting point; fine-tuning per chain/method is expected to
+// happen later by adjusting only this header.
+//
+// Counting strategy:
+//
+// - `c4_prover_execute` resets `ctx->compute_units` to 0 at the start of each
+//   pass. Because the prover may run multiple passes (one per `C4_PENDING`
+//   round-trip), only the final pass -- where every sub-request is a cache hit
+//   and the actual proof bytes are produced -- contributes to the published
+//   value. This avoids double-counting work that is repeated across passes.
+// - Hybrid mode is *not* explicitly excluded. RPC sub-requests, Beacon-API
+//   fetches, internal requests and the Patricia-trie work performed by
+//   `c4_eth_get_receipt_proof` are still billed when running in hybrid mode --
+//   the server actually performed that work. What hybrid skips is the SSZ
+//   Merkle-proof construction (`ssz_create_*proof*` call sites guarded by
+//   `C4_PROVER_FLAG_HYBRID`), which keeps the published value lower than for
+//   the equivalent non-hybrid request without requiring extra branches here.
+
+// ::: Sub-request costs (network + provider billing surrogate)
+
+#define CU_INTERNAL_REQUEST   1  // c4_send_internal_request (period_store, internal sub-prover)
+#define CU_BEACON_JSON        5  // c4_send_beacon_json (small JSON GET, e.g. header lookup)
+#define CU_BEACON_SSZ        15  // c4_send_beacon_ssz (full SignedBeaconBlock or LCU)
+
+#define CU_RPC_DEFAULT       10  // eth_getBlockBy*, eth_getTransactionBy*, eth_chainId, web3_sha3, ...
+#define CU_RPC_GET_CODE      15  // eth_getCode
+#define CU_RPC_RECEIPT       15  // eth_getTransactionReceipt
+#define CU_RPC_GET_PROOF     50  // eth_getProof (incl. storage keys)
+#define CU_RPC_BLOCK_RECEIPTS 50 // eth_getBlockReceipts
+#define CU_RPC_LOGS          75  // eth_getLogs
+#define CU_RPC_ACCESS_LIST  150  // eth_createAccessList
+#define CU_RPC_TRACE_CALL   300  // debug_traceCall (most expensive provider call)
+
+// ::: SSZ / Merkle proof costs (server CPU)
+
+#define CU_SSZ_PROOF              3  // ssz_create_proof (single gindex)
+#define CU_SSZ_MULTI_PROOF_BASE   2  // ssz_create_multi_proof base cost
+#define CU_SSZ_MULTI_PROOF_LEAF   1  // per extra gindex in a multi-proof
+
+// ::: Patricia / receipt-trie costs (server CPU)
+
+#define CU_PATRICIA_INSERT        1  // per element inserted into the receipts/tx trie
+#define CU_PATRICIA_PROOF         5  // generation of one Patricia-Merkle proof
+
+// ::: Historic-proof costs (server CPU on top of the sub-requests they trigger)
+
+#define CU_HISTORIC_HEADER_HOP    5  // per step of the header-chain proof (depth bounded)
+#define CU_HISTORIC_DIRECT       40  // historical_summaries + period_store proof construction
+#define CU_ZK_PROOF_INCLUDE      80  // ZK-proof data attached to the sync section
+
+// ::: Helpers
+
+/**
+ * Map an eth-RPC method name to its compute-unit cost class.
+ *
+ * Heavy provider-side calls (`debug_traceCall`, `eth_createAccessList`) cost the
+ * most; bulk-data calls (`eth_getProof`, `eth_getBlockReceipts`, `eth_getLogs`)
+ * are next; everything else falls into the default light tier.
+ *
+ * @param method JSON-RPC method name; NULL is treated as default.
+ * @return cost class in compute units
+ */
+static inline uint32_t cu_for_eth_rpc_method(const char* method) {
+  if (!method) return CU_RPC_DEFAULT;
+  if (strcmp(method, "eth_getProof") == 0) return CU_RPC_GET_PROOF;
+  if (strcmp(method, "eth_getCode") == 0) return CU_RPC_GET_CODE;
+  if (strcmp(method, "debug_traceCall") == 0) return CU_RPC_TRACE_CALL;
+  if (strcmp(method, "eth_createAccessList") == 0) return CU_RPC_ACCESS_LIST;
+  if (strcmp(method, "eth_getBlockReceipts") == 0) return CU_RPC_BLOCK_RECEIPTS;
+  if (strcmp(method, "eth_getLogs") == 0) return CU_RPC_LOGS;
+  if (strcmp(method, "eth_getTransactionReceipt") == 0) return CU_RPC_RECEIPT;
+  return CU_RPC_DEFAULT;
+}
+
+/**
+ * Add a raw number of compute units to the prover context.
+ *
+ * Prefer one of the more specific helpers (`eth_cu_add_proof`,
+ * `eth_cu_add_multi_proof`, `eth_cu_add_patricia`) when applicable so the
+ * cost model stays in one place. No-op if `ctx` is NULL.
+ */
+static inline void eth_cu_add(prover_ctx_t* ctx, uint32_t cu) {
+  if (ctx) ctx->compute_units += cu;
+}
+
+/** Account for a single-leaf SSZ Merkle proof (`ssz_create_proof`). */
+static inline void eth_cu_add_proof(prover_ctx_t* ctx) {
+  if (ctx) ctx->compute_units += CU_SSZ_PROOF;
+}
+
+/**
+ * Account for an SSZ multi-proof with `gindex_count` leaves
+ * (`ssz_create_multi_proof*` family).
+ */
+static inline void eth_cu_add_multi_proof(prover_ctx_t* ctx, uint32_t gindex_count) {
+  if (ctx) ctx->compute_units += CU_SSZ_MULTI_PROOF_BASE + gindex_count * CU_SSZ_MULTI_PROOF_LEAF;
+}
+
+/**
+ * Account for building a Patricia-Merkle proof over a trie of `n_inserts`
+ * elements with `n_proofs` Merkle proofs extracted from it: linear cost for
+ * filling the trie plus a per-proof cost.
+ */
+static inline void eth_cu_add_patricia(prover_ctx_t* ctx, uint32_t n_inserts, uint32_t n_proofs) {
+  if (ctx) ctx->compute_units += n_inserts * CU_PATRICIA_INSERT + n_proofs * CU_PATRICIA_PROOF;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ETH_COMPUTE_UNITS_H */

--- a/src/chains/eth/prover/eth_req.c
+++ b/src/chains/eth/prover/eth_req.c
@@ -24,6 +24,7 @@
 #include "eth_req.h"
 #include "beacon.h"
 #include "beacon_types.h"
+#include "eth_compute_units.h"
 #include "json.h"
 #include "logger.h"
 #include "rlp.h"
@@ -226,6 +227,10 @@ bytes_t c4_serialize_receipt(json_t r, buffer_t* buf) {
 
 // sends a request to the eth rpc and returns the result or returns with status C4_PENDING
 c4_status_t c4_send_eth_rpc(prover_ctx_t* ctx, char* method, char* params, uint32_t ttl, json_t* result, data_request_t** req) {
+  // Account for compute units. Counted on every call (cache-hit or not) so that
+  // the value reported by `eth_prover_execute` reflects the work the server had
+  // to coordinate for this request, regardless of caching state.
+  eth_cu_add(ctx, cu_for_eth_rpc_method(method));
   bytes32_t id     = {0};
   buffer_t  buffer = {0};
   bprintf(&buffer, "{\"jsonrpc\":\"2.0\",\"method\":\"%s\",\"params\":%s,\"id\":1}", method, params);

--- a/src/chains/eth/prover/eth_tools.c
+++ b/src/chains/eth/prover/eth_tools.c
@@ -26,6 +26,7 @@
 #include "beacon_types.h"
 #include "bytes.h"
 #include "eth_account.h"
+#include "eth_compute_units.h"
 #include "eth_tx.h"
 #include "prover.h"
 #include "version.h"
@@ -99,6 +100,7 @@ ssz_builder_t eth_ssz_create_state_proof(prover_ctx_t* ctx, json_t block_number,
 
   if (use_block_context) {
     const gindex_t* gi = c4_call_block_context_gindexes();
+    eth_cu_add_multi_proof(ctx, CALL_BLOCK_CONTEXT_FIELD_COUNT);
 #ifdef PROVER_CACHE
     if (block->merkle_cache.valid)
       proof = ssz_create_multi_proof_from_body_cache(&block->merkle_cache, body_root, gi, CALL_BLOCK_CONTEXT_FIELD_COUNT);
@@ -111,6 +113,10 @@ ssz_builder_t eth_ssz_create_state_proof(prover_ctx_t* ctx, json_t block_number,
   else {
     gindex_t block_index = eth_get_gindex_for_block(c4_chain_fork_id(ctx->chain_id, block->slot >> 5), block_number);
     gindex_t state_index = ssz_gindex(block->body.def, 2, "executionPayload", "stateRoot");
+    if (block_index == 0)
+      eth_cu_add_proof(ctx);
+    else
+      eth_cu_add_multi_proof(ctx, 2);
 #ifdef PROVER_CACHE
     if (block->merkle_cache.valid) {
       gindex_t gi_arr[2] = {state_index, block_index};

--- a/src/chains/eth/prover/historic_proof.c
+++ b/src/chains/eth/prover/historic_proof.c
@@ -25,6 +25,7 @@
 #include "../server/eth_clients.h"
 #include "beacon.h"
 #include "beacon_types.h"
+#include "eth_compute_units.h"
 #include "eth_req.h"
 #include "eth_tools.h"
 #include "json.h"
@@ -101,6 +102,7 @@ static c4_status_t check_historic_proof_header(prover_ctx_t* ctx, blockroot_proo
     buffer_add_le(&proof, json_get_uint64(header, "proposer_index"), 8);
     buffer_append(&proof, json_get_bytes(header, "state_root", &header_buf));
     buffer_append(&proof, json_get_bytes(header, "body_root", &header_buf));
+    eth_cu_add(ctx, CU_HISTORIC_HEADER_HOP); // each successful hop in the header chain
   }
 
   block_proof->sync_aggregate = src_block->sync_aggregate;
@@ -172,6 +174,11 @@ static c4_status_t check_historic_proof_direct(prover_ctx_t* ctx, blockroot_proo
   if (!state_period) return C4_SUCCESS;                                                        // the client does not have a state yet, so he might as well get the head and verify the block.
   if (block_period >= state_period) return C4_SUCCESS;                                         // the target block is within the current range of the client
 
+  // Historic-direct path: the actual sub-requests below are billed via their
+  // respective helpers; this constant covers the server-side composition work
+  // (summary list build, gindex math, proof concatenation, hash_tree_root).
+  eth_cu_add(ctx, CU_HISTORIC_DIRECT);
+
   TRY_ASYNC(c4_beacon_get_block_for_eth(ctx, json_parse("\"latest\""), &block)); // we get the latest because we know for latest we get the a proof for the state. Older sztates are not stored
   TRY_ADD_ASYNC(status, get_historical_summaries(ctx, &block, &history_proof));
   TRY_ADD_ASYNC(status, c4_send_internal_request(ctx, bprintf(&buf2, "period_store/%d/blocks.ssz", block_period), NULL, 0, &blocks)); // get the blockd
@@ -198,10 +205,11 @@ static c4_status_t check_historic_proof_direct(prover_ctx_t* ctx, blockroot_proo
     buffer_append(&list_data, json_get_bytes(entry, "state_summary_root", &buf));
   }
 
-  // create the proofs
-  ssz_ob_t summaries_ob           = {.bytes = list_data.data, .def = &SUMMARIES};
-  bytes_t  block_idx_proof        = ssz_create_proof(blocks_ob, blocks_root, block_gidx);
-  bytes_t  period_idx_proof       = ssz_create_proof(summaries_ob, root, period_gidx);
+  // create the proofs (two genuinely separate single-leaf proofs)
+  ssz_ob_t summaries_ob = {.bytes = list_data.data, .def = &SUMMARIES};
+  eth_cu_add(ctx, 2 * CU_SSZ_PROOF);
+  bytes_t block_idx_proof  = ssz_create_proof(blocks_ob, blocks_root, block_gidx);
+  bytes_t period_idx_proof = ssz_create_proof(summaries_ob, root, period_gidx);
   bytes_t  block_root_expected    = ssz_at(blocks_ob, block_idx).bytes;
   ssz_ob_t summary_ob             = ssz_at(summaries_ob, summary_idx);
   bytes_t  blocks_root_in_summary = ssz_get(&summary_ob, "block_summary_root").bytes;
@@ -336,6 +344,7 @@ c4_status_t c4_get_syncdata_proof(prover_ctx_t* ctx, syncdata_state_t* sync_data
     // we need a zk_proof (if available) for the required period.
     builder->def             = C4_ETH_REQUEST_SYNCDATA_UNION + 2; // TODO find a way to better handle this in the future, so updates on ssz will not break the build.
     zk_proof_data_t zk_proof = {0};
+    eth_cu_add(ctx, CU_ZK_PROOF_INCLUDE); // ZK proof attached to the sync section
     TRY_ASYNC(c4_fetch_zk_proof_data(ctx, &zk_proof, sync_data->required_period));
     ssz_add_bytes(builder, "vk_hash", ssz_get(&zk_proof.sync_proof, "vk_hash").bytes);
     ssz_add_bytes(builder, "proof", ssz_get(&zk_proof.sync_proof, "proof").bytes);

--- a/src/chains/eth/prover/proof_block.c
+++ b/src/chains/eth/prover/proof_block.c
@@ -23,6 +23,7 @@
 
 #include "beacon.h"
 #include "beacon_types.h"
+#include "eth_compute_units.h"
 #include "eth_req.h"
 #include "eth_tools.h"
 #include "historic_proof.h"
@@ -69,6 +70,7 @@ c4_status_t c4_proof_block(prover_ctx_t* ctx) {
   // create merkle proof
   gindex_t ep_gindex              = ssz_gindex(block.body.def, 1, "executionPayload");
   bytes_t  execution_payload_proof = NULL_BYTES;
+  eth_cu_add_proof(ctx);
 #ifdef PROVER_CACHE
   if (block.merkle_cache.valid)
     execution_payload_proof = ssz_create_multi_proof_from_body_cache(&block.merkle_cache, body_root, &ep_gindex, 1);
@@ -114,6 +116,7 @@ c4_status_t c4_proof_block_number(prover_ctx_t* ctx) {
   gindex_t bn_gi[2] = {ssz_gindex(block.body.def, 2, "executionPayload", "blockNumber"),
                         ssz_gindex(block.body.def, 2, "executionPayload", "timestamp")};
   bytes_t  execution_payload_proof = NULL_BYTES;
+  eth_cu_add_multi_proof(ctx, 2);
 #ifdef PROVER_CACHE
   if (block.merkle_cache.valid)
     execution_payload_proof = ssz_create_multi_proof_from_body_cache(&block.merkle_cache, body_root, bn_gi, 2);
@@ -161,6 +164,7 @@ c4_status_t c4_proof_block_header(prover_ctx_t* ctx) {
   // create multi-merkle proof for 14 selected execution payload fields
   const gindex_t* gi                      = c4_block_header_gindexes(ctx->chain_id, ssz_get_uint64(&block.header, "slot"));
   bytes_t         execution_payload_proof = NULL_BYTES;
+  eth_cu_add_multi_proof(ctx, BLOCK_HEADER_FIELD_COUNT);
 #ifdef PROVER_CACHE
   if (block.merkle_cache.valid)
     execution_payload_proof = ssz_create_multi_proof_from_body_cache(&block.merkle_cache, body_root, gi, BLOCK_HEADER_FIELD_COUNT);

--- a/src/chains/eth/prover/proof_block_receipts.c
+++ b/src/chains/eth/prover/proof_block_receipts.c
@@ -24,6 +24,7 @@
 #include "beacon.h"
 #include "beacon_types.h"
 #include "bytes.h"
+#include "eth_compute_units.h"
 #include "eth_req.h"
 #include "eth_tools.h"
 #include "historic_proof.h"
@@ -121,7 +122,8 @@ c4_status_t c4_proof_block_receipts(prover_ctx_t* ctx) {
                         ssz_gindex(block.body.def, 2, "executionPayload", "receiptsRoot"),
                         ssz_gindex(block.body.def, 2, "executionPayload", "transactions"),
                         ssz_gindex(block.body.def, 2, "executionPayload", "baseFeePerGas")};
-  bytes_t  multi_proof = NULL_BYTES;
+  bytes_t multi_proof = NULL_BYTES;
+  eth_cu_add_multi_proof(ctx, 5);
 #ifdef PROVER_CACHE
   if (block.merkle_cache.valid)
     multi_proof = ssz_create_multi_proof_from_body_cache(&block.merkle_cache, body_root, br_gi, 5);

--- a/src/chains/eth/prover/proof_logs.c
+++ b/src/chains/eth/prover/proof_logs.c
@@ -23,6 +23,7 @@
 
 #include "beacon.h"
 #include "beacon_types.h"
+#include "eth_compute_units.h"
 #include "eth_req.h"
 #include "eth_tools.h"
 #include "historic_proof.h"
@@ -170,6 +171,7 @@ static c4_status_t proof_create_multiproof(prover_ctx_t* ctx, proof_logs_block_t
   for (proof_logs_tx_t* tx = block->txs; tx; tx = tx->next, i++)
     gindex[i + 3] = ssz_gindex(block->beacon_block.body.def, 3, "executionPayload", "transactions", tx->tx_index);
 
+  eth_cu_add_multi_proof(ctx, 3 + block->tx_count);
   block->proof = ssz_create_multi_proof_for_gindexes(block->beacon_block.body, block->body_root, gindex, 3 + block->tx_count);
   safe_free(gindex);
 
@@ -188,6 +190,10 @@ static c4_status_t proof_block(prover_ctx_t* ctx, proof_logs_block_t* block) {
 
   TRACE_START(ctx, "build_receipt_tree");
   TRACE_ADD_UINT64(ctx, "block", block->block_number);
+
+  // Patricia trie work for this block: linear cost per receipt inserted into
+  // the trie, plus one proof per matching tx.
+  eth_cu_add_patricia(ctx, (uint32_t) json_len(block->block_receipts), block->tx_count);
 
 #ifdef PROVER_CACHE
   bytes32_t cachekey;

--- a/src/chains/eth/prover/proof_receipt.c
+++ b/src/chains/eth/prover/proof_receipt.c
@@ -23,6 +23,7 @@
 
 #include "beacon.h"
 #include "beacon_types.h"
+#include "eth_compute_units.h"
 #include "eth_req.h"
 #include "eth_tools.h"
 #include "historic_proof.h"
@@ -98,6 +99,12 @@ static ssz_ob_t create_receipts_proof(json_t block_receipts, uint32_t tx_index, 
 }
 
 c4_status_t c4_eth_get_receipt_proof(prover_ctx_t* ctx, bytes32_t block_hash, json_t block_receipts, uint32_t tx_index, json_t* receipt, ssz_ob_t* receipt_proof) {
+
+  // Account for Patricia trie work: one insertion per receipt plus one proof.
+  // When the trie is served from the prover cache the linear part is essentially
+  // a no-op, but we still bill it because the original work that filled the
+  // cache was performed by this server -- this keeps the formula simple.
+  eth_cu_add_patricia(ctx, (uint32_t) json_len(block_receipts), 1);
 
   // now we should have all data required to create the proof
 #ifdef PROVER_CACHE
@@ -220,6 +227,7 @@ c4_status_t c4_proof_receipt(prover_ctx_t* ctx) {
 
   REQUEST_WORKER_THREAD_CATCH(ctx, c4_free_block_proof(&block_proof));
   TRACE_START(ctx, "multiproof");
+  eth_cu_add_multi_proof(ctx, 4);
   bytes_t state_proof = ssz_create_multi_proof(block.body, body_root, 4,
                                                ssz_gindex(block.body.def, 2, "executionPayload", "blockNumber"),
                                                ssz_gindex(block.body.def, 2, "executionPayload", "blockHash"),

--- a/src/chains/eth/prover/proof_sync.c
+++ b/src/chains/eth/prover/proof_sync.c
@@ -22,6 +22,7 @@
  */
 
 #include "beacon_types.h"
+#include "eth_compute_units.h"
 #include "eth_tools.h"
 #include "eth_verify.h"
 #include "prover.h"
@@ -39,6 +40,10 @@ static uint64_t next_sync_committee_gindex(chain_id_t chain_id, uint64_t slot) {
 }
 
 static c4_status_t req_client_update(prover_ctx_t* ctx, uint32_t period, uint32_t count, chain_id_t chain_id, bytes_t* data) {
+  // This helper enqueues a Beacon-API SSZ request directly on `ctx->state`
+  // instead of going through `c4_send_beacon_ssz`, so we have to add the CU
+  // ourselves to keep accounting consistent with the rest of the code.
+  eth_cu_add(ctx, CU_BEACON_SSZ);
   buffer_t tmp = {0};
   bprintf(&tmp, "eth/v1/beacon/light_client/updates?start_period=%d&count=%d", period, count);
 
@@ -125,8 +130,9 @@ static c4_status_t extract_sync_data(prover_ctx_t* ctx, bytes_t old_data, bytes_
   ssz_add_bytes(&signgin_data_builder, "BeaconBlockHeader", header.bytes);
   ssz_add_bytes(&signgin_data_builder, "domain", bytes(domain, 32));
   ssz_ob_t signing_data = ssz_builder_to_bytes(&signgin_data_builder);
-  gindex_t state_gidx   = ssz_gindex(signing_data.def, 2, "BeaconBlockHeader", "stateRoot");
-  bytes_t  header_proof = ssz_create_proof(signing_data, domain, state_gidx);
+  gindex_t state_gidx = ssz_gindex(signing_data.def, 2, "BeaconBlockHeader", "stateRoot");
+  eth_cu_add_proof(ctx);
+  bytes_t header_proof = ssz_create_proof(signing_data, domain, state_gidx);
   bytes_t  full_proof   = bytes(malloc(header_proof.len + state_proof.len + 32), header_proof.len + state_proof.len + 32);
   memcpy(full_proof.data, aggregate, 32);                                              // 1
   memcpy(full_proof.data + 32, state_proof.data, state_proof.len);                     // 5 for deneb

--- a/src/chains/eth/prover/proof_transaction.c
+++ b/src/chains/eth/prover/proof_transaction.c
@@ -23,6 +23,7 @@
 
 #include "beacon.h"
 #include "beacon_types.h"
+#include "eth_compute_units.h"
 #include "eth_req.h"
 #include "eth_tools.h"
 #include "historic_proof.h"
@@ -154,6 +155,7 @@ c4_status_t c4_proof_transaction(prover_ctx_t* ctx) {
 
   TRACE_START(ctx, "proof_data");
 
+  eth_cu_add_multi_proof(ctx, 4);
   bytes_t state_proof = ssz_create_multi_proof(block.body, body_root, 4,
                                                ssz_gindex(block.body.def, 2, "executionPayload", "blockNumber"),
                                                ssz_gindex(block.body.def, 2, "executionPayload", "blockHash"),

--- a/src/prover/prover.c
+++ b/src/prover/prover.c
@@ -432,6 +432,13 @@ c4_status_t c4_prover_execute(prover_ctx_t* ctx) {
   if (ctx->state.error) return C4_ERROR;
   if (ctx->proof.data) return C4_SUCCESS;
 
+  // Reset compute units before each pass so that only the work performed in
+  // the final, successful pass contributes to the value reported as the
+  // `Compute-Units` HTTP response header. This rule is a property of the
+  // prover state machine and must hold for every chain implementation; doing
+  // it here means individual chain modules don't have to remember to reset.
+  ctx->compute_units = 0;
+
   // execute the prover. The return value does not matter, we always check the state again after execution.
   prover_execute(ctx);
 


### PR DESCRIPTION
## Summary

Phase 2 of the API-key-billing plumbing.
[Phase 1](https://github.com/corpus-core/colibri-stateless/pull/) only plumbed a `uint64_t compute_units` field through `prover_ctx_t` and emitted it as a `Compute-Units` HTTP response header (always 0). This PR fills that field with values that reflect the work the server actually performed for each request, so an upstream load balancer can charge API keys accordingly.

The cost model lives in a single new header (`src/chains/eth/prover/eth_compute_units.h`) and uses an Alchemy-style small/discrete scale (e.g. `eth_blockNumber` ≈ 25 CU, `eth_call` ≈ several hundred CU, internal cache-hit sub-request = 1 CU). All numerical values are intentionally a starting point -- fine-tuning is expected to happen by editing only that header later.

### Where the hooks sit

| Layer | Helper(s) | Constant(s) |
|-------|-----------|-------------|
| Sub-requests | `c4_send_eth_rpc` | `cu_for_eth_rpc_method()` (per-method tier) |
|              | `c4_send_beacon_json/_ssz/_internal_request`, `req_client_update` | `CU_BEACON_JSON / CU_BEACON_SSZ / CU_INTERNAL_REQUEST` |
| Historic   | `check_historic_proof_header` (per hop) | `CU_HISTORIC_HEADER_HOP` |
|            | `check_historic_proof_direct` | `CU_HISTORIC_DIRECT` |
|            | `c4_get_syncdata_proof` (ZK path) | `CU_ZK_PROOF_INCLUDE` |
| SSZ Merkle | every `ssz_create_proof*` call site (proof_block.c, proof_block_receipts.c, proof_logs.c, proof_receipt.c, proof_sync.c, proof_transaction.c, eth_tools.c, historic_proof.c) | `eth_cu_add_proof` / `eth_cu_add_multi_proof` |
| Patricia   | `c4_eth_get_receipt_proof`, `proof_logs.c::proof_block` | `eth_cu_add_patricia(n_inserts, n_proofs)` |

### Reset semantics

The prover may run multiple `C4_PENDING` passes for one request. Only the final pass (where every sub-request is a cache hit and the actual proof bytes are produced) contributes to the published value. This `compute_units = 0` reset is hoisted into `c4_prover_execute`, so it holds for **every** chain implementation, not just ETH.

### Hybrid mode

Hybrid branches are *not* explicitly excluded. RPC sub-requests, Beacon-API fetches, internal requests, and the Patricia-trie work performed by `c4_eth_get_receipt_proof` are still billed in hybrid mode -- the server did do that work. What hybrid skips is the SSZ Merkle-proof construction (the `ssz_create_*proof*` call sites), which keeps the published value naturally lower than the non-hybrid equivalent without requiring extra branches or `if (HYBRID)` guards.

### Code review

Reviewed via the `code-reviewer` subagent. The two Major findings (centralized reset + accurate hybrid documentation) plus the most relevant Minors (include-path convention, missing CU on `req_client_update`, `int` -> `uint32_t` helper signatures, tighter Patricia helper) were all addressed before opening this PR.

## Test plan

- [x] `cmake --build build/default` -- clean build
- [x] `ctest --test-dir build/default` -- 40/40 tests pass
- [ ] Smoke-test against a live server: pick a few methods (`eth_blockNumber`, `eth_getTransactionReceipt`, `eth_getLogs`, `eth_call`) and verify the `Compute-Units` header values land in plausible relative ranges
- [ ] Watch CI