### PR TITLE
improve error handling 

### DIFF
--- a/bindings/colibri_common.c
+++ b/bindings/colibri_common.c
@@ -566,6 +566,9 @@ static c4_status_t handle_request_prover(c4_rpc_ctx_t* ctx) {
       return C4_SUCCESS;
     case C4_ERROR:
       rp->request->error = strdup(rp->ctx->state.error ? rp->ctx->state.error : "local prover failed");
+      // make sure the error is also set on the verifier
+      if (!ctx->verifier.state.error) 
+        ctx->verifier.state.error = bprintf(NULL, "Proof-creating for %s (%j) failed: %s", rp->ctx->method, rp->ctx->params, rp->request->error);
       free_request_prover(ctx);
       return C4_ERROR;
     default:

--- a/src/chains/eth/verifier/sync_committee_state.c
+++ b/src/chains/eth/verifier/sync_committee_state.c
@@ -534,6 +534,33 @@ static c4_status_t init_sync_state(verify_ctx_t* ctx) {
   }
 }
 
+
+/**
+ * Clear all sync committee state for a chain on critical errors.
+ * Called when weak subjectivity validation fails or corruption is detected.
+ * Forces re-initialization from a trusted checkpoint on next verification.
+ *
+ * @param chain_id Chain identifier for which to clear all state
+ */
+static void clear_sync_state(chain_id_t chain_id) {
+  storage_plugin_t storage_conf = {0};
+  c4_get_storage_config(&storage_conf);
+
+  // Delete all sync states for this chain
+  c4_chain_state_t chain_state = c4_get_chain_state(chain_id);
+  for (uint32_t i = 0; chain_state.status == C4_STATE_SYNC_PERIODS && i < MAX_SYNC_PERIODS && chain_state.data.periods[i] != 0; i++) {
+    uint32_t p = chain_state.data.periods[i];
+    char     name[100];
+    sbprintf(name, "sync_%l_%d", (uint64_t) chain_id, p);
+    storage_conf.del(name);
+  }
+
+  // Delete chain state
+  char name[100];
+  sbprintf(name, "states_%l", (uint64_t) chain_id);
+  storage_conf.del(name);
+}
+
 /**
  * Retrieve sync committee validators from persistent storage cache.
  * Handles BLS deserialization if needed and strips the 32-byte previous_pubkeys_hash suffix.
@@ -577,6 +604,13 @@ static c4_sync_validators_t get_validators_from_cache(verify_ctx_t* ctx, uint32_
   }
 
   if (found && storage_conf.get) storage_conf.get(name, &validators);
+  if (found && validators.data.len == 0) {
+    log_debug("sync cache corrupted. The data for %s is missing, so we re init the sync state", name);
+
+    // this is a corrupted state, we need to clear it
+    clear_sync_state(ctx->chain_id);
+    return (c4_sync_validators_t){.current_period = period };
+  }
   log_debug("fetch from cache %s : %d bytes)", name, validators.data.len);
   if (validators.data.len % 48 == 32)
     memcpy(previous_root, validators.data.data + validators.data.len - 32, 32);
@@ -623,32 +657,6 @@ static c4_sync_validators_t get_validators_from_cache(verify_ctx_t* ctx, uint32_
       .validators     = validators.data};
   memcpy(result.previous_pubkeys_hash, previous_root, 32);
   return result;
-}
-
-/**
- * Clear all sync committee state for a chain on critical errors.
- * Called when weak subjectivity validation fails or corruption is detected.
- * Forces re-initialization from a trusted checkpoint on next verification.
- *
- * @param chain_id Chain identifier for which to clear all state
- */
-static void clear_sync_state(chain_id_t chain_id) {
-  storage_plugin_t storage_conf = {0};
-  c4_get_storage_config(&storage_conf);
-
-  // Delete all sync states for this chain
-  c4_chain_state_t chain_state = c4_get_chain_state(chain_id);
-  for (uint32_t i = 0; chain_state.status == C4_STATE_SYNC_PERIODS && i < MAX_SYNC_PERIODS && chain_state.data.periods[i] != 0; i++) {
-    uint32_t p = chain_state.data.periods[i];
-    char     name[100];
-    sbprintf(name, "sync_%l_%d", (uint64_t) chain_id, p);
-    storage_conf.del(name);
-  }
-
-  // Delete chain state
-  char name[100];
-  sbprintf(name, "states_%l", (uint64_t) chain_id);
-  storage_conf.del(name);
 }
 
 #ifdef USE_CHECKPOINTZ

--- a/src/util/state.c
+++ b/src/util/state.c
@@ -33,8 +33,8 @@ void c4_append_prover_request_props(buffer_t* payload, bytes_t client_state, cha
   bprintf(payload, ",\"version\":%d", c4_current_version_number());
 
   // Prefer the supplied snapshot; fall back to a fresh storage read if the caller passed NULL_BYTES.
-  bytes_t cs        = client_state;
-  bool    cs_owned  = false;
+  bytes_t cs       = client_state;
+  bool    cs_owned = false;
   if (!cs.data || !cs.len) {
     cs       = c4_get_client_state(chain_id);
     cs_owned = true;
@@ -122,15 +122,14 @@ void c4_state_take_requests(c4_state_t* dst, c4_state_t* src) {
   if (!dst) return;
   data_request_t* tail = src->requests;
   while (tail->next) tail = tail->next;
-  tail->next     = dst->requests;
-  dst->requests  = src->requests;
-  src->requests  = NULL;
+  tail->next    = dst->requests;
+  dst->requests = src->requests;
+  src->requests = NULL;
 }
 
 c4_status_t c4_state_add_error(c4_state_t* state, const char* error) {
   // NULL-Check: Use generic message if error is NULL
   if (!error) error = "Unknown error";
-
   if (state->error) {
     // Store old error pointer to free after creating new concatenated string
     char* old_error = state->error;


### PR DESCRIPTION
- when the state is corrupt and files are missing, we just re init now.
- when a sub prover fails the error is now reported back top the verifier.