### PR TITLE
Add chain-aware checkpointz defaults across bindings

### DIFF
--- a/bindings/dart/lib/src/client.dart
+++ b/bindings/dart/lib/src/client.dart
@@ -389,7 +389,7 @@ class Colibri {
   List<String> _selectServers(DataRequest request, {required bool useProverFallback}) {
     switch (request.requestType) {
       case 'checkpointz':
-        return checkpointz;
+        return [...checkpointz, ...beaconApis];
       case 'beacon_api':
         if (useProverFallback && provers.isNotEmpty) {
           return [...provers, ...beaconApis];
@@ -487,6 +487,12 @@ List<String> _defaultCheckpointz(int chainId) {
         'https://sync.invis.tools',
         'https://beaconstate.ethstaker.cc',
       ],
+    11155111 => [
+        'https://sepolia.beaconstate.info',
+        'https://checkpoint-sync.sepolia.ethpandaops.io',
+      ],
+    100 => ['https://checkpoint.gnosischain.com'],
+    10200 => ['https://checkpoint.chiadochain.net'],
     _ => <String>[],
   };
 }

--- a/bindings/emscripten/src/chains.ts
+++ b/bindings/emscripten/src/chains.ts
@@ -38,7 +38,12 @@ export const default_config: {
     rpcs: ["https://mainnet1.colibri-proof.tech/execution"],
     beacon_apis: ["https://mainnet1.colibri-proof.tech/consensus/"],
     prover: ["https://mainnet1.colibri-proof.tech"],
-    checkpointz: [], //"https://sync-mainnet.beaconcha.in", "https://beaconstate.info", "https://sync.invis.tools", "https://beaconstate.ethstaker.cc"],
+    checkpointz: [
+      "https://sync-mainnet.beaconcha.in",
+      "https://beaconstate.info",
+      "https://sync.invis.tools",
+      "https://beaconstate.ethstaker.cc",
+    ],
     pollingInterval: 12000,
   },
   '11155111': { // Sepolia
@@ -46,7 +51,10 @@ export const default_config: {
     beacon_apis: ["https://ethereum-sepolia-beacon-api.publicnode.com"],
     rpcs: ["https://ethereum-sepolia-rpc.publicnode.com"],
     prover: ["https://sepolia.colibri-proof.tech"],
-    checkpointz: [], // No public checkpointz for Sepolia yet
+    checkpointz: [
+      "https://sepolia.beaconstate.info",
+      "https://checkpoint-sync.sepolia.ethpandaops.io",
+    ],
     pollingInterval: 12000,
   },
   '100': { // gnosis
@@ -54,7 +62,7 @@ export const default_config: {
     beacon_apis: ["https://gnosis.colibri-proof.tech"],
     rpcs: ["https://rpc.ankr.com/gnosis"],
     prover: ["https://gnosis.colibri-proof.tech"],
-    checkpointz: [], // TODO: Add Gnosis checkpointz servers
+    checkpointz: ["https://checkpoint.gnosischain.com"],
     pollingInterval: 5000,
   },
   '10200': { // gnosis chiado
@@ -62,7 +70,10 @@ export const default_config: {
     beacon_apis: ["https://chiado.colibri-proof.tech/consensus/"],
     rpcs: ["https://gnosis-chiado-rpc.publicnode.com"],
     prover: ["https://chiado.colibri-proof.tech"],
-    checkpointz: ["https://chiado.colibri-proof.tech/consensus/"], // No public checkpointz for Chiado yet
+    checkpointz: [
+      "https://checkpoint.chiadochain.net",
+      "https://chiado.colibri-proof.tech/consensus/",
+    ],
     pollingInterval: 5000,
   },
 };

--- a/bindings/kotlin/lib/src/main/kotlin/com/corpuscore/colibri/Colibri.kt
+++ b/bindings/kotlin/lib/src/main/kotlin/com/corpuscore/colibri/Colibri.kt
@@ -123,7 +123,7 @@ class Colibri(
     var provers: Array<String> = arrayOf("https://c4.incubed.net"), // Default value
     var ethRpcs: Array<String> = arrayOf("https://rpc.ankr.com/eth"), // Default value
     var beaconApis: Array<String> = arrayOf("https://lodestar-mainnet.chainsafe.io"), // Default value
-    var checkpointz: Array<String> = arrayOf("https://sync-mainnet.beaconcha.in", "https://beaconstate.info", "https://sync.invis.tools", "https://beaconstate.ethstaker.cc"), // Default checkpointz servers
+    var checkpointz: Array<String> = emptyArray(),
     var obliviousNodes: Array<String> = emptyArray(), // TEE RPC endpoints for eth_getProof
     var trustedCheckpoint: String? = null, // Optional trusted checkpoint
     var includeCode: Boolean = false, // Default value
@@ -156,6 +156,23 @@ class Colibri(
 //            println("ColibriStorage implementation registered.")
             // Optionally, trigger C-side re-configuration if needed, but likely handled at init.
         }
+
+        /** Default checkpointz URLs for supported chains. */
+        fun defaultCheckpointz(chainId: BigInteger): Array<String> = when (chainId) {
+            BigInteger.ONE -> arrayOf(
+                "https://sync-mainnet.beaconcha.in",
+                "https://beaconstate.info",
+                "https://sync.invis.tools",
+                "https://beaconstate.ethstaker.cc",
+            )
+            BigInteger.valueOf(11155111) -> arrayOf(
+                "https://sepolia.beaconstate.info",
+                "https://checkpoint-sync.sepolia.ethpandaops.io",
+            )
+            BigInteger.valueOf(100) -> arrayOf("https://checkpoint.gnosischain.com")
+            BigInteger.valueOf(10200) -> arrayOf("https://checkpoint.chiadochain.net")
+            else -> emptyArray()
+        }
     }
     private val client = HttpClient(CIO) {
         engine {
@@ -175,7 +192,10 @@ class Colibri(
     private fun serversForRequest(request: JSONObject, useProverFallback: Boolean = false): Array<String> {
         val type = request.optString("type", "eth_rpc")
         return when (type) {
-            "checkpointz" -> checkpointz
+            "checkpointz" -> {
+                val configured = if (checkpointz.isEmpty()) defaultCheckpointz(chainId) else checkpointz
+                configured + beaconApis
+            }
             "beacon_api" -> if (useProverFallback && provers.isNotEmpty()) provers else beaconApis
             "prover" -> provers
             else -> {

--- a/bindings/python/src/colibri/client.py
+++ b/bindings/python/src/colibri/client.py
@@ -152,10 +152,18 @@ class Colibri:
     def _get_default_checkpointz(chain_id: int) -> List[str]:
         """Get default checkpointz URLs for chain"""
         defaults = {
-            1: ["https://sync-mainnet.beaconcha.in", "https://beaconstate.info", "https://sync.invis.tools", "https://beaconstate.ethstaker.cc"],
-            11155111: [],  # No public checkpointz for Sepolia yet
-            100: [],  # TODO: Add Gnosis checkpointz servers
-            10200: [],  # No public checkpointz for Chiado yet
+            1: [
+                "https://sync-mainnet.beaconcha.in",
+                "https://beaconstate.info",
+                "https://sync.invis.tools",
+                "https://beaconstate.ethstaker.cc",
+            ],
+            11155111: [
+                "https://sepolia.beaconstate.info",
+                "https://checkpoint-sync.sepolia.ethpandaops.io",
+            ],
+            100: ["https://checkpoint.gnosischain.com"],
+            10200: ["https://checkpoint.chiadochain.net"],
         }
         return defaults.get(chain_id, [])
 
@@ -471,7 +479,7 @@ class Colibri:
 
                 # Determine server list
                 if request.request_type == "checkpointz":
-                    servers = self.checkpointz
+                    servers = list(self.checkpointz) + list(self.beacon_apis)
                 elif request.request_type == "prover":
                     servers = self.provers
                 elif request.request_type == "beacon_api":

--- a/bindings/swift/Sources/Colibri/Colibri.swift
+++ b/bindings/swift/Sources/Colibri/Colibri.swift
@@ -236,7 +236,7 @@ public class Colibri {
     public var eth_rpcs: [String] = []
     public var beacon_apis: [String] = []
     public var provers: [String] = ["https://c4.incubed.net"]
-    public var checkpointz: [String] = ["https://sync-mainnet.beaconcha.in", "https://beaconstate.info", "https://sync.invis.tools", "https://beaconstate.ethstaker.cc"]
+    public var checkpointz: [String] = []
     /// TEE RPC endpoints for eth_getProof (privacy-preserving storage reads).
     public var obliviousNodes: [String] = []
     public var trustedCheckpoint: String? = nil
@@ -258,6 +258,30 @@ public class Colibri {
     private var lightClientTimer: DispatchSourceTimer?
 
     public init() {}
+
+    /// Default checkpointz URLs for supported chains.
+    public static func defaultCheckpointz(for chainId: UInt64) -> [String] {
+        switch chainId {
+        case 1:
+            return [
+                "https://sync-mainnet.beaconcha.in",
+                "https://beaconstate.info",
+                "https://sync.invis.tools",
+                "https://beaconstate.ethstaker.cc",
+            ]
+        case 11155111:
+            return [
+                "https://sepolia.beaconstate.info",
+                "https://checkpoint-sync.sepolia.ethpandaops.io",
+            ]
+        case 100:
+            return ["https://checkpoint.gnosischain.com"]
+        case 10200:
+            return ["https://checkpoint.chiadochain.net"]
+        default:
+            return []
+        }
+    }
 
     public static func initialize() {
         // Placeholder for initialization if needed
@@ -574,7 +598,10 @@ public class Colibri {
                     let requestType = request["type"] as? String
                     let servers: [String]
                     if requestType == "checkpointz" {
-                        servers = self.checkpointz
+                        let configured = self.checkpointz.isEmpty
+                            ? Colibri.defaultCheckpointz(for: self.chainId)
+                            : self.checkpointz
+                        servers = configured + self.beacon_apis
                     } else if requestType == "prover" {
                         servers = self.provers
                     } else if requestType == "beacon_api" && useProverFallback && !self.provers.isEmpty {


### PR DESCRIPTION
## Summary

- Set public checkpoint sync defaults per chain in TypeScript, Python, Dart, Swift, and Kotlin (mainnet, Sepolia, Gnosis, Chiado).
- Refactor Swift/Kotlin: empty `checkpointz` by default; resolve chain-specific URLs at request time via `defaultCheckpointz`.
- Add `checkpointz → beacon_apis` fallback in Python, Dart, Swift, and Kotlin (TypeScript already had this in `http.ts`).

## Default URLs

| Chain | Checkpointz endpoints |
|-------|----------------------|
| Mainnet (1) | beaconcha.in, beaconstate.info, sync.invis.tools, beaconstate.ethstaker.cc |
| Sepolia (11155111) | sepolia.beaconstate.info, checkpoint-sync.sepolia.ethpandaops.io |
| Gnosis (100) | checkpoint.gnosischain.com |
| Chiado (10200) | checkpoint.chiadochain.net (+ existing colibri consensus URL in TS) |

## Test plan

- [x] `cmake --build build/default` succeeds
- [ ] Verify light client bootstrap on mainnet with default config (no explicit `checkpointz`)
- [ ] Verify Gnosis chain uses `checkpoint.gnosischain.com` when `checkpointz` is unset
- [ ] Confirm explicit `checkpointz=[]` still falls back to `beacon_apis` in Python/Dart/Swift/Kotlin