### PR TITLE
hardening(wsp): apply review fixes for historic_proof anchor

### DIFF
--- a/src/chains/eth/prover/historic_proof.c
+++ b/src/chains/eth/prover/historic_proof.c
@@ -156,15 +156,13 @@ static c4_status_t get_historical_summaries(prover_ctx_t* ctx, beacon_block_t* b
    */
 }
 
-// Records an error either to the provided state (prover path) or via log_warn
-// (server-side path with no state). Returns C4_ERROR for convenience.
+// Records an error either to the provided state (prover path, uses the
+// canonical `c4_state_add_error` so existing errors are preserved and chained,
+// not leaked) or via log_warn (server-side path with no state).
+// Returns C4_ERROR for convenience.
 static c4_status_t historic_merkle_error(c4_state_t* state, const char* msg) {
-  if (state) {
-    state->error = strdup(msg);
-  }
-  else {
-    log_warn("%s", msg);
-  }
+  if (state) return c4_state_add_error(state, msg);
+  log_warn("%s", msg);
   return C4_ERROR;
 }
 
@@ -190,6 +188,11 @@ c4_status_t c4_build_historic_merkle_proof(
   buffer_t buf      = stack_buffer(tmp);
 
   uint32_t  offset_period  = (uint32_t) (chain->fork_epochs[C4_FORK_BELLATRIX] >> chain->epochs_per_period_bits);
+  // historical_summaries first appears at the Capella fork; periods before
+  // that have no corresponding summary entry, so refuse to build a proof
+  // (otherwise `summary_idx` would underflow uint64 -> uint32).
+  if (block_period < offset_period)
+    return historic_merkle_error(state, "block_period predates historical_summaries fork");
   fork_id_t fork           = c4_chain_fork_id(chain_id, epoch_for_slot(recent_state_slot, chain)); // fork for the recent state
   json_t    data           = json_get(history_proof, "data");
   uint32_t  summary_idx    = (uint32_t) (block_period - offset_period);                            // index from Capella fork (first summary entry)

--- a/src/chains/eth/prover/historic_proof_zk.c
+++ b/src/chains/eth/prover/historic_proof_zk.c
@@ -84,11 +84,9 @@ static c4_status_t choose_snapshot_slot(prover_ctx_t* ctx, uint64_t period, uint
     }
   }
 
-  // Clear any error from the index lookup; absence is not fatal.
-  if (ctx->state.error) {
-    safe_free(ctx->state.error);
-    ctx->state.error = NULL;
-  }
+  // Clear any error from the index lookup; absence is not fatal. saved_err is
+  // restored unconditionally (it overwrites whatever the lookup left behind).
+  if (ctx->state.error) safe_free(ctx->state.error);
   ctx->state.error = saved_err;
   return C4_SUCCESS;
 }
@@ -119,7 +117,7 @@ c4_status_t c4_fetch_zk_proof_data(prover_ctx_t* ctx, zk_proof_data_t* zk_proof,
   TRY_ADD_ASYNC(status, c4_send_internal_request(ctx, (char*) buf.data.data, NULL, 0, &zk_proof->sync_proof.bytes));
 
   if (ctx->witness_key.len && ctx->witness_key.len % 20 == 0) {
-    for (int i = 0; i < (int) ctx->witness_key.len; i += 20) {
+    for (uint32_t i = 0; i < ctx->witness_key.len; i += 20) {
       buffer_reset(&buf);
       bytes_t     sig_data   = {0};
       c4_status_t sig_status = c4_send_internal_request(ctx, bprintf(&buf, "period_store/%l/sig_%x", period, bytes(ctx->witness_key.data + i, 20)), NULL, 0, &sig_data);

--- a/src/chains/eth/server/period_store.c
+++ b/src/chains/eth/server/period_store.c
@@ -4,6 +4,16 @@
 #include "period_store_zk_prover.h"
 #include <unistd.h>
 
+// Slave-mode helper: remove the locally cached `snapshots.idx` so the next
+// prover request triggers a fresh fetch from the master (see explanation in
+// `c4_period_sync_on_checkpoint`).
+static void invalidate_local_snapshots_idx(uint64_t period) {
+  if (!eth_config.period_store) return;
+  char* path = bprintf(NULL, "%s/%l/snapshots.idx", eth_config.period_store, period);
+  unlink(path);
+  safe_free(path);
+}
+
 bool c4_ps_file_exists(uint64_t period, const char* filename) {
   char*       path = bprintf(NULL, "%s/%l/%s", eth_config.period_store, period, filename);
   struct stat buffer;
@@ -36,7 +46,8 @@ void c4_period_sync_on_checkpoint(bytes32_t checkpoint, uint64_t slot) {
     c4_period_prover_on_checkpoint(period);
 
     // Master: schedule a fresh historic_proof snapshot for the periods we just rebuilt.
-    // First-success cascade over (finalized, justified, head epoch boundary) anchor candidates.
+    // MVP uses `slot` (finalized) as anchor; cascade over justified / head epoch boundary
+    // is documented as TODO in `c4_ps_build_historic_proof_snapshot`.
     if (c4_ps_file_exists(period, "zk_proof.ssz")) c4_ps_build_historic_proof_snapshot(period, slot);
     if (c4_ps_file_exists(period + 1, "zk_proof.ssz")) c4_ps_build_historic_proof_snapshot(period + 1, slot);
   }
@@ -48,15 +59,11 @@ void c4_period_sync_on_checkpoint(bytes32_t checkpoint, uint64_t slot) {
     // request and treats them as immutable forever after. That is correct for
     // `zk_proof_checkpoint_${slot}.ssz` (each slot has exactly one canonical
     // snapshot), but wrong for `snapshots.idx` which grows whenever the master
-    // builds a new snapshot. To keep slave responses fresh, invalidate the local
-    // copy of the index for the current and next period on every checkpoint
-    // event -- the next prover request will then re-fetch the latest index from
-    // the master via the existing `c4_handle_period_master_cb` path.
-    char* idx_path      = bprintf(NULL, "%s/%l/snapshots.idx", eth_config.period_store, period);
-    char* idx_path_next = bprintf(NULL, "%s/%l/snapshots.idx", eth_config.period_store, period + 1);
-    unlink(idx_path);
-    unlink(idx_path_next);
-    safe_free(idx_path);
-    safe_free(idx_path_next);
+    // builds a new snapshot. Invalidate the local copy of the index for the
+    // current and next period on every checkpoint event -- the next prover
+    // request will then re-fetch the latest index from the master via the
+    // existing `c4_handle_period_master_cb` path.
+    invalidate_local_snapshots_idx(period);
+    invalidate_local_snapshots_idx(period + 1);
   }
 }

--- a/src/chains/eth/server/period_store.h
+++ b/src/chains/eth/server/period_store.h
@@ -46,11 +46,12 @@ void     c4_build_zk_sync_proof_data(uint64_t period);
  * `historical_summaries` and the beacon header for the anchor slot, the merkle
  * proof construction and the file write happen via libuv callbacks.
  *
- * The anchor slot is chosen via a first-success fallback cascade over
- *   `[finalized_slot, finalized_slot + 32, finalized_slot + 64]`
- * (finalized -> justified -> head epoch boundary). Whichever candidate first
- * answers with both a `historical_summaries` response (Lodestar) and a beacon
- * header (Beacon API) is used as the anchor; subsequent candidates are skipped.
+ * MVP behaviour: the anchor slot is always `finalized_slot`. A planned
+ * first-success fallback cascade over `[finalized_slot, finalized_slot + 32,
+ * finalized_slot + 64]` (finalized -> justified -> head epoch boundary) is
+ * tracked as a `TODO` inside the implementation; when Lodestar's
+ * `historical_summaries` endpoint is unavailable for `finalized_slot` the
+ * build is currently skipped and retried on the next checkpoint event.
  *
  * On success the snapshot file is written and `snapshots.idx` for the period
  * is updated atomically. Old snapshots outside the checkpointz cache window

--- a/src/chains/eth/server/period_store_zk_historic.c
+++ b/src/chains/eth/server/period_store_zk_historic.c
@@ -46,9 +46,11 @@
 // anchors. Public checkpointz instances retain ~30 finalized snapshots which
 // roughly corresponds to 6 hours, hence 1800 slots at 12s/slot.
 #define CHECKPOINTZ_WINDOW_SLOTS 1800u
-
-// SSZ definition for blocks.ssz (must match period_store_historical_roots.c).
-static const ssz_def_t BLOCKS_DEF = SSZ_VECTOR("blocks", ssz_bytes32, SLOTS_PER_PERIOD);
+// Sanity cap for snapshots.idx entries. One snapshot per finalized SSE event
+// (~6 min) within the checkpointz window yields at most ~60 slots; we cap
+// generously so a corrupted local file does not trigger a huge `safe_calloc`
+// abort. Also bounds the `4 + count * 8` byte calculation on 32-bit platforms.
+#define SNAPSHOTS_IDX_MAX_COUNT  4096u
 
 typedef struct {
   uint64_t period;
@@ -101,8 +103,14 @@ static bool snapshots_idx_load(uint64_t period, uint64_t** out_slots, uint32_t* 
     fclose(f);
     return true;
   }
+  if (count > SNAPSHOTS_IDX_MAX_COUNT) {
+    log_warn("period_store: snapshots.idx for period %l has implausible count %u (max %u), treating as missing",
+             period, count, SNAPSHOTS_IDX_MAX_COUNT);
+    fclose(f);
+    return false;
+  }
 
-  uint64_t* slots = (uint64_t*) safe_calloc(count, sizeof(uint64_t));
+  uint64_t* slots = safe_calloc(count, sizeof(uint64_t));
   uint8_t   buf[8];
   for (uint32_t i = 0; i < count; i++) {
     if (fread(buf, 1, 8, f) != 8) {
@@ -266,79 +274,113 @@ static void snapshot_write_cb(void* user_data, file_data_t* files, int num_files
 // Builds a 112-byte BeaconBlockHeader from the JSON response of
 // `eth/v1/beacon/headers/${slot}` (message section). Writes into `out` (must
 // be at least HEADER_SSZ_SIZE bytes).
+//
+// The string-length pre-checks guard against an oversized hex value from a
+// malicious / compromised beacon API: `json_as_bytes` sets `buffer->data.len`
+// to the input JSON token length, and the downstream `hex_to_bytes` capacity
+// check then uses that length instead of the true fixed-buffer capacity, so
+// a longer hex value would overflow the 32-byte slot inside our 112-byte
+// stack array. Refusing anything but `"0x" + 64 hex chars` (= 66 chars)
+// closes that path here without requiring a `json_as_bytes` rewrite.
 static bool encode_beacon_block_header_from_json(json_t header_message, uint8_t* out) {
   if (header_message.type != JSON_TYPE_OBJECT) return false;
+
+  json_t parent = json_get(header_message, "parent_root");
+  json_t state  = json_get(header_message, "state_root");
+  json_t body   = json_get(header_message, "body_root");
+  if (parent.type != JSON_TYPE_STRING || parent.len != 66 ||
+      state.type != JSON_TYPE_STRING || state.len != 66 ||
+      body.type != JSON_TYPE_STRING || body.len != 66) return false;
 
   uint64_to_le(out + 0, json_get_uint64(header_message, "slot"));
   uint64_to_le(out + 8, json_get_uint64(header_message, "proposer_index"));
 
-  buffer_t parent_buf = {.data = {.data = out + 16, .len = 32}, .allocated = -32};
-  buffer_t state_buf  = {.data = {.data = out + 48, .len = 32}, .allocated = -32};
-  buffer_t body_buf   = {.data = {.data = out + 80, .len = 32}, .allocated = -32};
+  buffer_t parent_buf = {.data = {.data = out + 16, .len = 0}, .allocated = -32};
+  buffer_t state_buf  = {.data = {.data = out + 48, .len = 0}, .allocated = -32};
+  buffer_t body_buf   = {.data = {.data = out + 80, .len = 0}, .allocated = -32};
 
-  bytes_t parent = json_get_bytes(header_message, "parent_root", &parent_buf);
-  bytes_t state  = json_get_bytes(header_message, "state_root", &state_buf);
-  bytes_t body   = json_get_bytes(header_message, "body_root", &body_buf);
-  return parent.len == 32 && state.len == 32 && body.len == 32;
+  bytes_t parent_dec = json_as_bytes(parent, &parent_buf);
+  bytes_t state_dec  = json_as_bytes(state, &state_buf);
+  bytes_t body_dec   = json_as_bytes(body, &body_buf);
+  return parent_dec.len == 32 && state_dec.len == 32 && body_dec.len == 32;
+}
+
+// Reads `zk_proof.ssz` for the given period synchronously. Returns NULL_BYTES on
+// any failure (caller treats that as "skip snapshot, retry next event").
+static bytes_t read_legacy_zk_proof(uint64_t period) {
+  bytes_t out  = NULL_BYTES;
+  char*   path = bprintf(NULL, "%s/%l/zk_proof.ssz", eth_config.period_store, period);
+  FILE*   lf   = fopen(path, "rb");
+  safe_free(path);
+  if (!lf) return out;
+  fseek(lf, 0, SEEK_END);
+  long sz = ftell(lf);
+  fseek(lf, 0, SEEK_SET);
+  if (sz > 0) {
+    out.data = safe_malloc((uint32_t) sz);
+    out.len  = (uint32_t) fread(out.data, 1, (size_t) sz, lf);
+  }
+  fclose(lf);
+  return out;
 }
 
 static void try_complete_build(build_ctx_t* bctx) {
+  // All heap allocations declared up-front so the single `cleanup:` label can
+  // free everything that was actually allocated (NULL/zeroed values are no-ops).
+  char*         hdr_str            = NULL;
+  char*         sum_str            = NULL;
+  bytes_t       merkle_proof       = NULL_BYTES;
+  bytes_t       legacy_bytes       = NULL_BYTES;
+  ssz_builder_t builder            = {0};
+  ssz_builder_t checkpoint_builder = {0};
+  file_data_t   out_file           = {0};
+  bool          write_scheduled    = false;
+
   if (bctx->any_failed) {
     log_debug("period_store: historic_proof snapshot build for period %l slot %l aborted (one or more fetches failed)",
               bctx->period, bctx->anchor_slot);
-    build_ctx_free(bctx);
-    return;
+    goto cleanup;
   }
 
   // Decode period attested header from sync.ssz
-  const ssz_def_t* verify_request_def = eth_ssz_verification_type(ETH_SSZ_VERIFY_REQUEST);
-  ssz_ob_t         sync               = {.def = verify_request_def, .bytes = bctx->sync_ssz};
-  ssz_ob_t         proof              = ssz_get(&sync, "proof");
-  uint64_t         attested_slot      = ssz_get_uint64(&proof, "slot");
+  ssz_ob_t sync          = {.def = eth_ssz_verification_type(ETH_SSZ_VERIFY_REQUEST), .bytes = bctx->sync_ssz};
+  ssz_ob_t proof         = ssz_get(&sync, "proof");
+  uint64_t attested_slot = ssz_get_uint64(&proof, "slot");
   if (attested_slot == 0) {
     log_warn("period_store: invalid sync.ssz for period %l (no slot)", bctx->period);
-    build_ctx_free(bctx);
-    return;
+    goto cleanup;
   }
   uint64_t block_period = attested_slot >> 13;
   uint64_t block_idx    = attested_slot & (SLOTS_PER_PERIOD - 1);
 
-  // Parse JSON responses
-  char* hdr_str = (char*) safe_calloc(1, bctx->header_response.len + 1);
+  // Parse JSON responses: json_parse() mutates the buffer, so we duplicate.
+  hdr_str = (char*) safe_calloc(1, bctx->header_response.len + 1);
   memcpy(hdr_str, bctx->header_response.data, bctx->header_response.len);
   json_t hdr_doc = json_parse(hdr_str);
   json_t hdr_msg = json_get(json_get(json_get(hdr_doc, "data"), "header"), "message");
   if (hdr_msg.type != JSON_TYPE_OBJECT) {
     log_warn("period_store: invalid header response for slot %l", bctx->anchor_slot);
-    safe_free(hdr_str);
-    build_ctx_free(bctx);
-    return;
+    goto cleanup;
   }
   uint8_t anchor_header[HEADER_SSZ_SIZE] = {0};
   if (!encode_beacon_block_header_from_json(hdr_msg, anchor_header)) {
     log_warn("period_store: failed to encode anchor header for slot %l", bctx->anchor_slot);
-    safe_free(hdr_str);
-    build_ctx_free(bctx);
-    return;
+    goto cleanup;
   }
 
-  char* sum_str = (char*) safe_calloc(1, bctx->summaries_response.len + 1);
+  sum_str = (char*) safe_calloc(1, bctx->summaries_response.len + 1);
   memcpy(sum_str, bctx->summaries_response.data, bctx->summaries_response.len);
   json_t sum_doc = json_parse(sum_str);
   if (json_get(sum_doc, "data").type != JSON_TYPE_OBJECT) {
     log_warn("period_store: invalid historical_summaries response for slot %l", bctx->anchor_slot);
-    safe_free(hdr_str);
-    safe_free(sum_str);
-    build_ctx_free(bctx);
-    return;
+    goto cleanup;
   }
 
   // Build merkle proof via shared helper.
-  bytes_t  merkle_proof = {0};
   gindex_t combined_gix = 0;
   if (c4_build_historic_merkle_proof(
           (chain_id_t) http_server.chain_id,
-          NULL, // server has no state; errors get log_warn
+          NULL, // server has no state; helper logs via log_warn
           block_period,
           block_idx,
           bctx->blocks_ssz,
@@ -346,16 +388,22 @@ static void try_complete_build(build_ctx_t* bctx) {
           bctx->anchor_slot,
           &merkle_proof,
           &combined_gix) != C4_SUCCESS) {
-    safe_free(hdr_str);
-    safe_free(sum_str);
-    safe_free(merkle_proof.data);
-    build_ctx_free(bctx);
-    return;
+    goto cleanup;
+  }
+
+  // Read vk_hash, proof, header, pubkeys from the existing legacy zk_proof.ssz
+  // -- that file is the source of truth for these fields after
+  // `c4_build_zk_sync_proof_data`. Re-using it avoids maintaining two build
+  // paths for the ZK side.
+  legacy_bytes = read_legacy_zk_proof(bctx->period);
+  if (legacy_bytes.len == 0) {
+    log_warn("period_store: cannot read zk_proof.ssz for period %l, skipping historic snapshot", bctx->period);
+    goto cleanup;
   }
 
   // Build ZKSyncData SSZ with historic_proof variant (index 1 in checkpoint union).
-  ssz_builder_t builder            = ssz_builder_for_def(C4_ETH_REQUEST_SYNCDATA_UNION + 2);
-  ssz_builder_t checkpoint_builder = ssz_builder_for_def(ssz_get_def(builder.def, "checkpoint")->def.container.elements + 1);
+  builder            = ssz_builder_for_def(C4_ETH_REQUEST_SYNCDATA_UNION + 2);
+  checkpoint_builder = ssz_builder_for_def(ssz_get_def(builder.def, "checkpoint")->def.container.elements + 1);
   ssz_add_bytes(&checkpoint_builder, "proof", merkle_proof);
   ssz_add_bytes(&checkpoint_builder, "header", bytes(anchor_header, HEADER_SSZ_SIZE));
   ssz_add_uint64(&checkpoint_builder, (uint64_t) combined_gix);
@@ -364,62 +412,40 @@ static void try_complete_build(build_ctx_t* bctx) {
   ssz_add_bytes(&checkpoint_builder, "sync_committee_bits", bytes(NULL, 64));
   ssz_add_bytes(&checkpoint_builder, "sync_committee_signature", bytes(NULL, 96));
 
-  // Reuse vk_hash, proof, header, pubkeys from the legacy zk_proof.ssz. We
-  // read it back from disk rather than re-deriving to avoid maintaining two
-  // build paths (and because zk_proof.ssz is the source of truth for these
-  // fields after `c4_build_zk_sync_proof_data`).
-  char*       legacy_path  = bprintf(NULL, "%s/%l/zk_proof.ssz", eth_config.period_store, bctx->period);
-  FILE*       lf           = fopen(legacy_path, "rb");
-  bytes_t     legacy_bytes = NULL_BYTES;
-  if (lf) {
-    fseek(lf, 0, SEEK_END);
-    long sz = ftell(lf);
-    fseek(lf, 0, SEEK_SET);
-    if (sz > 0) {
-      legacy_bytes.data = safe_malloc((uint32_t) sz);
-      legacy_bytes.len  = (uint32_t) fread(legacy_bytes.data, 1, (size_t) sz, lf);
-    }
-    fclose(lf);
-  }
-  safe_free(legacy_path);
-
-  if (legacy_bytes.len == 0) {
-    log_warn("period_store: cannot read zk_proof.ssz for period %l, skipping historic snapshot", bctx->period);
-    safe_free(legacy_bytes.data);
-    safe_free(hdr_str);
-    safe_free(sum_str);
-    safe_free(merkle_proof.data);
-    buffer_free(&builder.fixed);
-    buffer_free(&builder.dynamic);
-    buffer_free(&checkpoint_builder.fixed);
-    buffer_free(&checkpoint_builder.dynamic);
-    build_ctx_free(bctx);
-    return;
-  }
-
   ssz_ob_t legacy = {.def = C4_ETH_REQUEST_SYNCDATA_UNION + 2, .bytes = legacy_bytes};
   ssz_add_bytes(&builder, "vk_hash", ssz_get(&legacy, "vk_hash").bytes);
   ssz_add_bytes(&builder, "proof", ssz_get(&legacy, "proof").bytes);
   ssz_add_bytes(&builder, "header", ssz_get(&legacy, "header").bytes);
   ssz_add_bytes(&builder, "pubkeys", ssz_get(&legacy, "pubkeys").bytes);
   ssz_add_builders(&builder, "checkpoint", checkpoint_builder);
+  // checkpoint_builder buffers were consumed/moved by ssz_add_builders;
+  // zero them so the cleanup label does not double-free.
+  checkpoint_builder = (ssz_builder_t) {0};
   ssz_add_bytes(&builder, "signatures", NULL_BYTES);
 
-  file_data_t out_file = {
-      .data = ssz_builder_to_bytes(&builder).bytes,
-      .path = bprintf(NULL, "%s/%l/zk_proof_checkpoint_%l.ssz", eth_config.period_store, bctx->period, bctx->anchor_slot)};
-
-  safe_free(legacy_bytes.data);
-  safe_free(hdr_str);
-  safe_free(sum_str);
-  safe_free(merkle_proof.data);
+  out_file.data = ssz_builder_to_bytes(&builder).bytes;
+  builder       = (ssz_builder_t) {0}; // builder buffers transferred to out_file
+  out_file.path = bprintf(NULL, "%s/%l/zk_proof_checkpoint_%l.ssz", eth_config.period_store, bctx->period, bctx->anchor_slot);
 
   int rc = c4_write_files_uv(bctx, snapshot_write_cb, &out_file, 1, O_WRONLY | O_CREAT | O_TRUNC, 0666);
   if (rc < 0) {
     log_warn("period_store: scheduling snapshot write failed for period %l slot %l", bctx->period, bctx->anchor_slot);
     c4_file_data_array_free(&out_file, 1, 1);
-    build_ctx_free(bctx);
+    goto cleanup;
   }
+  write_scheduled = true;
+
+cleanup:
+  safe_free(hdr_str);
+  safe_free(sum_str);
+  safe_free(merkle_proof.data);
+  safe_free(legacy_bytes.data);
+  buffer_free(&builder.fixed);
+  buffer_free(&builder.dynamic);
+  buffer_free(&checkpoint_builder.fixed);
+  buffer_free(&checkpoint_builder.dynamic);
+  if (!write_scheduled) build_ctx_free(bctx);
+  // else: snapshot_write_cb owns bctx and frees it on completion.
 }
 
 static void header_fetch_cb(client_t* client, void* user_data, data_request_t* r) {
@@ -500,6 +526,11 @@ static void files_read_cb(void* user_data, file_data_t* files, int num_files) {
 }
 
 void c4_ps_build_historic_proof_snapshot(uint64_t period, uint64_t finalized_slot) {
+  // TODO(historic_proof): implement first-success fallback cascade over
+  //   [finalized_slot, finalized_slot + 32, finalized_slot + 64]
+  // when Lodestar's historical_summaries endpoint is unavailable for the
+  // finalized anchor. Empirical Lodestar cache depth is ~80 slots (~16min),
+  // so finalized (-64 slots) is at the edge. MVP uses finalized only.
   if (eth_config.period_master_url) return; // slave mode: no local builds
   if (!eth_config.period_store) return;
   if (period == 0) return;

--- a/src/chains/eth/verifier/sync_committee.c
+++ b/src/chains/eth/verifier/sync_committee.c
@@ -352,9 +352,17 @@ static c4_status_t update_from_zk_sync_data(verify_ctx_t* ctx) {
         bytes_t   state_root  = ssz_get(&anchor_header, "stateRoot").bytes;
         bytes32_t att_root    = {0};
         bytes32_t computed    = {0};
+
+        // Defense-in-depth: reject structurally invalid input before the merkle
+        // verifier (which is `void`-returning and silently leaves `computed`
+        // unchanged on bad input -- safe today only because `computed` is
+        // zero-initialized and a SHA-256 state_root will never match all-zero).
+        if (state_root.len != 32 || (proof_bytes.len % 32) != 0 || gindex == 0)
+          RETURN_VERIFY_ERROR_STATUS(ctx, "historic_proof merkle verification: malformed input");
+
         ssz_hash_tree_root(header, att_root);
         ssz_verify_single_merkle_proof(proof_bytes, att_root, gindex, computed);
-        if (state_root.len != 32 || memcmp(computed, state_root.data, 32) != 0)
+        if (memcmp(computed, state_root.data, 32) != 0)
           RETURN_VERIFY_ERROR_STATUS(ctx, "historic_proof merkle verification failed for ZK sync data");
       }
     }


### PR DESCRIPTION
> **Stacked PR.** Base = `feat/wsp-historic-proof-anchor`. After the underlying PR merges into `dev`, this PR will automatically retarget to `dev`.

## Summary

Applies findings from the security-agent and code-reviewer that were raised on the historic_proof WSP anchor introduced by the underlying PR. No behaviour change for the happy path; primarily defensive checks and one real stack-overflow fix on the server side.

### Security
- **H-1 (HIGH)** — `encode_beacon_block_header_from_json` now refuses any `parent_root` / `state_root` / `body_root` whose JSON token length is not exactly `"0x" + 64 hex chars`. Background: `json_as_bytes` overwrites `buffer->data.len` with the input token length before `hex_to_bytes` runs its capacity check, so an oversized hex value from a malicious beacon API would overflow the 32-byte slot inside the 112-byte stack buffer. The underlying `json_as_bytes` weakness exists in several other places too and should be fixed structurally in a separate PR; this commit closes the new server-side instance.
- **M-1 (MEDIUM)** — verifier `historic_proof` branch now pre-checks `state_root.len == 32`, `proof.len % 32 == 0` and `gindex != 0` before calling the `void`-returning `ssz_verify_single_merkle_proof`. Without the pre-check a structurally invalid proof would silently leave `computed` zero-initialized and rely on the (vanishingly small) probability that a SHA-256 state root is not all-zero.
- **M-3 (MEDIUM)** — `c4_build_historic_merkle_proof` rejects `block_period < offset_period`, preventing a `uint64 -> uint32` underflow when the requested period predates the Capella fork.
- **M-4 (MEDIUM)** — `snapshots_idx_load` caps the entry count at `SNAPSHOTS_IDX_MAX_COUNT` (4096) so a corrupted local `snapshots.idx` can no longer trigger a huge `safe_calloc` abort.

### Code review
- **R1 (CRITICAL)** — `historic_merkle_error` switched from a raw `strdup` overwrite to `c4_state_add_error`, fixing a memory leak when the state already carried an error message.
- **R2** — `c4_ps_build_historic_proof_snapshot` docstring no longer claims to perform a first-success cascade; it now correctly documents the MVP (finalized slot only) and links to the cascade TODO.
- **I2 / I5** — duplicated `unlink(snapshots.idx)` boilerplate in `period_store.c` factored into `invalidate_local_snapshots_idx`, which also guards against `eth_config.period_store == NULL`.

### Cleanup
- **L-4** — witness-key loop counter changed from `int` to `uint32_t` to match `bytes_t.len`.
- **L-7** — removed the dead `ctx->state.error = NULL` store immediately before the unconditional `= saved_err` restore.

## Test plan
- [x] `cmake --build build/default` — clean.
- [x] `ctest --test-dir build/default` — 39/40 pass, `test_util_version` pre-existing failure unrelated to these changes.
- [x] `ReadLints` on touched files — clean.
- [ ] CI on the stacked branch (will run on push).

## Out of scope (deferred)
- Structural fix for `json_as_bytes` + `hex_to_bytes` + fixed-buffer interaction (would harden several other call sites).
- Atomic snapshot write (tmp + rename) to avoid orphan files on crash.
- Cascade over `[finalized, +32, +64]` anchor candidates in `c4_ps_build_historic_proof_snapshot`.