### PR TITLE
feat(op): kona-bridge als eigenständiger Sidecar-Service mit HTTP/SSE

### DIFF
--- a/.github/workflows/bindings-docker.yml
+++ b/.github/workflows/bindings-docker.yml
@@ -114,3 +114,48 @@ jobs:
           # Disable provenance/attestation to avoid GHCR upload issues
           provenance: false
           sbom: false
+
+  docker-kona-bridge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: ${{ inputs.push_image }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/corpus-core/colibri-kona-bridge
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ inputs.ref_type == 'tag' && startsWith(inputs.ref_name, 'v') }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: src/chains/op/kona_bridge
+          file: src/chains/op/kona_bridge/Dockerfile
+          # Multi-platform only for releases, single platform for dev/main/PRs (faster)
+          platforms: ${{ inputs.ref_type == 'tag' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          push: ${{ inputs.push_image }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=kona-bridge
+          cache-to: type=gha,mode=max,scope=kona-bridge
+          # Disable provenance/attestation to avoid GHCR upload issues
+          provenance: false
+          sbom: false

--- a/src/chains/op/kona_bridge/CMakeLists.txt
+++ b/src/chains/op/kona_bridge/CMakeLists.txt
@@ -1,9 +1,14 @@
 # CMakeLists.txt für Kona-P2P Bridge Integration (Statisch)
+#
+# Der empfohlene Weg ist das eigenständige Docker-Image:
+#   docker build -f src/chains/op/kona_bridge/Dockerfile -t kona-preconf-service .
+#
+# Für den integrierten C-FFI-Modus (Legacy): cmake .. -DBUILD_KONA_BRIDGE=ON -DBUILD_KONA_BRIDGE_FFI=ON
 
 cmake_minimum_required(VERSION 3.16)
 
-# Option um Kona-Bridge zu aktivieren/deaktivieren
-option(BUILD_KONA_BRIDGE "Build Kona-P2P bridge for native OP-Stack compatibility" ON)
+# OFF by default: kona-bridge läuft jetzt als eigenständiger Service
+option(BUILD_KONA_BRIDGE "Build Kona-P2P bridge as static C-FFI library (legacy mode)" OFF)
 
 if(NOT BUILD_KONA_BRIDGE)
     message(STATUS "Kona bridge disabled - skipping")
@@ -25,7 +30,7 @@ message(STATUS "Building Kona-P2P bridge with static linking")
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libkona_bridge_built.stamp
     COMMAND ${CMAKE_COMMAND} -E env CARGO_BUILD_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR}/target MACOSX_DEPLOYMENT_TARGET=15.0
-            ${CARGO_EXECUTABLE} build --release --lib
+            ${CARGO_EXECUTABLE} build --release --lib --features ffi
     COMMAND ${CMAKE_COMMAND} -E copy 
             ${CMAKE_CURRENT_BINARY_DIR}/target/release/libkona_bridge.a
             ${CMAKE_BINARY_DIR}/lib/libkona_bridge.a

--- a/src/chains/op/kona_bridge/Cargo.lock
+++ b/src/chains/op/kona_bridge/Cargo.lock
@@ -3273,12 +3273,14 @@ dependencies = [
 
 [[package]]
 name = "kona_bridge"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alloy",
+ "anyhow",
  "axum",
  "clap",
  "discv5",
+ "futures-util",
  "hex",
  "kona-p2p",
  "kona-registry",
@@ -3290,6 +3292,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "zstd",

--- a/src/chains/op/kona_bridge/Cargo.lock
+++ b/src/chains/op/kona_bridge/Cargo.lock
@@ -1735,7 +1735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.100",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2301,7 +2301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls",
+ "rustls 0.23.26",
  "rustls-pki-types",
 ]
 
@@ -2758,16 +2758,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
- "bytes",
+ "futures-util",
+ "http 0.2.12",
  "hyper 0.14.32",
- "native-tls",
+ "rustls 0.21.12",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -3580,7 +3581,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "ring",
- "rustls",
+ "rustls 0.23.26",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
@@ -3650,7 +3651,7 @@ dependencies = [
  "libp2p-identity",
  "rcgen",
  "ring",
- "rustls",
+ "rustls 0.23.26",
  "rustls-webpki 0.101.7",
  "thiserror 2.0.12",
  "x509-parser",
@@ -4612,7 +4613,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.26",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
@@ -4631,7 +4632,7 @@ dependencies = [
  "rand 0.9.1",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.26",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -4823,15 +4824,15 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-tls 0.5.0",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -4839,12 +4840,13 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration 0.5.1",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -4862,7 +4864,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-tls 0.6.0",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -5055,6 +5057,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
@@ -5170,6 +5184,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sec1"
@@ -5868,6 +5892,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6310,6 +6344,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "widestring"

--- a/src/chains/op/kona_bridge/Cargo.toml
+++ b/src/chains/op/kona_bridge/Cargo.toml
@@ -28,7 +28,7 @@ clap = { version = "4.5.4", features = ["derive", "env"] }
 zstd = "0.13"
 tempfile = "3.0"
 hex = "0.4"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 md5 = "0.7"
 anyhow = "1"
 

--- a/src/chains/op/kona_bridge/Cargo.toml
+++ b/src/chains/op/kona_bridge/Cargo.toml
@@ -1,16 +1,11 @@
 [package]
 name = "kona_bridge"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
+# TODO: Dependency migration to alloy 1.x + kona d7d4b5d requires kona-p2p → kona-node-service + kona-disc
+# refactoring of gossip.rs. Tracked separately.
 [dependencies]
-# SECURITY NOTE: alloy v0.15.10 contains alloy-dyn-abi with known DoS vulnerability (GHSA-76c9-3jph-rj3q)
-# However, this is a FALSE POSITIVE for kona_bridge:
-# - The vulnerable function eip712_signing_hash() is never called
-# - TypedData is not used (no EIP-712 signing)
-# - Only alloy::primitives and alloy::signers are used (not alloy-dyn-abi)
-# - Cannot update to newer alloy versions due to kona git dependency compatibility
-# See: .github/SECURITY_ASSESSMENT_alloy-dyn-abi.md for detailed analysis
 alloy = { version = "=0.15.10" }
 kona-p2p = { git = "https://github.com/op-rs/kona", rev = "b079a57fcfbb444d051e859f1e80f445daf5a2c7" }
 kona-registry = { git = "https://github.com/op-rs/kona", rev = "b079a57fcfbb444d051e859f1e80f445daf5a2c7" }
@@ -20,6 +15,8 @@ libp2p = { version = "0.55.0", features = ["macros", "tokio", "tcp", "noise", "g
 discv5 = "0.9.1"
 tokio = { version = "1.44.2", features = ["full"] }
 axum = "0.8.3"
+tokio-stream = { version = "0.1", features = ["sync"] }
+futures-util = "0.3"
 
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
@@ -28,14 +25,21 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.85"
 clap = { version = "4.5.4", features = ["derive", "env"] }
 
-# Additional dependencies for HTTP-first implementation
 zstd = "0.13"
 tempfile = "3.0"
 hex = "0.4"
 reqwest = { version = "0.11", features = ["json"] }
 md5 = "0.7"
+anyhow = "1"
 
+[[bin]]
+name = "kona-preconf-service"
+path = "src/main.rs"
 
 [lib]
 name = "kona_bridge"
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "rlib"]
+
+[features]
+default = []
+ffi = []

--- a/src/chains/op/kona_bridge/Dockerfile
+++ b/src/chains/op/kona_bridge/Dockerfile
@@ -1,0 +1,38 @@
+FROM rust:1.88-slim AS builder
+
+RUN apt-get update && apt-get install -y \
+    pkg-config libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Cache dependencies first
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo "fn main(){}" > src/main.rs && \
+    touch src/lib.rs src/config.rs src/gossip.rs src/http.rs \
+          src/processing.rs src/server.rs src/types.rs src/utils.rs && \
+    cargo build --release --bin kona-preconf-service 2>/dev/null; true
+
+# Build real binary
+COPY src/ src/
+RUN cargo build --release --bin kona-preconf-service
+
+# ---- Runtime image ----
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y \
+    libssl3 ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/release/kona-preconf-service /usr/local/bin/kona-preconf-service
+
+# P2P ports
+EXPOSE 8080
+EXPOSE 9090/udp
+EXPOSE 9091/tcp
+
+ENV OUTPUT_DIR=/data/preconfs
+
+VOLUME ["/data/preconfs"]
+
+CMD ["kona-preconf-service"]

--- a/src/chains/op/kona_bridge/Dockerfile
+++ b/src/chains/op/kona_bridge/Dockerfile
@@ -26,6 +26,14 @@ RUN apt-get update && apt-get install -y \
 
 COPY --from=builder /build/target/release/kona-preconf-service /usr/local/bin/kona-preconf-service
 
+# Add OCI labels for better GHCR integration
+LABEL org.opencontainers.image.title="Colibri Kona Bridge"
+LABEL org.opencontainers.image.description="OP Stack preconfirmation P2P service for Colibri"
+LABEL org.opencontainers.image.url="https://github.com/corpus-core/colibri-stateless"
+LABEL org.opencontainers.image.source="https://github.com/corpus-core/colibri-stateless"
+LABEL org.opencontainers.image.vendor="Corpus Core"
+LABEL org.opencontainers.image.licenses="PolyForm-Noncommercial-1.0.0"
+
 # P2P ports
 EXPOSE 8080
 EXPOSE 9090/udp

--- a/src/chains/op/kona_bridge/Dockerfile
+++ b/src/chains/op/kona_bridge/Dockerfile
@@ -4,6 +4,10 @@ RUN apt-get update && apt-get install -y \
     pkg-config libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Tell openssl-sys to use system OpenSSL (avoids vendored build which needs perl/make)
+ENV OPENSSL_NO_VENDOR=1
+ENV PKG_CONFIG_ALLOW_CROSS=1
+
 WORKDIR /build
 
 # Cache dependencies first

--- a/src/chains/op/kona_bridge/src/gossip.rs
+++ b/src/chains/op/kona_bridge/src/gossip.rs
@@ -5,6 +5,7 @@ use crate::{
     processing::process_preconf_with_correct_format,
     types::{BlockDeduplicator, BlockBitmaskTracker, KonaBridgeStats},
 };
+use tokio::sync::broadcast;
 use discv5::{ConfigBuilder, enr::CombinedKey};
 use kona_p2p::{LocalNode, Network};
 use kona_registry::ROLLUP_CONFIGS;
@@ -30,6 +31,7 @@ pub async fn run_gossip_network(
     running: Arc<Mutex<bool>>,
     deduplicator: Option<Arc<Mutex<BlockDeduplicator>>>,
     bitmask_tracker: Option<Arc<Mutex<BlockBitmaskTracker>>>,
+    sse_tx: Option<broadcast::Sender<u64>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     
     let gossip = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), gossip_port);
@@ -181,6 +183,9 @@ pub async fn run_gossip_network(
                     ).await {
                         Ok(()) => {
                             latest_block_number = number;
+                            if let Some(ref tx) = sse_tx {
+                                let _ = tx.send(number);
+                            }
                             let mut stats_guard = stats.lock().unwrap();
                             stats_guard.processed_preconfs += 1;
                             stats_guard.gossip_processed += 1;

--- a/src/chains/op/kona_bridge/src/http.rs
+++ b/src/chains/op/kona_bridge/src/http.rs
@@ -6,6 +6,7 @@ use crate::{
     types::{BridgeMode, BlockBitmaskTracker, BlockDeduplicator, HttpHealthTracker, KonaBridgeStats},
     utils::{extract_block_number_from_preconf_data, extract_block_hash_from_preconf_data, update_symlinks_lib},
 };
+use tokio::sync::broadcast;
 use reqwest;
 use std::{
     path::PathBuf,
@@ -202,6 +203,7 @@ pub async fn run_http_primary_with_gossip_fallback(
     running: Arc<Mutex<bool>>,
     deduplicator: Arc<Mutex<BlockDeduplicator>>,
     bitmask_tracker: Arc<Mutex<BlockBitmaskTracker>>,
+    sse_tx: Option<broadcast::Sender<u64>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     
     let client = reqwest::Client::new();
@@ -266,6 +268,9 @@ pub async fn run_http_primary_with_gossip_fallback(
                 // Process and save the preconf
                     match process_http_preconf(preconf_data, chain_id, output_dir).await {
                         Ok(block_number) => {
+                            if let Some(ref tx) = sse_tx {
+                                let _ = tx.send(block_number);
+                            }
                             // FIXED: Only check for duplicates in hybrid mode (when gossip is active)
                             let is_duplicate = {
                                 let tracker = health_tracker.lock().unwrap();
@@ -340,8 +345,9 @@ pub async fn run_http_primary_with_gossip_fallback(
                                         let gossip_running = running.clone();
                                         let gossip_sequencer = expected_sequencer.map(|s| s.to_string());
                                         let gossip_deduplicator = deduplicator.clone();
-                                        let gossip_bitmask_tracker = bitmask_tracker.clone(); // Clone for async move
-                                        
+                                        let gossip_bitmask_tracker = bitmask_tracker.clone();
+                                        let gossip_sse_tx = sse_tx.clone();
+
                                         gossip_task = Some(tokio::spawn(async move {
                                             info!("📡 Gossip backup task started");
                                             if let Err(e) = gossip::run_gossip_network(
@@ -354,7 +360,8 @@ pub async fn run_http_primary_with_gossip_fallback(
                                                 gossip_stats,
                                                 gossip_running,
                                                 Some(gossip_deduplicator),
-                                                Some(gossip_bitmask_tracker), // CRITICAL FIX: Pass bitmask_tracker to gossip
+                                                Some(gossip_bitmask_tracker),
+                                                gossip_sse_tx,
                                             ).await {
                                                 warn!("📡 Gossip backup failed: {}", e);
                                             }
@@ -518,8 +525,9 @@ pub async fn run_http_primary_with_gossip_fallback(
                 expected_sequencer,
                 stats,
                 running,
-                Some(deduplicator), // Shared Deduplicator für Fallback
-                Some(bitmask_tracker), // CRITICAL FIX: Pass bitmask_tracker to gossip fallback
+                Some(deduplicator),
+                Some(bitmask_tracker),
+                sse_tx,
             ).await;
         }
     }

--- a/src/chains/op/kona_bridge/src/lib.rs
+++ b/src/chains/op/kona_bridge/src/lib.rs
@@ -1,32 +1,36 @@
-// lib.rs - HTTP-first Kona-Bridge mit modularer Struktur
-// Haupteinstiegspunkt und C-FFI für die Kona-Bridge
+// lib.rs - Kona-Bridge: Bibliothek (C-FFI via feature "ffi") und Basis für Standalone-Binary
 
-mod config;
-mod gossip;
-mod http;
-mod processing;
-mod types;
-mod utils;
+pub mod config;
+pub mod gossip;
+pub mod http;
+pub mod processing;
+pub mod types;
+pub mod utils;
+pub mod server;
 
 use config::ChainConfig;
 use http::run_http_primary_with_gossip_fallback;
-use types::{BridgeMode, BlockBitmaskTracker, BlockDeduplicator, HttpHealthTracker, KonaBridgeConfig, KonaBridgeHandle, KonaBridgeStats};
+use types::{BridgeMode, BlockBitmaskTracker, BlockDeduplicator, HttpHealthTracker, KonaBridgeStats};
 use utils::cleanup_old_files;
 
 use alloy::primitives::Address;
 use std::{
-    ffi::CStr,
-    fs,
-    os::raw::c_int,
     path::PathBuf,
     sync::{Arc, Mutex},
-    thread,
-    time::Duration,
 };
-use tracing::{error, info, warn};
+use tokio::sync::broadcast;
+use tracing::{info, warn};
+#[cfg(feature = "ffi")]
+use tracing::error;
+
+#[cfg(feature = "ffi")]
+use std::{ffi::CStr, fs, os::raw::c_int, thread, time::Duration};
+#[cfg(feature = "ffi")]
+use types::{KonaBridgeConfig, KonaBridgeHandle};
 
 
 /// Startet die echte Kona-Bridge mit korrektem Preconf-Format
+#[cfg(feature = "ffi")]
 #[no_mangle]
 pub extern "C" fn kona_bridge_start(config: *const KonaBridgeConfig) -> *mut KonaBridgeHandle {
     eprintln!("🚀 kona_bridge_start called from C");
@@ -175,6 +179,7 @@ pub extern "C" fn kona_bridge_start(config: *const KonaBridgeConfig) -> *mut Kon
                 sequencer_address.as_deref(),
                 stats_clone,
                 running_clone,
+                None, // No SSE in C-FFI mode
             ).await {
                 error!("❌ HTTP-first network failed: {}", e);
                 error!("❌ Error details: {:?}", e);
@@ -215,8 +220,8 @@ pub extern "C" fn kona_bridge_start(config: *const KonaBridgeConfig) -> *mut Kon
     Box::into_raw(Box::new(handle))
 }
 
-/// HTTP-first Netzwerk mit Gossip-Fallback
-async fn run_http_first_network(
+/// HTTP-first Netzwerk mit Gossip-Fallback (auch vom Standalone-Binary nutzbar)
+pub async fn run_http_first_network(
     chain_id: u64,
     disc_port: u16,
     gossip_port: u16,
@@ -228,6 +233,7 @@ async fn run_http_first_network(
     expected_sequencer: Option<&str>,
     stats: Arc<Mutex<KonaBridgeStats>>,
     running: Arc<Mutex<bool>>,
+    sse_tx: Option<broadcast::Sender<u64>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     
     info!("🚀 HTTP-first network starting for chain {}", chain_id);
@@ -290,12 +296,12 @@ async fn run_http_first_network(
             health_tracker,
             stats,
             running,
-            Arc::new(Mutex::new(BlockDeduplicator::new())), // Shared Deduplicator
-            Arc::new(Mutex::new(BlockBitmaskTracker::new())), // Shared Bitmask Tracker
+            Arc::new(Mutex::new(BlockDeduplicator::new())),
+            Arc::new(Mutex::new(BlockBitmaskTracker::new())),
+            sse_tx,
         ).await?;
     } else {
         info!("🌐 No HTTP endpoint - starting directly in gossip mode");
-        // No HTTP endpoint available, start gossip directly
         gossip::run_gossip_network(
             chain_id,
             disc_port,
@@ -305,8 +311,9 @@ async fn run_http_first_network(
             expected_sequencer,
             stats,
             running,
-            None, // Kein Deduplicator im reinen Gossip-Modus
-            None, // Kein Bitmask-Tracker im reinen Gossip-Modus
+            None,
+            None,
+            sse_tx,
         ).await?;
     }
     
@@ -314,6 +321,7 @@ async fn run_http_first_network(
 }
 
 /// Stoppt die Kona-Bridge
+#[cfg(feature = "ffi")]
 #[no_mangle]
 pub extern "C" fn kona_bridge_stop(handle: *mut KonaBridgeHandle) {
     if handle.is_null() {
@@ -342,6 +350,7 @@ pub extern "C" fn kona_bridge_stop(handle: *mut KonaBridgeHandle) {
 }
 
 /// Prüft ob die Bridge läuft
+#[cfg(feature = "ffi")]
 #[no_mangle]
 pub extern "C" fn kona_bridge_is_running(handle: *const KonaBridgeHandle) -> c_int {
     if handle.is_null() {
@@ -357,6 +366,7 @@ pub extern "C" fn kona_bridge_is_running(handle: *const KonaBridgeHandle) -> c_i
 }
 
 /// Gibt Statistiken über die Bridge zurück
+#[cfg(feature = "ffi")]
 #[no_mangle]
 pub extern "C" fn kona_bridge_get_stats(
     handle: *const KonaBridgeHandle,
@@ -399,6 +409,7 @@ pub extern "C" fn kona_bridge_get_stats(
 }
 
 /// Hilfsfunktion für Logging-Setup von C aus (CPU-optimized)
+#[cfg(feature = "ffi")]
 #[no_mangle]
 pub extern "C" fn kona_bridge_init_logging() {
     use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};

--- a/src/chains/op/kona_bridge/src/main.rs
+++ b/src/chains/op/kona_bridge/src/main.rs
@@ -1,493 +1,153 @@
-// main_helios.rs - Echte Kona-P2P Implementation basierend auf Helios
-use alloy::{
-    primitives::{Address, Bytes, address},
-    signers::Signature,
-};
-use clap::Parser;
-use discv5::{ConfigBuilder, Enr, enr::CombinedKey};
-use kona_p2p::{LocalNode, Network};
-use kona_registry::ROLLUP_CONFIGS;
-use libp2p::{Multiaddr, identity::Keypair};
-use op_alloy_rpc_types_engine::{OpExecutionPayload, OpNetworkPayloadEnvelope};
-use serde::{Deserialize, Serialize};
-use ethereum_ssz::Encode;
-use std::{
-    borrow::BorrowMut,
-    fs,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-    path::PathBuf,
-    sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
-};
-use tokio::sync::RwLock;
-use tracing::{info, warn, error};
-use tracing_subscriber::{EnvFilter, FmtSubscriber};
+// main.rs - Standalone kona-preconf-service Binary
+//
+// Startet den P2P-Gossip-Receiver und einen HTTP-Server (Port 8080).
+// Konfiguration via Umgebungsvariablen:
+//   CHAIN_ID                   (required) OP-Stack Chain-ID, z.B. 8453 für Base
+//   OUTPUT_DIR                 Verzeichnis für Preconf-Dateien (default: ./preconfs)
+//   DISC_PORT                  discv5 Discovery-Port (default: 9090)
+//   GOSSIP_PORT                libp2p Gossip-Port (default: 9091)
+//   HTTP_PORT                  HTTP-Server-Port (default: 8080)
+//   TTL_MINUTES                TTL für Preconf-Dateien (default: 60)
+//   CLEANUP_INTERVAL_MINUTES   Cleanup-Intervall in Minuten (default: 5)
+//   HTTP_POLL_INTERVAL         HTTP-Polling-Intervall in Sekunden (default: 1)
+//   HTTP_FAILURE_THRESHOLD     Fehler vor Gossip-Fallback (default: 5)
+//   SEQUENCER_ADDRESS          Erwartete Sequencer-Adresse (optional)
 
-#[derive(Parser)]
-#[command(name = "kona_bridge")]
-#[command(about = "Kona-P2P OP Stack Preconfirmation Bridge")]
-struct Args {
-    /// Chain ID (z.B. 10 für OP Mainnet, 8453 für Base)
-    #[arg(short, long, default_value = "8453")]
-    chain_id: u64,
+mod config;
+mod gossip;
+mod http;
+mod processing;
+mod server;
+mod types;
+mod utils;
 
-    /// Network name (op-mainnet, base, unichain, etc.)
-    #[arg(short, long, default_value = "base")]
-    network: String,
+use alloy::primitives::Address;
+use std::{env, fs, path::PathBuf, sync::{Arc, Mutex}};
+use tokio::sync::broadcast;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
 
-    /// Output-Verzeichnis für Preconfs
-    #[arg(short, long, default_value = "./preconfs")]
-    output_dir: PathBuf,
-
-    /// Discovery Port
-    #[arg(long, default_value = "9090")]
-    disc_port: u16,
-
-    /// Gossip Port  
-    #[arg(long, default_value = "9091")]
-    gossip_port: u16,
-
-    /// Expected Sequencer Address (optional)
-    #[arg(long)]
-    sequencer_address: Option<String>,
-
-    /// Chain Name (optional, für Logging)
-    #[arg(long)]
-    chain_name: Option<String>,
-}
+use config::ChainConfig;
+use http::run_http_primary_with_gossip_fallback;
+use types::{BlockBitmaskTracker, BlockDeduplicator, BridgeMode, HttpHealthTracker, KonaBridgeStats};
+use utils::cleanup_old_files;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    enable_tracing();
-    let args = Args::parse();
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                EnvFilter::new(
+                    "warn,kona_bridge=info,libp2p=off,discv5=off,kona_p2p=off,hyper=off",
+                )
+            }),
+        )
+        .with_target(false)
+        .compact()
+        .init();
 
-    info!("🚀 Starting Kona-P2P OP Stack Bridge");
-    info!("⛓️  Chain ID: {}", args.chain_id);
-    info!("🌐 Network: {}", args.network);
-    info!("📁 Output: {:?}", args.output_dir);
+    let chain_id: u64 = env::var("CHAIN_ID")
+        .expect("CHAIN_ID env var required")
+        .parse()
+        .expect("CHAIN_ID must be a number");
 
-    // Create output directory
-    fs::create_dir_all(&args.output_dir)?;
+    let output_dir = PathBuf::from(
+        env::var("OUTPUT_DIR").unwrap_or_else(|_| "./preconfs".to_string()),
+    );
+    let disc_port: u16 = env::var("DISC_PORT")
+        .ok().and_then(|v| v.parse().ok()).unwrap_or(9090);
+    let gossip_port: u16 = env::var("GOSSIP_PORT")
+        .ok().and_then(|v| v.parse().ok()).unwrap_or(9091);
+    let http_port: u16 = env::var("HTTP_PORT")
+        .ok().and_then(|v| v.parse().ok()).unwrap_or(8080);
+    let ttl_minutes: u64 = env::var("TTL_MINUTES")
+        .ok().and_then(|v| v.parse().ok()).unwrap_or(60);
+    let cleanup_interval: u64 = env::var("CLEANUP_INTERVAL_MINUTES")
+        .ok().and_then(|v| v.parse().ok()).unwrap_or(5);
+    let http_poll_interval: u64 = env::var("HTTP_POLL_INTERVAL")
+        .ok().and_then(|v| v.parse().ok()).unwrap_or(1);
+    let http_failure_threshold: u32 = env::var("HTTP_FAILURE_THRESHOLD")
+        .ok().and_then(|v| v.parse().ok()).unwrap_or(5);
+    let sequencer_address = env::var("SEQUENCER_ADDRESS").ok();
 
-    // Start network
-    start_network(&args).await?;
+    fs::create_dir_all(&output_dir)?;
 
-    Ok(())
-}
+    info!("🚀 kona-preconf-service starting");
+    info!("⛓️  Chain ID: {}", chain_id);
+    info!("📁 Output:   {:?}", output_dir);
+    info!("🌐 HTTP:     0.0.0.0:{}", http_port);
 
-async fn start_network(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
-    let chain_config = ChainConfig::from(args.network.as_str(), args.chain_id);
+    let stats = Arc::new(Mutex::new(KonaBridgeStats {
+        connected_peers: 0, received_preconfs: 0, processed_preconfs: 0, failed_preconfs: 0,
+        http_received: 0, http_processed: 0, gossip_received: 0, gossip_processed: 0,
+        mode_switches: 0, current_mode: 0, total_gaps: 0, http_gaps: 0,
+        gossip_gaps: 0, bitmask_gaps: 0,
+    }));
+    let running = Arc::new(Mutex::new(true));
+    let (sse_tx, _) = broadcast::channel::<u64>(64);
 
-    let gossip = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), args.gossip_port);
-    let mut gossip_addr = Multiaddr::from(gossip.ip());
-    gossip_addr.push(libp2p::multiaddr::Protocol::Tcp(gossip.port()));
-
-    let CombinedKey::Secp256k1(k256_key) = CombinedKey::generate_secp256k1() else {
-        return Err("Failed to generate secp256k1 key".into());
-    };
-    
-    let advertise_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
-    let disc = LocalNode::new(k256_key, advertise_ip, args.disc_port, args.disc_port);
-    let disc_listen = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), args.disc_port);
-
-    let gossip_key = Keypair::generate_secp256k1();
-
-    let cfg = ROLLUP_CONFIGS
-        .get(&chain_config.chain_id)
-        .ok_or_else(|| format!("Rollup config not found for chain {}", chain_config.chain_id))?
-        .clone();
-
-    info!("🔍 Discovery: 0.0.0.0:{}", args.disc_port);
-    info!("📡 Gossip: 0.0.0.0:{}", args.gossip_port);
-    info!("🔐 Expected sequencer: {}", chain_config.unsafe_signer);
-
-    let mut network = Network::builder()
-        .with_rollup_config(cfg)
-        .with_unsafe_block_signer(chain_config.unsafe_signer)
-        .with_discovery_address(disc)
-        .with_gossip_address(gossip_addr)
-        .with_keypair(gossip_key)
-        .with_discovery_config(ConfigBuilder::new(disc_listen.into()).build())
-        .build()
-        .map_err(|e| format!("Failed to build network driver: {}", e))?;
-
-    // Add bootnodes
-    for bootnode in chain_config.bootnodes {
-        info!("🔗 Adding bootnode: {}", bootnode);
-        network
-            .discovery
-            .borrow_mut()
-            .disc
-            .borrow_mut()
-            .add_enr(bootnode)
-            .map_err(|e| format!("Failed to add bootnode: {}", e))?;
+    // HTTP server runs in background
+    {
+        let srv_dir   = output_dir.clone();
+        let srv_stats = stats.clone();
+        let srv_sse   = sse_tx.clone();
+        tokio::spawn(async move {
+            if let Err(e) = server::run_http_server(srv_dir, chain_id, http_port, srv_stats, srv_sse).await {
+                tracing::error!("HTTP server error: {}", e);
+            }
+        });
     }
 
-    let mut payload_recv = network.unsafe_block_recv();
-    network
-        .start()
-        .await
-        .map_err(|e| format!("Failed to start network driver: {}", e))?;
+    // P2P / HTTP-first network (blocks until shutdown)
+    let network_name = match chain_id {
+        10      => "op-mainnet",
+        8453    => "base",
+        130     => "unichain",
+        480     => "worldchain",
+        7777777 => "zora",
+        _       => { tracing::warn!("Unknown chain {}, using base config", chain_id); "base" }
+    };
 
-    info!("✅ Kona-P2P network started successfully!");
-    info!("🎧 Listening for preconfirmation messages...");
+    let mut chain_config = ChainConfig::from(network_name, chain_id);
+    if let Some(ref addr) = sequencer_address {
+        if let Ok(parsed) = addr.parse::<Address>() {
+            chain_config.unsafe_signer = parsed;
+        }
+    }
 
-    let state = Arc::new(RwLock::new(PreconfState {
-        latest_block_number: 0,
-        previous_block_number: None,
-        processed_count: 0,
+    let health_tracker = Arc::new(Mutex::new(HttpHealthTracker {
+        consecutive_failures: 0,
+        last_success: None,
+        failure_threshold: http_failure_threshold,
+        current_mode: BridgeMode::HttpOnly,
+        consecutive_success_blocks: 0,
     }));
 
-    let output_dir = args.output_dir.clone();
-    let chain_id = args.chain_id;
-    let expected_sequencer = args.sequencer_address.clone();
-
-    // Process incoming payloads
-    while let Ok(payload_envelope) = payload_recv.recv().await {
-        let hash = payload_envelope.payload.block_hash();
-        let number = payload_envelope.payload.block_number();
-        
-        info!("🎉 PRECONF RECEIVED! Block #{} Hash: {}", number, hash);
-
-        // Check if this is newer than our latest
-        let should_process = {
-            let state_guard = state.read().await;
-            number > state_guard.latest_block_number
-        };
-
-        if should_process {
-            match process_preconf(&payload_envelope, chain_id, &output_dir, expected_sequencer.as_deref()).await {
-                Ok(()) => {
-                    let mut state_guard = state.write().await;
-                    
-                    // Update symlinks with atomic operation
-                    let filename = format!("block_{}_{}.raw", chain_id, number);
-                    let current_latest = state_guard.latest_block_number;
-                    
-                    info!("🔄 Updating symlinks: new={}, previous_block={}", filename, current_latest);
-                    
-                    if let Err(e) = update_symlinks(&output_dir, &filename, current_latest, chain_id).await {
-                        error!("⚠️  Failed to update symlinks: {}", e);
-                    }
-                    
-                    // Update state
-                    if current_latest > 0 {
-                        state_guard.previous_block_number = Some(current_latest);
-                    }
-                    state_guard.latest_block_number = number;
-                    state_guard.processed_count += 1;
-                    info!("✅ Preconf processed successfully (total: {})", state_guard.processed_count);
-                }
-                Err(e) => {
-                    error!("❌ Failed to process preconf: {}", e);
-                }
-            }
-        } else {
-            info!("⏭️  Skipping old preconf (block #{} <= {})", number, state.read().await.latest_block_number);
-        }
-    }
-
-    Ok(())
-}
-
-async fn process_preconf(
-    payload_envelope: &OpNetworkPayloadEnvelope,
-    chain_id: u64,
-    output_dir: &PathBuf,
-    expected_sequencer: Option<&str>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let block_number = payload_envelope.payload.block_number();
-    let block_hash = payload_envelope.payload.block_hash();
-    
-    info!("📦 Processing preconf for block #{}", block_number);
-
-    // Create SequencerCommitment (same as Helios)
-    let commitment = SequencerCommitment::from(payload_envelope.clone());
-    
-    // Extract execution payload
-    let execution_payload_bytes = match &payload_envelope.payload {
-        OpExecutionPayload::V1(payload) => payload.as_ssz_bytes(),
-        OpExecutionPayload::V2(payload) => payload.as_ssz_bytes(),
-        OpExecutionPayload::V3(payload) => payload.as_ssz_bytes(),
-        OpExecutionPayload::V4(payload) => payload.as_ssz_bytes(),
-    };
-
-    // Verify sequencer signature if expected sequencer is provided
-    if let Some(expected) = expected_sequencer {
-        let recovered_address = recover_sequencer_address(&commitment, chain_id)?;
-        let expected_address = expected.parse::<Address>()
-            .map_err(|e| format!("Invalid expected sequencer address: {}", e))?;
-        
-        if recovered_address != expected_address {
-            return Err(format!(
-                "Sequencer mismatch: expected {}, got {}", 
-                expected_address, recovered_address
-            ).into());
-        }
-        
-        info!("🔐 Sequencer signature verified: {}", recovered_address);
-    }
-
-    // Format: 32-byte domain + execution_payload
-    let mut preconf_data = Vec::new();
-    
-    // Add 32-byte zero domain (wie in Go-Implementation)
-    preconf_data.extend_from_slice(&[0u8; 32]);
-    
-    // Add execution payload
-    preconf_data.extend_from_slice(&execution_payload_bytes);
-
-    // Compress with ZSTD
-    let compressed_payload = zstd::encode_all(preconf_data.as_slice(), 0)?;
-    
-    info!("🗜️  ZSTD compression: {} bytes -> {} bytes ({}% reduction)",
-        preconf_data.len(), 
-        compressed_payload.len(),
-        100 - (compressed_payload.len() * 100 / preconf_data.len()));
-
-    // Extract signature (65 bytes)
-    let signature_bytes = signature_to_bytes(&commitment.signature);
-
-    // Combine: compressed_payload + signature (65 bytes)
-    let mut final_data = Vec::new();
-    final_data.extend_from_slice(&compressed_payload);
-    final_data.extend_from_slice(&signature_bytes);
-
-    // Write to file: block_{chain_id}_{block_number}.raw
-    let filename = format!("block_{}_{}.raw", chain_id, block_number);
-    let filepath = output_dir.join(&filename);
-    
-    // Atomic write
-    let temp_filepath = filepath.with_extension("tmp");
-    fs::write(&temp_filepath, &final_data)?;
-    fs::rename(&temp_filepath, &filepath)?;
-
-    info!("💾 Saved preconf to: {:?}", filepath);
-
-    // Create metadata file
-    let meta_filename = format!("block_{}_{}.json", chain_id, block_number);
-    let meta_filepath = output_dir.join(&meta_filename);
-    
-    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
-    let metadata = serde_json::json!({
-        "chain_id": chain_id.to_string(),
-        "block_number": block_number,
-        "block_hash": format!("0x{:x}", block_hash),
-        "received_unix": timestamp,
-        "signature": format!("0x{}", hex::encode(&signature_bytes)),
-        "compressed_size": compressed_payload.len(),
-        "decompressed_size": preconf_data.len(),
-        "file_path": filename
-    });
-
-    fs::write(&meta_filepath, serde_json::to_string_pretty(&metadata)?)?;
-
-    Ok(())
-}
-
-fn signature_to_bytes(signature: &Signature) -> [u8; 65] {
-    let mut bytes = [0u8; 65];
-    bytes[..32].copy_from_slice(&signature.r().to_be_bytes::<32>());
-    bytes[32..64].copy_from_slice(&signature.s().to_be_bytes::<32>());
-    bytes[64] = if signature.v() { 28 } else { 27 };
-    bytes
-}
-
-fn recover_sequencer_address(_commitment: &SequencerCommitment, _chain_id: u64) -> Result<Address, Box<dyn std::error::Error>> {
-    // TODO: Implement signature recovery logic
-    // This would use the same logic as in the Go implementation
-    Ok(Address::ZERO) // Placeholder
-}
-
-fn enable_tracing() {
-    let env_filter = EnvFilter::from_default_env()
-        .add_directive("kona_bridge".parse().unwrap());
-
-    let subscriber = FmtSubscriber::builder()
-        .with_env_filter(env_filter)
-        .finish();
-
-    tracing::subscriber::set_global_default(subscriber)
-        .expect("subscriber set failed");
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct SequencerCommitment {
-    data: Bytes,
-    signature: Signature,
-}
-
-impl From<OpNetworkPayloadEnvelope> for SequencerCommitment {
-    fn from(value: OpNetworkPayloadEnvelope) -> Self {
-        let parent_root = value.parent_beacon_block_root.unwrap_or_default();
-        let payload = match value.payload {
-            OpExecutionPayload::V1(payload) => payload.as_ssz_bytes(),
-            OpExecutionPayload::V2(payload) => payload.as_ssz_bytes(),
-            OpExecutionPayload::V3(payload) => payload.as_ssz_bytes(),
-            OpExecutionPayload::V4(payload) => payload.as_ssz_bytes(),
-        };
-
-        let data = [parent_root.as_slice(), &payload].concat();
-
-        SequencerCommitment {
-            data: data.into(),
-            signature: value.signature,
-        }
-    }
-}
-
-struct PreconfState {
-    latest_block_number: u64,
-    previous_block_number: Option<u64>,
-    processed_count: u64,
-}
-
-struct ChainConfig {
-    unsafe_signer: Address,
-    chain_id: u64,
-    bootnodes: Vec<Enr>,
-}
-
-impl ChainConfig {
-    fn from(network: &str, chain_id: u64) -> Self {
-        match network {
-            "op-mainnet" => ChainConfig {
-                unsafe_signer: address!("AAAA45d9549EDA09E70937013520214382Ffc4A2"),
-                chain_id: 10,
-                bootnodes: Vec::new(),
-            },
-            "base" => ChainConfig {
-                unsafe_signer: address!("Af6E19BE0F9cE7f8afd49a1824851023A8249e8a"),
-                chain_id: 8453,
-                bootnodes: Vec::new(),
-            },
-            "unichain" => ChainConfig {
-                unsafe_signer: address!("833C6f278474A78658af91aE8edC926FE33a230e"),
-                chain_id: 130,
-                bootnodes: vec![
-                    "enr:-Iq4QNqqxkwND5YdrKxSVR8RoZHwU6Qa42ff_0XNjD428_n9OTEy3N9iR4uZTfQxACB00fT7Y8__q238kpb6TcsRvw-GAZZoqRJLgmlkgnY0gmlwhDQOHieJc2VjcDI1NmsxoQLqnqr2lfrL5TCQvrelsEEagUWbv25sqsFR5YfudxIKG4N1ZHCCdl8",
-                    "enr:-Iq4QBtf4EkiX7NfYxCn6CKIh3ZJqjk70NWS9hajT1k3W7-3ePWBc5-g19tBqYAMWlfSSz3sir024EQc5YH3TAxVY76GAZZopWrWgmlkgnY0gmlwhAOUZK2Jc2VjcDI1NmsxoQN3trHnKYTV1Q4ArpNP_qmCkCIm_pL6UNpCM0wnUNjkBYN1ZHCCdl8",
-                ]
-                .iter()
-                .map(|v| v.parse().unwrap())
-                .collect(),
-            },
-            _ => {
-                // Use provided chain_id for custom networks
-                ChainConfig {
-                    unsafe_signer: Address::ZERO, // Will need to be configured
-                    chain_id,
-                    bootnodes: Vec::new(),
-                }
-            }
-        }
-    }
-}
-
-
-async fn update_symlinks(
-    output_dir: &PathBuf, 
-    new_latest_filename: &str, 
-    previous_block_number: u64,
-    chain_id: u64
-) -> Result<(), Box<dyn std::error::Error>> {
-    let latest_path = output_dir.join("latest.raw");
-    let pre_latest_path = output_dir.join("pre_latest.raw");
-    
-    #[cfg(unix)]
+    // Start TTL cleanup
     {
-        use std::os::unix::fs::symlink;
-        
-        // Update pre_latest.raw first (should point to current latest before we update it)
-        if previous_block_number > 0 {
-            let previous_filename = format!("block_{}_{}.raw", chain_id, previous_block_number);
-            let previous_file_path = output_dir.join(&previous_filename);
-            
-            info!("🔍 Checking for previous block file: {} (exists: {})", previous_filename, previous_file_path.exists());
-            
-            // Only update pre_latest if the previous file actually exists
-            if previous_file_path.exists() {
-                // Remove old pre_latest symlink
-                if let Err(e) = fs::remove_file(&pre_latest_path) {
-                    if e.kind() != std::io::ErrorKind::NotFound {
-                        warn!("⚠️  Failed to remove old pre_latest.raw: {}", e);
-                    }
-                }
-                
-                // Create new pre_latest symlink
-                if let Err(e) = symlink(&previous_filename, &pre_latest_path) {
-                    warn!("⚠️  Failed to create pre_latest.raw symlink: {}", e);
-                } else {
-                    info!("🔗 Updated pre_latest.raw symlink to {}", previous_filename);
-                }
-            } else {
-                warn!("⚠️  Previous block file {} does not exist, skipping pre_latest.raw update", previous_filename);
-            }
-        }
-        
-        // Update latest.raw
-        // Remove old latest symlink
-        if let Err(e) = fs::remove_file(&latest_path) {
-            if e.kind() != std::io::ErrorKind::NotFound {
-                warn!("⚠️  Failed to remove old latest.raw: {}", e);
-            }
-        }
-        
-        // Create new latest symlink
-        if let Err(e) = symlink(new_latest_filename, &latest_path) {
-            warn!("⚠️  Failed to create latest.raw symlink: {}", e);
-        } else {
-            info!("🔗 Updated latest.raw symlink to {}", new_latest_filename);
-        }
-        
-        // Verify both symlinks exist and are valid
-        verify_symlinks(output_dir).await?;
+        let cdir = output_dir.clone();
+        let crun = running.clone();
+        tokio::spawn(async move {
+            cleanup_old_files(cdir, ttl_minutes, cleanup_interval, crun).await;
+        });
     }
-    
-    Ok(())
-}
 
-async fn verify_symlinks(output_dir: &PathBuf) -> Result<(), Box<dyn std::error::Error>> {
-    let latest_path = output_dir.join("latest.raw");
-    let pre_latest_path = output_dir.join("pre_latest.raw");
-    
-    // Check latest.raw
-    if !latest_path.exists() {
-        warn!("⚠️  latest.raw symlink does not exist!");
-        return Err("latest.raw symlink missing".into());
-    }
-    
-    // Check if latest.raw points to a valid file
-    match fs::metadata(&latest_path) {
-        Ok(metadata) => {
-            if !metadata.is_file() {
-                warn!("⚠️  latest.raw does not point to a valid file!");
-            } else {
-                info!("✅ latest.raw symlink is valid");
-            }
-        }
-        Err(e) => {
-            warn!("⚠️  latest.raw symlink is broken: {}", e);
-        }
-    }
-    
-    // Check pre_latest.raw (optional, might not exist for first block )
-    if pre_latest_path.exists() {
-        match fs::metadata(&pre_latest_path) {
-            Ok(metadata) => {
-                if !metadata.is_file() {
-                    warn!("⚠️  pre_latest.raw does not point to a valid file!");
-                } else {
-                    info!("✅ pre_latest.raw symlink is valid");
-                }
-            }
-            Err(e) => {
-                warn!("⚠️  pre_latest.raw symlink is broken: {}", e);
-            }
-        }
+    if let Some(http_endpoint) = chain_config.get_http_endpoint() {
+        run_http_primary_with_gossip_fallback(
+            http_endpoint, chain_id, disc_port, gossip_port,
+            &output_dir, http_poll_interval, &chain_config,
+            sequencer_address.as_deref(), health_tracker, stats, running,
+            Arc::new(Mutex::new(BlockDeduplicator::new())),
+            Arc::new(Mutex::new(BlockBitmaskTracker::new())),
+            Some(sse_tx),
+        ).await.map_err(|e| anyhow::anyhow!("{}", e))?;
     } else {
-        info!("ℹ️  pre_latest.raw does not exist (normal for first block)");
+        gossip::run_gossip_network(
+            chain_id, disc_port, gossip_port, &output_dir,
+            &chain_config, sequencer_address.as_deref(),
+            stats, running, None, None, Some(sse_tx),
+        ).await.map_err(|e| anyhow::anyhow!("{}", e))?;
     }
-    
+
     Ok(())
 }

--- a/src/chains/op/kona_bridge/src/server.rs
+++ b/src/chains/op/kona_bridge/src/server.rs
@@ -1,0 +1,119 @@
+// server.rs - Axum HTTP-Server mit SSE-Notifications für den Standalone-Service
+
+use crate::types::KonaBridgeStats;
+use axum::{
+    body::Body,
+    extract::{Path, State},
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use axum::response::sse::{Event, KeepAlive, Sse};
+use futures_util::stream::Stream;
+use std::{convert::Infallible, path::PathBuf, sync::{Arc, Mutex}};
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::StreamExt;
+use tracing::error;
+
+struct AppState {
+    output_dir: PathBuf,
+    chain_id:   u64,
+    stats:      Arc<Mutex<KonaBridgeStats>>,
+    sse_tx:     broadcast::Sender<u64>,
+}
+
+pub async fn run_http_server(
+    output_dir: PathBuf,
+    chain_id: u64,
+    port: u16,
+    stats: Arc<Mutex<KonaBridgeStats>>,
+    sse_tx: broadcast::Sender<u64>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let state = Arc::new(AppState { output_dir, chain_id, stats, sse_tx });
+
+    let app = Router::new()
+        .route("/preconf/latest",     get(serve_latest))
+        .route("/preconf/pre_latest", get(serve_pre_latest))
+        .route("/preconf/:block_hex", get(serve_block))
+        .route("/stats",              get(serve_stats))
+        .route("/sse",                get(sse_handler))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", port)).await?;
+    tracing::info!("🌐 HTTP server listening on 0.0.0.0:{}", port);
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+async fn serve_latest(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    serve_raw_file(state.output_dir.join("latest.raw")).await
+}
+
+async fn serve_pre_latest(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    serve_raw_file(state.output_dir.join("pre_latest.raw")).await
+}
+
+async fn serve_block(
+    State(state): State<Arc<AppState>>,
+    Path(block_hex): Path<String>,
+) -> impl IntoResponse {
+    let hex_str = block_hex.trim_start_matches("0x").trim_start_matches("0X");
+    let block_number = match u64::from_str_radix(hex_str, 16) {
+        Ok(n) => n,
+        Err(_) => return (StatusCode::BAD_REQUEST, "Invalid block number").into_response(),
+    };
+    let filename = format!("block_{}_{}.raw", state.chain_id, block_number);
+    serve_raw_file(state.output_dir.join(filename)).await
+}
+
+async fn serve_raw_file(path: PathBuf) -> Response<Body> {
+    match tokio::fs::read(&path).await {
+        Ok(data) => (
+            [(header::CONTENT_TYPE, "application/octet-stream")],
+            data,
+        ).into_response(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            StatusCode::NOT_FOUND.into_response()
+        }
+        Err(e) => {
+            error!("Failed to read file {:?}: {}", path, e);
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+async fn serve_stats(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let s = state.stats.lock().unwrap();
+    axum::Json(serde_json::json!({
+        "connected_peers":    s.connected_peers,
+        "received_preconfs":  s.received_preconfs,
+        "processed_preconfs": s.processed_preconfs,
+        "failed_preconfs":    s.failed_preconfs,
+        "http_received":      s.http_received,
+        "http_processed":     s.http_processed,
+        "gossip_received":    s.gossip_received,
+        "gossip_processed":   s.gossip_processed,
+        "mode_switches":      s.mode_switches,
+        "current_mode":       s.current_mode,
+        "total_gaps":         s.total_gaps,
+        "http_gaps":          s.http_gaps,
+        "gossip_gaps":        s.gossip_gaps,
+        "bitmask_gaps":       s.bitmask_gaps,
+    }))
+}
+
+async fn sse_handler(
+    State(state): State<Arc<AppState>>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let rx = state.sse_tx.subscribe();
+    let stream = BroadcastStream::new(rx).filter_map(|res| {
+        res.ok().map(|block_number| {
+            Ok(Event::default()
+                .event("preconf")
+                .data(block_number.to_string()))
+        })
+    });
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}

--- a/src/chains/op/server/handler.c
+++ b/src/chains/op/server/handler.c
@@ -50,7 +50,9 @@ void op_server_shutdown(http_server_t* server) {
   log_info("🛑 Shutting down OP server handler...");
 
   // Stop Kona preconf capture if running
+#ifdef KONA_BRIDGE_AVAILABLE
   stop_kona_preconf_capture();
+#endif
 
   log_info("✅ OP server handler shutdown complete");
 }

--- a/src/chains/op/server/op_conf.c
+++ b/src/chains/op/server/op_conf.c
@@ -4,9 +4,9 @@
 
 op_config_t op_config = {
     .preconf_storage_dir              = "./preconfs",
-    .preconf_ttl_minutes              = 30, // 30 minutes TTL,
-    .preconf_cleanup_interval_minutes = 5,  // Cleanup every 5 minutes,
-
+    .preconf_ttl_minutes              = 30,
+    .preconf_cleanup_interval_minutes = 5,
+    .master_kona_bridge_url           = NULL,
 };
 
 void op_configure() {
@@ -15,6 +15,7 @@ void op_configure() {
   conf_string(&op_config.preconf_storage_dir, "PRECONF_DIR", "preconf_dir", 'P', "directory for storing preconfirmations");
   conf_int(&op_config.preconf_ttl_minutes, "PRECONF_TTL", "preconf_ttl", 'T', "TTL for preconfirmations in minutes", 1, 1440);
   conf_int(&op_config.preconf_cleanup_interval_minutes, "PRECONF_CLEANUP_INTERVAL", "preconf_cleanup_interval", 'C', "cleanup interval in minutes", 1, 60);
+  conf_string(&op_config.master_kona_bridge_url, "MASTER_KONA_BRIDGE_URL", "master_kona_bridge_url", 0, "kona-preconf-service base URL for remote fallback (e.g. http://kona-bridge:8080)");
 
   http_server.prover_flags |= C4_PROVER_FLAG_USE_ACCESSLIST;
 }

--- a/src/chains/op/server/op_conf.h
+++ b/src/chains/op/server/op_conf.h
@@ -7,8 +7,9 @@ typedef struct {
   char* preconf_storage_dir;
   int   preconf_ttl_minutes;
   int   preconf_cleanup_interval_minutes;
-  // preconf_use_gossip removed - now using automatic HTTP fallback until gossip is active
-
+  // When set, preconfs missing locally are fetched from this kona-preconf-service URL
+  // and cached to preconf_storage_dir. Example: "http://kona-bridge:8080"
+  char* master_kona_bridge_url;
 } op_config_t;
 
 extern op_config_t op_config;

--- a/src/chains/op/server/preconf.c
+++ b/src/chains/op/server/preconf.c
@@ -1,15 +1,128 @@
 #include "handler.h"
 #include "op_conf.h"
 #include "uv_util.h"
+#include "logger.h"
+#include <curl/curl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <uv.h>
+
+// ---- Remote fallback: fetch preconf from master kona-bridge via blocking curl ----
+
+typedef struct {
+  uv_work_t         work;
+  single_request_t* req;
+  char*             master_url;  // Full URL to fetch
+  char*             cache_path;  // Local path to cache the result (NULL = no caching)
+  uint8_t*          data;
+  uint32_t          data_len;
+} preconf_remote_fetch_t;
+
+static size_t preconf_curl_write(void* ptr, size_t size, size_t nmemb, void* ud) {
+  preconf_remote_fetch_t* ctx  = (preconf_remote_fetch_t*) ud;
+  uint32_t                real = (uint32_t)(size * nmemb);
+  uint8_t*                buf  = realloc(ctx->data, ctx->data_len + real);
+  if (!buf) return 0;
+  memcpy(buf + ctx->data_len, ptr, real);
+  ctx->data = buf;
+  ctx->data_len += real;
+  return real;
+}
+
+// Runs in libuv thread pool — blocking curl call is safe here
+static void preconf_remote_worker(uv_work_t* work) {
+  preconf_remote_fetch_t* ctx = (preconf_remote_fetch_t*) work->data;
+
+  CURL* curl = curl_easy_init();
+  if (!curl) return;
+
+  curl_easy_setopt(curl, CURLOPT_URL, ctx->master_url);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, preconf_curl_write);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, ctx);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5L);
+  curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+
+  long    http_code = 0;
+  CURLcode res      = curl_easy_perform(curl);
+  curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+  curl_easy_cleanup(curl);
+
+  if (res != CURLE_OK || http_code != 200 || ctx->data_len == 0) {
+    free(ctx->data);
+    ctx->data     = NULL;
+    ctx->data_len = 0;
+    return;
+  }
+
+  // Cache to local filesystem for block-specific requests (not latest/pre_latest symlinks)
+  if (ctx->cache_path) {
+    FILE* f = fopen(ctx->cache_path, "wb");
+    if (f) {
+      fwrite(ctx->data, 1, ctx->data_len, f);
+      fclose(f);
+    }
+  }
+}
+
+// Runs in main event loop after worker completes
+static void preconf_remote_complete(uv_work_t* work, int status) {
+  preconf_remote_fetch_t* ctx = (preconf_remote_fetch_t*) work->data;
+
+  if (status == 0 && ctx->data && ctx->data_len > 0) {
+    ctx->req->req->response = (bytes_t){.len = ctx->data_len, .data = ctx->data};
+    ctx->data               = NULL; // ownership transferred
+  }
+  else {
+    free(ctx->data);
+    ctx->req->req->error = strdup("Preconf not available locally or on master bridge");
+  }
+
+  c4_internal_call_finish(ctx->req);
+  free(ctx->master_url);
+  free(ctx->cache_path);
+  free(ctx);
+}
+
+// ---- Main preconf handler ----
 
 static void c4_handle_preconf_cb(void* user_data, file_data_t* files, int num_files) {
   single_request_t* r = (single_request_t*) user_data;
-  if (files[0].error)
+
+  if (files[0].error) {
+    // Try master bridge fallback when file is missing and MASTER_KONA_BRIDGE_URL is set
+    if (op_config.master_kona_bridge_url) {
+      const char* preconf_path = r->req->url; // e.g. "preconf/latest"
+      char*       master_url   = bprintf(NULL, "%s/%s", op_config.master_kona_bridge_url, preconf_path);
+
+      // Only cache when requesting a specific block number (not latest/pre_latest symlinks)
+      char* cache_path = NULL;
+      if (files[0].path &&
+          strncmp(preconf_path, "preconf/latest", 14) != 0 &&
+          strncmp(preconf_path, "preconf/pre_latest", 18) != 0) {
+        cache_path = strdup(files[0].path);
+      }
+
+      c4_file_data_array_free(files, num_files, 0);
+
+      preconf_remote_fetch_t* ctx = calloc(1, sizeof(*ctx));
+      ctx->work.data              = ctx;
+      ctx->req                    = r;
+      ctx->master_url             = master_url;
+      ctx->cache_path             = cache_path;
+
+      uv_queue_work(uv_default_loop(), &ctx->work,
+                    preconf_remote_worker, preconf_remote_complete);
+      return;
+    }
+
     r->req->error = strdup(files[0].error);
+  }
   else {
     r->req->response   = files[0].data;
     files[0].data.data = NULL;
   }
+
   c4_file_data_array_free(files, num_files, 0);
   c4_internal_call_finish(r);
 }


### PR DESCRIPTION
## Summary

- **kona-preconf-service**: Neues standalone Rust-Binary (Axum, Port 8080) das OP-Stack Preconfs per P2P-Gossip empfängt und über HTTP bereitstellt
- **SSE-Stream** (`GET /sse`): Notifiziert Prover-Instanzen proaktiv per Server-Sent Events bei jedem neuen Preconf-Block
- **MASTER_KONA_BRIDGE_URL**: Prover-Knoten ohne lokale Preconfs fetchen diese async (libuv + curl) vom zentralen Service und cachen sie lokal
- **Dockerfile**: Eigenständiges Docker-Image für kona-preconf-service, getrennt vom Prover-Image
- **CMake**: `BUILD_KONA_BRIDGE` default `OFF` — Prover-Build hat keine Rust-Abhängigkeit mehr

## HTTP API (kona-preconf-service :8080)

| Endpunkt | Beschreibung |
|---|---|
| `GET /preconf/latest` | Neuestes Preconf (latest.raw) |
| `GET /preconf/pre_latest` | Vorletztes Preconf |
| `GET /preconf/0x{block_hex}` | Spezifischer Block |
| `GET /stats` | JSON-Statistiken |
| `GET /sse` | SSE-Stream: `event: preconf, data: {block_number}` |

## Architecture

```
kona-preconf-service          Prover Node A (shared volume)
  P2P Gossip ──► /data/preconfs/ ◄── direktes Filesystem-Lesen
  HTTP :8080 ─────────────────────►  Fallback via MASTER_KONA_BRIDGE_URL
  SSE  /sse  ─────────────────────►  (optional) proaktiver Prefetch
```

## Test plan

- [ ] `cargo build --bin kona-preconf-service` kompiliert ohne Fehler
- [ ] `CHAIN_ID=8453 OUTPUT_DIR=/tmp/preconfs kona-preconf-service` startet
- [ ] Nach Peer-Discovery: Dateien in `/tmp/preconfs/`, Symlinks `latest.raw` / `pre_latest.raw`
- [ ] `curl http://localhost:8080/preconf/latest` liefert Binärdaten
- [ ] `curl -N http://localhost:8080/sse` streamt neue Block-Events
- [ ] `curl http://localhost:8080/stats` gibt JSON zurück
- [ ] Prover mit `MASTER_KONA_BRIDGE_URL=http://localhost:8080` fetcht und cached Preconfs
- [ ] `docker build -f src/chains/op/kona_bridge/Dockerfile src/chains/op/kona_bridge` baut Image
- [ ] Prover-Build ohne `BUILD_KONA_BRIDGE=ON` hat keine Rust-Abhängigkeit

🤖 Generated with [Claude Code](https://claude.com/claude-code)