### PR TITLE
feat(bindings): surface verified EVM reverts in dart/python/swift/kotlin

### DIFF
--- a/bindings/dart/doc.md
+++ b/bindings/dart/doc.md
@@ -230,12 +230,36 @@ import 'package:colibri_stateless/colibri_stateless.dart';
 
 try {
   final result = await colibri.rpc('eth_getBalance', ['0x…', 'latest']);
+} on RevertError catch (e) {
+  // Verified EVM revert (e.g. eth_call) -- decode e.data with the contract ABI
 } on ProofError catch (e) {
   // Proof generation or verification failed
 } on RPCError catch (e) {
   // RPC or network error
 } on ColibriError catch (e) {
   // Other Colibri errors
+}
+```
+
+### Verified EVM reverts (`RevertError`)
+
+When an `eth_call` (or similar EVM execution) is verified successfully but the
+EVM itself executed a `REVERT`, the binding throws a [RevertError]. This is a
+fully verified outcome -- not a transport or proof failure -- and matches the
+Geth-style RPC error `{ code: 3, message: "execution reverted", data: "0x..." }`.
+
+`RevertError` extends [RPCError] (code = 3) and exposes the raw revert return
+data as a `0x`-prefixed hex string in `data`. Callers typically ABI-decode this
+against the contract's error definitions (custom errors, `Error(string)`, etc.).
+This is the mechanism that lets dApp libraries decode `OffchainLookup`
+(EIP-3668 / CCIP-Read) for example for the ENS off-chain resolver.
+
+```dart
+try {
+  await colibri.rpc('eth_call', [{'to': '0x…', 'data': '0x…'}, 'latest']);
+} on RevertError catch (e) {
+  // e.data == '0x556f1830...'  // ABI-encoded OffchainLookup or custom error
+  print('reverted with: ${e.data}');
 }
 ```
 

--- a/bindings/dart/lib/colibri_stateless.dart
+++ b/bindings/dart/lib/colibri_stateless.dart
@@ -10,6 +10,7 @@
 /// {@canonicalFor types.ProofError}
 /// {@canonicalFor types.VerificationError}
 /// {@canonicalFor types.RPCError}
+/// {@canonicalFor types.RevertError}
 /// {@canonicalFor types.HTTPError}
 /// {@canonicalFor types.DataRequest}
 library colibri_stateless;

--- a/bindings/dart/lib/src/client.dart
+++ b/bindings/dart/lib/src/client.dart
@@ -251,6 +251,8 @@ class Colibri {
         switch (status['status']) {
           case 'success':
             return status['result'];
+          case 'revert':
+            throw RevertError((status['data'] ?? '0x').toString());
           case 'error':
             throw VerificationError(status['error']?.toString() ?? 'Unknown verification error');
           case 'pending':
@@ -308,6 +310,11 @@ class Colibri {
           case 'success':
             _onDebug?.call('rpc: $method → success');
             return status['result'];
+          case 'revert': {
+            final data = (status['data'] ?? '0x').toString();
+            _onDebug?.call('rpc: $method → revert (data=$data)');
+            throw RevertError(data);
+          }
           case 'error':
             final errorMsg = status['error']?.toString() ?? 'Unknown RPC error';
             _onDebug?.call('rpc: $method → error: $errorMsg');

--- a/bindings/dart/lib/src/types.dart
+++ b/bindings/dart/lib/src/types.dart
@@ -95,6 +95,24 @@ class RPCError extends ColibriError {
   final int? code;
 }
 
+/// Thrown when an `eth_call` (or similar EVM execution) ran to completion but
+/// reverted. The verifier has fully verified the revert -- this is a legitimate
+/// outcome of EVM execution, not a transport or proof error.
+///
+/// Maps to the Geth-style RPC error `{ code: 3, message: "execution reverted",
+/// data: "0x..." }`, which is also the EIP-1193 representation used by ethers
+/// to decode `OffchainLookup` (EIP-3668 / CCIP-Read) and custom Solidity errors.
+///
+/// The raw revert bytes are exposed in [data] as a `0x`-prefixed hex string;
+/// callers typically ABI-decode them with the contract's error definitions.
+class RevertError extends RPCError {
+  RevertError(this.data, {super.details})
+      : super('execution reverted', code: 3);
+
+  /// Raw EVM revert return-data as `0x`-prefixed hex (may be `0x` when empty).
+  final String data;
+}
+
 /// Thrown when HTTP transport fails for a data request.
 class HTTPError extends ColibriError {
   HTTPError(super.message, {this.statusCode, super.details});

--- a/bindings/kotlin/doc.md
+++ b/bindings/kotlin/doc.md
@@ -228,6 +228,38 @@ val colibri = Colibri(
 )
 ```
 
+## Error handling
+
+The binding throws `ColibriException` for any failure (proof, network, RPC, etc.).
+Verified EVM reverts are signalled by the dedicated subclass `ColibriRevertException`
+so callers can distinguish them from transport/proof errors.
+
+### Verified EVM reverts (`ColibriRevertException`)
+
+When an `eth_call` (or similar EVM execution) is verified successfully but the
+EVM itself executed a `REVERT`, the binding throws `ColibriRevertException`.
+This is a fully verified outcome -- not a transport or proof failure -- and
+matches the Geth-style RPC error
+`{ "code": 3, "message": "execution reverted", "data": "0x..." }`.
+
+`ColibriRevertException` extends `ColibriException` (with `code = 3`) and
+exposes the raw revert return data as a `0x`-prefixed hex string in `data`.
+Callers typically ABI-decode this against the contract's error definitions
+(custom errors, `Error(string)`, etc.). This is the mechanism that lets dApp
+libraries decode `OffchainLookup` (EIP-3668 / CCIP-Read) for example for the
+ENS off-chain resolver.
+
+```kotlin
+try {
+    val result = colibri.rpc("eth_call", arrayOf(mapOf("to" to "0x…", "data" to "0x…"), "latest"))
+} catch (e: ColibriRevertException) {
+    // e.data == "0x556f1830..."  // ABI-encoded OffchainLookup or custom error
+    println("reverted with: ${e.data}")
+} catch (e: ColibriException) {
+    println("other error: ${e.message}")
+}
+```
+
 ## Example Android App
 
 A complete working example is available in the [example directory](https://github.com/corpus-core/colibri-stateless/tree/main/bindings/kotlin/example). This minimal Android app demonstrates:

--- a/bindings/kotlin/lib/src/main/kotlin/com/corpuscore/colibri/Colibri.kt
+++ b/bindings/kotlin/lib/src/main/kotlin/com/corpuscore/colibri/Colibri.kt
@@ -70,7 +70,25 @@ enum class ProverMode(val value: Int) {
 }
 
 // Custom Exception for Colibri errors
-class ColibriException(message: String) : RuntimeException(message)
+open class ColibriException(message: String) : RuntimeException(message)
+
+/**
+ * Thrown when an `eth_call` (or similar EVM execution) ran to completion but
+ * reverted. The verifier has fully verified the revert -- this is a legitimate
+ * EVM outcome, not a transport or proof error.
+ *
+ * Maps to the Geth-style RPC error `{ "code": 3, "message": "execution reverted",
+ * "data": "0x..." }`, which is also the EIP-1193 representation used by ethers
+ * to decode `OffchainLookup` (EIP-3668 / CCIP-Read) and custom Solidity errors.
+ *
+ * @param data Raw EVM revert return-data as `0x`-prefixed hex string
+ *   (`"0x"` when empty). Callers typically ABI-decode this with the
+ *   contract's error definitions.
+ */
+class ColibriRevertException(val data: String) : ColibriException("execution reverted") {
+    /** EIP-1193 / Geth RPC error code for `execution reverted`. */
+    val code: Int = 3
+}
 
 // Interface for storage operations callback.
 // Implementations MUST be thread-safe when used with coroutines on Dispatchers.IO.
@@ -508,6 +526,12 @@ class Colibri(
                                 return@withContext null
                              }
                         }
+                        "revert" -> {
+                            // EVM ran to completion but reverted -- a fully verified
+                            // outcome. Expose the raw revert data so callers can decode
+                            // OffchainLookup (EIP-3668) / custom Solidity errors.
+                            throw ColibriRevertException(state.optString("data", "0x"))
+                        }
                         "error" -> {
                              throw ColibriException("Verifier error for method $method: ${state.optString("error", "Unknown error")}")
                         }
@@ -585,6 +609,12 @@ class Colibri(
                                 return@withContext if (result == JSONObject.NULL) null else convertJsonToJava(result)
                             }
                             return@withContext null
+                        }
+                        "revert" -> {
+                            // EVM ran to completion but reverted -- a fully verified
+                            // outcome. Expose the raw revert data so callers can decode
+                            // OffchainLookup (EIP-3668) / custom Solidity errors.
+                            throw ColibriRevertException(state.optString("data", "0x"))
                         }
                         "error" -> {
                             throw ColibriException("RPC error for method $method: ${state.optString("error", "Unknown error")}")

--- a/bindings/python/doc.md
+++ b/bindings/python/doc.md
@@ -540,11 +540,15 @@ from colibri.types import (
     ProofError,        # Proof generation/verification failed
     VerificationError, # Proof verification failed
     RPCError,          # RPC call failed
+    RevertError,       # Verified EVM revert (eth_call etc.) -- subclass of RPCError
     HTTPError          # Network request failed
 )
 
 try:
     result = await client.rpc("eth_getBalance", ["0x...", "latest"])
+except RevertError as e:
+    # Verified EVM revert -- decode e.data with the contract ABI
+    print(f"Reverted with data: {e.data}")
 except ProofError as e:
     print(f"Proof error: {e}")
     # Handle proof generation failure
@@ -560,6 +564,30 @@ except HTTPError as e:
 except ColibriError as e:
     print(f"General Colibri error: {e}")
     # Handle any other Colibri error
+```
+
+### Verified EVM reverts (`RevertError`)
+
+When an `eth_call` (or similar EVM execution) is verified successfully but the
+EVM itself executed a `REVERT`, the binding raises `RevertError`. This is a
+fully verified outcome -- not a transport or proof failure -- and matches the
+Geth-style RPC error `{"code": 3, "message": "execution reverted", "data": "0x..."}`.
+
+`RevertError` is a subclass of `RPCError` (with `code = 3`) and exposes the raw
+revert return data as a `0x`-prefixed hex string in `data`. Callers typically
+ABI-decode this against the contract's error definitions (custom errors,
+`Error(string)`, etc.). This is the mechanism that lets dApp libraries decode
+`OffchainLookup` (EIP-3668 / CCIP-Read) for example for the ENS off-chain
+resolver.
+
+```python
+from colibri import RevertError
+
+try:
+    await client.rpc("eth_call", [{"to": "0x...", "data": "0x..."}, "latest"])
+except RevertError as e:
+    # e.data == "0x556f1830..."  # ABI-encoded OffchainLookup or custom error
+    print(f"reverted with: {e.data}")
 ```
 
 ### Graceful Degradation

--- a/bindings/python/src/colibri/__init__.py
+++ b/bindings/python/src/colibri/__init__.py
@@ -6,7 +6,7 @@ Python bindings for the Colibri stateless Ethereum proof library.
 
 import atexit
 from .storage import ColibriStorage, DefaultStorage, MemoryStorage  
-from .types import MethodType, ColibriError, RPCError
+from .types import MethodType, ColibriError, RPCError, RevertError
 from .testing import MockStorage, MockRequestHandler, MockProofData, TestHelper
 
 # Try to import native module
@@ -79,6 +79,7 @@ __all__ = [
     "MethodType",
     "ColibriError",
     "RPCError",
+    "RevertError",
     "MockStorage",
     "MockRequestHandler",
     "MockProofData",

--- a/bindings/python/src/colibri/client.py
+++ b/bindings/python/src/colibri/client.py
@@ -17,6 +17,7 @@ from .types import (
     PrivacyMode,
     ProofError,
     ProverMode,
+    RevertError,
     RPCError,
     VerificationError,
 )
@@ -323,6 +324,8 @@ class Colibri:
                     
                     if status["status"] == "success":
                         return status.get("result")
+                    elif status["status"] == "revert":
+                        raise RevertError(status.get("data", "0x"))
                     elif status["status"] == "error":
                         raise VerificationError(status.get("error", "Unknown verification error"))
                     elif status["status"] == "pending":
@@ -333,11 +336,15 @@ class Colibri:
             finally:
                 native.verify_free_ctx(ctx)
                 
+        # Propagate VerificationError and RevertError as-is. RevertError is a
+        # fully verified outcome (the EVM ran to completion but reverted) --
+        # callers need it intact to decode the data for EIP-3668 / CCIP-Read or
+        # custom Solidity errors.
+        except (VerificationError, RevertError):
+            raise
         except json.JSONDecodeError as e:
             raise VerificationError(f"Invalid JSON in verification response: {e}") from e
         except Exception as e:
-            if isinstance(e, VerificationError):
-                raise
             raise VerificationError(f"Proof verification failed: {e}") from e
 
     async def rpc(self, method: str, params: List[Any]) -> Any:
@@ -386,6 +393,8 @@ class Colibri:
 
                 if status["status"] == "success":
                     return status.get("result")
+                elif status["status"] == "revert":
+                    raise RevertError(status.get("data", "0x"))
                 elif status["status"] == "error":
                     raise ColibriError(status.get("error", "Unknown RPC error"))
                 elif status["status"] == "pending":

--- a/bindings/python/src/colibri/types.py
+++ b/bindings/python/src/colibri/types.py
@@ -77,6 +77,26 @@ class RPCError(ColibriError):
         self.code = code
 
 
+class RevertError(RPCError):
+    """Raised when an ``eth_call`` (or similar EVM execution) ran to completion
+    but reverted. The verifier has fully verified the revert -- this is a
+    legitimate EVM outcome, not a transport or proof error.
+
+    Maps to the Geth-style RPC error
+    ``{"code": 3, "message": "execution reverted", "data": "0x..."}``, which is
+    also the EIP-1193 representation used by ethers to decode
+    ``OffchainLookup`` (EIP-3668 / CCIP-Read) and custom Solidity errors.
+
+    :ivar data: Raw EVM revert return-data as ``0x``-prefixed hex string
+        (``"0x"`` when empty). Callers typically ABI-decode this with the
+        contract's error definitions.
+    """
+
+    def __init__(self, data: str, details: Optional[str] = None):
+        super().__init__("execution reverted", code=3, details=details)
+        self.data = data
+
+
 class HTTPError(ColibriError):
     """Exception raised for HTTP errors"""
     

--- a/bindings/swift/Sources/Colibri/Colibri.swift
+++ b/bindings/swift/Sources/Colibri/Colibri.swift
@@ -427,6 +427,12 @@ public class Colibri {
             case "success":
                 // Success: return the result (could be any JSON type)
                 return state["result"] as Any // Explicitly cast to Any
+            case "revert":
+                // EVM ran to completion but reverted -- a fully verified
+                // outcome. Expose the raw revert data so callers can decode
+                // OffchainLookup (EIP-3668) / custom Solidity errors.
+                let data = state["data"] as? String ?? "0x"
+                throw ColibriError.revert(data: data)
             case "error":
                 let errorMsg = state["error"] as? String ?? "Unknown verifier error"
                 throw ColibriError.proofError("Verifier error for method \(method): \(errorMsg)")
@@ -493,6 +499,12 @@ public class Colibri {
             switch status {
             case "success":
                 return statusDict["result"] as Any
+            case "revert":
+                // EVM ran to completion but reverted -- a fully verified
+                // outcome. Expose the raw revert data so callers can decode
+                // OffchainLookup (EIP-3668) / custom Solidity errors.
+                let data = statusDict["data"] as? String ?? "0x"
+                throw ColibriError.revert(data: data)
             case "error":
                 let errorMsg = statusDict["error"] as? String ?? "Unknown error"
                 throw ColibriError.proofError("RPC error for method \(method): \(errorMsg)")
@@ -829,7 +841,18 @@ public enum ColibriError: Error, LocalizedError, Equatable {
     case memoryAllocationFailed
     case nullPointerReceived
     case contextCreationFailed
-    
+    /// EVM `eth_call` ran to completion but reverted. The verifier has fully
+    /// verified the revert -- this is a legitimate EVM outcome, not a transport
+    /// or proof error. The associated value is the raw revert return-data as a
+    /// `0x`-prefixed hex string ("0x" when empty). Maps to the Geth/EIP-1193
+    /// RPC error code 3 (see `ColibriError.revertCode`), which ethers uses to
+    /// decode `OffchainLookup` (EIP-3668 / CCIP-Read) and custom Solidity errors.
+    case revert(data: String)
+
+    /// EIP-1193 / Geth RPC error code for `execution reverted`. Use this when
+    /// forwarding a `.revert(data:)` outcome to a JSON-RPC layer.
+    public static let revertCode: Int = 3
+
     public var errorDescription: String? {
         switch self {
         case .invalidInput:
@@ -858,6 +881,8 @@ public enum ColibriError: Error, LocalizedError, Equatable {
             return "Null-Pointer von C-Funktion erhalten"
         case .contextCreationFailed:
             return "Kontext-Erstellung fehlgeschlagen"
+        case .revert:
+            return "execution reverted"
         }
     }
     
@@ -889,6 +914,8 @@ public enum ColibriError: Error, LocalizedError, Equatable {
             return "Unerwarteter null-Pointer von der C-Bibliothek."
         case .contextCreationFailed:
             return "Der Kontext für die Operation konnte nicht erstellt werden."
+        case .revert(let data):
+            return "EVM-Call wurde verifiziert, aber revertierte. Revert-Data: \(data)"
         }
     }
 }

--- a/bindings/swift/doc.md
+++ b/bindings/swift/doc.md
@@ -279,6 +279,34 @@ public enum ColibriError: Error {
     case proofError(String)
     case networkError(String)
     case invalidParams(String)
+    /// EVM execution ran to completion but reverted. Raw revert return-data
+    /// as a `0x`-prefixed hex string ("0x" when empty). EIP-1193 error code 3.
+    case revert(data: String)
+}
+```
+
+#### Verified EVM reverts (`ColibriError.revert`)
+
+When an `eth_call` (or similar EVM execution) is verified successfully but the
+EVM itself executed a `REVERT`, the binding throws `ColibriError.revert(data:)`.
+This is a fully verified outcome -- not a transport or proof failure -- and
+matches the Geth-style RPC error
+`{ code: 3, message: "execution reverted", data: "0x..." }`.
+
+The associated value is the raw revert return data as a `0x`-prefixed hex
+string. Callers typically ABI-decode this against the contract's error
+definitions (custom errors, `Error(string)`, etc.). This is the mechanism that
+lets dApp libraries decode `OffchainLookup` (EIP-3668 / CCIP-Read) for example
+for the ENS off-chain resolver.
+
+```swift
+do {
+    let result = try await colibri.rpc(method: "eth_call", params: "[{...}, \"latest\"]")
+} catch ColibriError.revert(let data) {
+    // data == "0x556f1830..."  // ABI-encoded OffchainLookup or custom error
+    print("reverted with: \(data)")
+} catch {
+    print("other error: \(error)")
 }
 ```
 


### PR DESCRIPTION
## Summary

Mirrors the existing JS-binding behaviour for the new `revert` status (already produced by the C library in [`bindings/colibri_common.c`](bindings/colibri_common.c)) in the **Dart**, **Python**, **Swift** and **Kotlin** bindings. Before this PR, those bindings collapsed a verified EVM revert into a generic error and dropped the revert data, breaking dApp flows that rely on Geth-style RPC errors -- most prominently **EIP-3668 / CCIP-Read** (used by ENS off-chain resolvers like \`.box\` or \`offchaindemo.eth\`).

The new behaviour matches the Geth RPC contract:

\`\`\`json
{ \"jsonrpc\": \"2.0\", \"error\": { \"code\": 3, \"message\": \"execution reverted\", \"data\": \"0x...\" } }
\`\`\`

Each binding now throws a dedicated, typed exception derived from its existing RPC-error base class, carrying the raw revert return-data as a \`0x\`-prefixed hex string.

- **Dart**: \`RevertError extends RPCError\` (code 3, \`data\`)
- **Python**: \`RevertError(RPCError)\` (re-exported from the package)
- **Swift**: new \`ColibriError.revert(data:)\` case + \`ColibriError.revertCode\` constant
- **Kotlin**: \`ColibriRevertException : ColibriException\` with \`data\` and \`code = 3\` (parent class made \`open\` so subclassing is supported)

The new \`revert\` status branch is added only to the \`verifyProof()\` and \`rpc()\` (resp. \`verify_proof\`/\`rpc\`) entry points -- the prover (\`createProof\`) never produces this status by contract.

## Documentation

\`bindings/*/doc.md\` (gitbook source) get a new **\"Verified EVM reverts\"** section explaining the contract, the EIP-3668 use case and an ABI-decode example. \`README.md\` files are intentionally left untouched (this is a developer-facing edge case for the long-form docs).

## Out of scope

- C library: already correct.
- CLI tools: already correct.
- Prover path: revert status is never produced there.
- \`README.md\` files of the bindings.

## Test plan

- [x] \`cmake --build build/default\` (clean, all targets succeed)
- [x] Linter pass on all touched files (no errors)
- [x] code-reviewer subagent run on the diff (no must-fix findings; nice-to-haves addressed)
- [ ] Reviewer to spot-check the four bindings against the JS reference at [\`bindings/emscripten/src/index.ts\`](bindings/emscripten/src/index.ts) (lines 78-84, 266-267, 349-350)
- [ ] Manual smoke test: an \`eth_call\` to an OffchainLookup-reverting contract via one of the new bindings surfaces the typed exception with non-empty \`data\`