### PR TITLE
ci(release): auto-publish gitbook docs to colibri-stateless-doc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,3 +400,76 @@ jobs:
           else
             echo "- ❌ No Windows installers found" >> $GITHUB_STEP_SUMMARY
           fi
+
+  update-docs:
+    needs: check-workflows-and-tag
+    if: needs.check-workflows-and-tag.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    env:
+      TAG_NAME: ${{ needs.check-workflows-and-tag.outputs.tag_name }}
+    steps:
+      - name: Checkout source repository at release commit
+        uses: actions/checkout@v4
+        with:
+          path: source
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Checkout colibri-stateless-doc repository
+        uses: actions/checkout@v4
+        with:
+          repository: corpus-core/colibri-stateless-doc
+          token: ${{ secrets.DOCS_REPO_TOKEN }}
+          path: docs
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install mermaid-cli
+        run: npm install -g @mermaid-js/mermaid-cli
+
+      - name: Generate documentation
+        working-directory: source
+        env:
+          DOCS_DIR: ${{ github.workspace }}/docs
+          DOCS_GITHUB_REF: ${{ needs.check-workflows-and-tag.outputs.tag_name }}
+        run: node scripts/doc/index.js
+
+      - name: Commit, push and tag documentation
+        working-directory: docs
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No documentation changes detected."
+            DOC_CHANGED=false
+          else
+            git commit -m "docs: update for release ${TAG_NAME}"
+            git push origin HEAD:main
+            DOC_CHANGED=true
+          fi
+
+          # Tag the doc repo with the same release tag so it stays in sync with the
+          # source release. Force-update so re-runs of the same release work.
+          git tag -f "${TAG_NAME}"
+          git push origin "${TAG_NAME}" --force
+
+          echo "doc_changed=${DOC_CHANGED}" >> $GITHUB_ENV
+
+      - name: Create Summary
+        if: always()
+        run: |
+          echo "## Documentation Update Result" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ job.status }}" = "success" ]; then
+            if [ "${doc_changed:-false}" = "true" ]; then
+              echo "✅ Pushed documentation update and tag \`${TAG_NAME}\` to corpus-core/colibri-stateless-doc" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "ℹ️ No documentation changes; only tag \`${TAG_NAME}\` was updated in corpus-core/colibri-stateless-doc" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "❌ Failed to update documentation for tag \`${TAG_NAME}\`" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/scripts/doc/parse_defs.js
+++ b/scripts/doc/parse_defs.js
@@ -134,7 +134,8 @@ function add_function_def(sections, line, doc_comment, file, line_number) {
     let fn = p >= 0 ? last_line.substring(0, p).trim().split(' ').at(-1) : last_line.trim().split(' ').at(-1).replace(';', '').trim()
 
     section.content.push('\n## ' + fn)
-    section.content.push(`[${file.replace('../', '')}](${GITHUB_BLOB_BASE}/src/${file}#L${line_number})`)
+    const display_file = file.startsWith('../') ? file.substring(3) : file
+    section.content.push(`[${display_file}](${GITHUB_BLOB_BASE}/src/${file}#L${line_number})`)
     section.content.push('')
     section.content.push(doc_comment.comment)
     section.content.push('')

--- a/scripts/doc/parse_defs.js
+++ b/scripts/doc/parse_defs.js
@@ -4,7 +4,11 @@ const fs = require('fs');
 const path = require('path');
 const { toCamelCase, get_full_src_path, align, get_doc_path } = require('./utils');
 
-
+// Branch or tag used in generated GitHub source links. Defaults to `dev` for
+// local invocations; release workflows set this to the release tag (e.g. `v1.1.25`)
+// so that documentation links point to the exact code revision of the release.
+const GITHUB_REF = process.env.DOCS_GITHUB_REF || 'dev';
+const GITHUB_BLOB_BASE = `https://github.com/corpus-core/colibri-stateless/blob/${GITHUB_REF}`;
 
 function add_section(line, sections) {
     const regex = /\/\/ (\:+) (.*)/g;
@@ -130,7 +134,7 @@ function add_function_def(sections, line, doc_comment, file, line_number) {
     let fn = p >= 0 ? last_line.substring(0, p).trim().split(' ').at(-1) : last_line.trim().split(' ').at(-1).replace(';', '').trim()
 
     section.content.push('\n## ' + fn)
-    section.content.push(`[${file.replace('../', '')}](https://github.com/corpus-core/colibri-stateless/blob/dev/src/${file}#L${line_number})`)
+    section.content.push(`[${file.replace('../', '')}](${GITHUB_BLOB_BASE}/src/${file}#L${line_number})`)
     section.content.push('')
     section.content.push(doc_comment.comment)
     section.content.push('')
@@ -415,7 +419,7 @@ function create_type(type, types) {
     content.push('\n## ' + type.type + '\n')
     content.push(type.comment)
     content.push('')
-    content.push(`\nThe Type is defined in [src/${type.file}](https://github.com/corpus-core/colibri-stateless/blob/dev/src/${type.file}#L${type.line_number}).\n`)
+    content.push(`\nThe Type is defined in [src/${type.file}](${GITHUB_BLOB_BASE}/src/${type.file}#L${type.line_number}).\n`)
     content.push('')
     content.push('```python')
     content.push('class ' + type.type + '(Container):')


### PR DESCRIPTION
## Summary

- Adds a new `update-docs` job in `.github/workflows/release.yml` that runs in parallel with `create-release` for every tagged release. It checks out `corpus-core/colibri-stateless-doc` via a `DOCS_REPO_TOKEN` PAT, runs `scripts/doc/index.js` against it, commits documentation changes, pushes them to `main` and force-tags the doc repo with the same release tag (e.g. `v1.1.25`).
- Makes the GitHub source links generated by `scripts/doc/parse_defs.js` configurable via a new `DOCS_GITHUB_REF` env variable (default `dev`). The release workflow sets it to the release tag so the generated documentation links point at the exact release revision instead of always pointing at `dev`.

## Why

Until now the gitbook documentation was generated and committed manually after each release. This automates that step on every release, keeping `corpus-core.gitbook.io/specification-colibri-stateless` in sync with the released source, while also tagging the doc repo so its history matches the source releases.

## Prerequisites

- Repository secret `DOCS_REPO_TOKEN` must be set in `corpus-core/colibri-stateless` with write access to `corpus-core/colibri-stateless-doc` (Contents: Read & Write).

## Test plan

- [ ] Push a test tag (or re-run the latest release workflow) and verify:
  - [ ] `update-docs` job runs to completion alongside `create-release`.
  - [ ] A `docs: update for release <tag>` commit appears on `corpus-core/colibri-stateless-doc@main` (if there were any doc changes).
  - [ ] A tag matching the release tag (e.g. `v1.1.25`) is created on `corpus-core/colibri-stateless-doc`.
  - [ ] Generated GitHub source links in the doc repo point at `blob/<release-tag>/src/...` instead of `blob/dev/src/...`.
- [ ] Verify a local `node scripts/doc/index.js` run still produces `blob/dev/...` links (backwards compatibility).