### PR TITLE
feat(verifier): delayed same-node retry for oblivious eth_getProof

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -36,6 +36,7 @@ jobs:
             -DETH_LOGS=OFF \
             -DETH_CALL=OFF \
             -DETH_ACCOUNT=OFF \
+            -DETH_OBLIVIOUS=OFF \
             -DEVMLIGHT=OFF \
             -DPROVER=OFF \
             -DCLI=OFF \

--- a/bindings/colibri_common.c
+++ b/bindings/colibri_common.c
@@ -122,6 +122,8 @@ void c4i_add_data_request(buffer_t* result, data_request_t* req, bool req_ptr_as
   bprintf(result, "\"chain_id\": %d,", (uint32_t) req->chain_id);
   bprintf(result, "\"encoding\": \"%s\",", encoding_to_string(req->encoding));
   bprintf(result, "\"exclude_mask\": \"%d\",", (uint32_t) req->node_exclude_mask);
+  if (req->delay)
+    bprintf(result, "\"delay\": %d,", (uint32_t) req->delay);
   bprintf(result, "\"method\": \"%s\",", method_to_string(req->method));
   bprintf(result, "\"url\": \"%s\",", req->url);
   if (req->payload.data)

--- a/bindings/dart/lib/src/client.dart
+++ b/bindings/dart/lib/src/client.dart
@@ -376,6 +376,10 @@ class Colibri {
   }) async {
     Future<void> handleRequest(DataRequest request) async {
       try {
+        // Honor a requested delay before (re-)executing (e.g. oblivious-node retry backoff).
+        if (request.delay > 0) {
+          await Future<void>.delayed(Duration(milliseconds: request.delay));
+        }
         final response = await _executeHttpRequest(request, useProverFallback: useProverFallback);
         _native.reqSetResponse(request.reqPtr, response.data, response.nodeIndex);
       } catch (error) {

--- a/bindings/dart/lib/src/types.dart
+++ b/bindings/dart/lib/src/types.dart
@@ -135,6 +135,7 @@ class DataRequest {
     required this.excludeMask,
     required this.chainId,
     this.payload,
+    this.delay = 0,
   });
 
   /// Opaque native handle (pointer) for this request; used when fulfilling.
@@ -153,11 +154,20 @@ class DataRequest {
   final int chainId;
   /// Optional JSON payload for the request.
   final Map<String, dynamic>? payload;
+  /// Milliseconds to wait before (re-)executing this request (e.g. oblivious-node retry backoff).
+  final int delay;
 
   /// Parses a JSON request object returned by native status calls.
   static DataRequest fromJson(Map<String, dynamic> data) {
     final excludeRaw = data['exclude_mask'];
     final excludeMask = switch (excludeRaw) {
+      int value => value,
+      String value => int.tryParse(value) ?? 0,
+      _ => 0,
+    };
+
+    final delayRaw = data['delay'];
+    final delay = switch (delayRaw) {
       int value => value,
       String value => int.tryParse(value) ?? 0,
       _ => 0,
@@ -202,6 +212,7 @@ class DataRequest {
         return int.tryParse(raw.toString()) ?? 1;
       }(),
       payload: normalizedPayload,
+      delay: delay,
     );
   }
 }

--- a/bindings/emscripten/src/http.ts
+++ b/bindings/emscripten/src/http.ts
@@ -165,6 +165,8 @@ export async function fetch_rpc(urls: string[], payload: any, as_proof: boolean 
  */
 export async function handle_request(req: DataRequest, conf: C4Config) {
   const free_buffers: number[] = [];
+  // Honor a requested delay before (re-)executing (e.g. oblivious-node retry backoff).
+  if (req.delay && req.delay > 0) await new Promise(resolve => setTimeout(resolve, req.delay));
   let servers: string[] = [];
   if (req.type === 'eth_rpc' && req.payload?.method === 'eth_getProof' && conf.oblivious_nodes?.length) {
     servers = [...conf.oblivious_nodes];

--- a/bindings/emscripten/src/types.ts
+++ b/bindings/emscripten/src/types.ts
@@ -179,6 +179,8 @@ export interface DataRequest {
     url: string;
     payload: any;
     req_ptr: number;
+    /** Milliseconds to wait before (re-)executing this request (e.g. oblivious-node retry backoff). Optional. */
+    delay?: number;
 }
 
 // Enum for RPC method types

--- a/bindings/kotlin/lib/src/main/kotlin/com/corpuscore/colibri/Colibri.kt
+++ b/bindings/kotlin/lib/src/main/kotlin/com/corpuscore/colibri/Colibri.kt
@@ -273,6 +273,10 @@ class Colibri(
         val reqPtr = request.getLong("req_ptr")
 //        println("fetchRequest:  for req_ptr $reqPtr)")
 
+        // Honor a requested delay before (re-)executing (e.g. oblivious-node retry backoff).
+        val delayMs = request.optLong("delay", 0L)
+        if (delayMs > 0L) delay(delayMs)
+
         var index = 0
         var lastError = ""
         for (server in servers) {

--- a/bindings/python/src/colibri/client.py
+++ b/bindings/python/src/colibri/client.py
@@ -499,7 +499,11 @@ class Colibri:
         async def handle_single_request(request_dict: Dict[str, Any]) -> None:
             try:
                 request = DataRequest.from_dict(request_dict)
-                
+
+                # Honor a requested delay before (re-)executing (e.g. oblivious-node retry backoff).
+                if getattr(request, "delay", 0):
+                    await asyncio.sleep(request.delay / 1000.0)
+
                 # Mock request handling for testing
                 if self.request_handler:
                     try:

--- a/bindings/python/src/colibri/types.py
+++ b/bindings/python/src/colibri/types.py
@@ -123,6 +123,7 @@ class DataRequest:
         request_type: str = "eth_rpc",
         exclude_mask: int = 0,
         chain_id: int = 1,
+        delay: int = 0,
     ):
         self.req_ptr = req_ptr
         self.url = url
@@ -132,6 +133,8 @@ class DataRequest:
         self.request_type = request_type
         self.exclude_mask = exclude_mask
         self.chain_id = chain_id
+        # Milliseconds to wait before (re-)executing (e.g. oblivious-node retry backoff).
+        self.delay = delay
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "DataRequest":
@@ -145,6 +148,7 @@ class DataRequest:
             request_type=data.get("type", "eth_rpc"),
             exclude_mask=int(data.get("exclude_mask", 0)),
             chain_id=int(data.get("chain_id", 1)),
+            delay=int(data.get("delay", 0)),
         )
 
     def to_dict(self) -> Dict[str, Any]:

--- a/bindings/swift/Sources/Colibri/Colibri.swift
+++ b/bindings/swift/Sources/Colibri/Colibri.swift
@@ -613,6 +613,19 @@ public class Colibri {
                         print("❌ ERROR: req_ptr neither String nor NSNumber in request: \(request)")
                         return
                     }
+
+                    // Honor a requested delay before (re-)executing (e.g. oblivious-node retry backoff).
+                    let delayMs: UInt64
+                    if let delayNum = request["delay"] as? NSNumber {
+                        delayMs = delayNum.uint64Value
+                    } else if let delayStr = request["delay"] as? String, let v = UInt64(delayStr) {
+                        delayMs = v
+                    } else {
+                        delayMs = 0
+                    }
+                    if delayMs > 0 {
+                        try? await Task.sleep(nanoseconds: delayMs * 1_000_000)
+                    }
                     
                     // Convert exclude_mask from String to Int
                     let excludeMask: Int

--- a/libs/curl/http.c
+++ b/libs/curl/http.c
@@ -395,6 +395,7 @@ static void log_request(curl_request_t* creq, bool success, bytes_t data, char* 
   char* host = strncmp(server, "http://", 7) == 0 ? server + 7 : strncmp(server, "https://", 8) == 0 ? server + 8 : server;
   char* end =strchr(host, '/');
   if (end) *end = '\0';
+  if (creq->request->type != C4_DATA_TYPE_ETH_RPC) host = creq->url;
   if (creq->request->payload.len && creq->request->payload.data)
     log_info("[%s]: %s : %r -> %s", success ? "SUCCESS" : "ERROR  ", host, creq->request->payload, buffer_as_string(buf));
   else

--- a/libs/curl/http.c
+++ b/libs/curl/http.c
@@ -34,10 +34,23 @@
 #include <direct.h>
 #define MKDIR(path) _mkdir(path)
 #include "../../src/util/win_compat.h"
+#include <windows.h>
 #else
 #include <unistd.h>
 #define MKDIR(path) mkdir(path, 0755)
 #endif
+
+// Blocks the current thread for the given number of milliseconds. Used to honor
+// a data_request_t.delay (e.g. waiting between oblivious-node retries). The CLI
+// host is single-threaded, so a blocking sleep is acceptable here.
+static void curl_sleep_ms(uint32_t ms) {
+  if (!ms) return;
+#ifdef _WIN32
+  Sleep(ms);
+#else
+  usleep((useconds_t) ms * 1000);
+#endif
+}
 
 typedef struct {
   json_t config;
@@ -378,15 +391,34 @@ static void log_request(curl_request_t* creq, bool success, bytes_t data, char* 
     bprintf(&buf, "(%d bytes, %l ms)", data.len, duration_ms);
   else
     bprintf(&buf, "-> %r ", data);
+  char* server = strdup(creq->url ? creq->url : "");
+  char* host = strncmp(server, "http://", 7) == 0 ? server + 7 : strncmp(server, "https://", 8) == 0 ? server + 8 : server;
+  char* end =strchr(host, '/');
+  if (end) *end = '\0';
   if (creq->request->payload.len && creq->request->payload.data)
-    log_info("[%s]: %s : %r -> %s", success ? "SUCCESS" : "ERROR  ", creq->url, creq->request->payload, buffer_as_string(buf));
+    log_info("[%s]: %s : %r -> %s", success ? "SUCCESS" : "ERROR  ", host, creq->request->payload, buffer_as_string(buf));
   else
-    log_info("[%s]: %s -> %s", success ? "SUCCESS" : "ERROR  ", creq->url, buffer_as_string(buf));
+    log_info("[%s]: %s -> %s", success ? "SUCCESS" : "ERROR  ", host, buffer_as_string(buf));
   buffer_free(&buf);
+  safe_free(server);
 }
 
 void curl_fetch_all(c4_state_t* state) {
   bool retry = true;
+
+  // Honor any requested delay (e.g. oblivious-node retry backoff) before issuing
+  // the pending requests. Sleep once for the longest requested delay, then clear
+  // it so we don't wait again on internal node-rotation retries.
+  uint32_t max_delay = 0;
+  for (data_request_t* req = state->requests; req; req = req->next) {
+    if (!req->response.data && req->delay > max_delay) max_delay = req->delay;
+  }
+  if (max_delay) {
+    curl_sleep_ms(max_delay);
+    for (data_request_t* req = state->requests; req; req = req->next) {
+      if (!req->response.data) req->delay = 0;
+    }
+  }
 
   while (retry) {
     retry               = false;

--- a/libs/curl/http.c
+++ b/libs/curl/http.c
@@ -415,6 +415,7 @@ void curl_fetch_all(c4_state_t* state) {
     if (!req->response.data && req->delay > max_delay) max_delay = req->delay;
   }
   if (max_delay) {
+    log_info("Sleeping for %d ms", max_delay);
     curl_sleep_ms(max_delay);
     for (data_request_t* req = state->requests; req; req = req->next) {
       if (!req->response.data) req->delay = 0;

--- a/src/chains/eth/CMakeLists.txt
+++ b/src/chains/eth/CMakeLists.txt
@@ -26,7 +26,12 @@ option(ETH_RECEIPT  "support eth receipt verification. eth_getTransactionReceipt
 option(ETH_LOGS  "support eth logs verification. eth_getLogs" ON)
 option(ETH_CALL  "support eth call verification. eth_call, eth_estimateGas" ON)
 option(ETH_UTIL  "support eth utils like eth_chainId or web3_sha3" ON)
+option(ETH_OBLIVIOUS "support oblivious-node delayed-retry path (TEE/ORAM warm-up). When OFF, the oblivious helpers and call paths are compiled out so the linker drops the adaptive retry-delay learner (saves ~1-2 KB). Disable for embedded targets that never talk to oblivious nodes." ON)
 option(USE_CHECKPOINTZ "enable checkpoint fetching from checkpointz (beacon node) for bootstrap and weak subjectivity validation (requires HTTP access, saves ~2-3 KB if disabled). SECURITY WARNING: Disabling this removes (1) automatic bootstrap checkpoint fetching and (2) weak subjectivity period validation, requiring manual checkpoint configuration and increasing long-range attack risk. Only disable for embedded devices without HTTP access. See: https://github.com/runtimeverification/beacon-chain-verification/blob/master/weak-subjectivity/weak-subjectivity-analysis.pdf" ON)
+
+if(ETH_OBLIVIOUS)
+    add_definitions(-DETH_OBLIVIOUS)
+endif()
 
 if(USE_CHECKPOINTZ)
     add_definitions(-DUSE_CHECKPOINTZ)

--- a/src/chains/eth/prover/eth_req.c
+++ b/src/chains/eth/prover/eth_req.c
@@ -253,6 +253,7 @@ c4_status_t c4_send_eth_rpc(prover_ctx_t* ctx, char* method, char* params, uint3
         json_t code = json_get(error, "code");
         if (code.len == 6 && strncmp(code.start, "-32602", 6) == 0)
           RETRY_REQUEST(data_request);
+#ifdef ETH_OBLIVIOUS
         else if (strcmp(method, "eth_getProof") == 0 && eth_is_oblivious_unavailable(response)) {
           // Oblivious node reported the requested state as not yet available.
           // Retry the SAME node after a short delay (bounded), instead of
@@ -263,6 +264,7 @@ c4_status_t c4_send_eth_rpc(prover_ctx_t* ctx, char* method, char* params, uint3
             return C4_PENDING;
           THROW_ERROR_WITH("oblivious node did not provide the proof within the retry budget for %s (params: %s) : %j", method, params, json_get(error, "message"));
         }
+#endif
         else
           THROW_ERROR_WITH("Error when calling eth-rpc for %s (params: %s) : %j", method, params, json_get(error, "message"));
       }
@@ -275,6 +277,7 @@ c4_status_t c4_send_eth_rpc(prover_ctx_t* ctx, char* method, char* params, uint3
         RETRY_REQUEST(data_request);
       //      THROW_ERROR_WITH("Error when calling eth-rpc for %s (params: %s): Invalid JSON response (no result)", method, params);
 
+#ifdef ETH_OBLIVIOUS
       // Feed the adaptive oblivious-retry learner. Only when at least one
       // delayed retry was needed do we *know* this request went through the
       // oblivious code path -- a plain `eth_getProof` against a regular node
@@ -283,6 +286,7 @@ c4_status_t c4_send_eth_rpc(prover_ctx_t* ctx, char* method, char* params, uint3
       // in call_ctx.c, which has the explicit VERIFY_FLAG_OBLIVIOUS signal.
       if (strcmp(method, "eth_getProof") == 0 && data_request->retry_count > 0)
         eth_oblivious_retry_observe(ctx->chain_id, data_request->retry_count);
+#endif
 
       *result = res;
       return C4_SUCCESS;

--- a/src/chains/eth/prover/eth_req.c
+++ b/src/chains/eth/prover/eth_req.c
@@ -259,7 +259,7 @@ c4_status_t c4_send_eth_rpc(prover_ctx_t* ctx, char* method, char* params, uint3
           // failing the whole proof. Covers the locally generated
           // colibri_proofCall in hybrid mode whose eth_getProof requests are
           // routed to the oblivious node by the host.
-          if (c4_state_retry_after(data_request, ETH_OBLIVIOUS_RETRY_DELAY_MS, ETH_OBLIVIOUS_MAX_RETRIES))
+          if (c4_state_retry_after(data_request, eth_oblivious_retry_delay(data_request->retry_count), ETH_OBLIVIOUS_MAX_RETRIES))
             return C4_PENDING;
           THROW_ERROR_WITH("oblivious node did not provide the proof within the retry budget for %s (params: %s) : %j", method, params, json_get(error, "message"));
         }

--- a/src/chains/eth/prover/eth_req.c
+++ b/src/chains/eth/prover/eth_req.c
@@ -259,7 +259,7 @@ c4_status_t c4_send_eth_rpc(prover_ctx_t* ctx, char* method, char* params, uint3
           // failing the whole proof. Covers the locally generated
           // colibri_proofCall in hybrid mode whose eth_getProof requests are
           // routed to the oblivious node by the host.
-          if (c4_state_retry_after(data_request, eth_oblivious_retry_delay(data_request->retry_count), ETH_OBLIVIOUS_MAX_RETRIES))
+          if (c4_state_retry_after(data_request, eth_oblivious_retry_delay(ctx->chain_id, data_request->retry_count), ETH_OBLIVIOUS_MAX_RETRIES))
             return C4_PENDING;
           THROW_ERROR_WITH("oblivious node did not provide the proof within the retry budget for %s (params: %s) : %j", method, params, json_get(error, "message"));
         }
@@ -274,6 +274,15 @@ c4_status_t c4_send_eth_rpc(prover_ctx_t* ctx, char* method, char* params, uint3
           (res.type == JSON_TYPE_NULL && (strcmp(method, "eth_getBlockReceipts") == 0)))
         RETRY_REQUEST(data_request);
       //      THROW_ERROR_WITH("Error when calling eth-rpc for %s (params: %s): Invalid JSON response (no result)", method, params);
+
+      // Feed the adaptive oblivious-retry learner. Only when at least one
+      // delayed retry was needed do we *know* this request went through the
+      // oblivious code path -- a plain `eth_getProof` against a regular node
+      // would also reach here with retry_count == 0 and must not pollute the
+      // learner. The R == 0 downward probe is handled by the verifier path
+      // in call_ctx.c, which has the explicit VERIFY_FLAG_OBLIVIOUS signal.
+      if (strcmp(method, "eth_getProof") == 0 && data_request->retry_count > 0)
+        eth_oblivious_retry_observe(ctx->chain_id, data_request->retry_count);
 
       *result = res;
       return C4_SUCCESS;

--- a/src/chains/eth/prover/eth_req.c
+++ b/src/chains/eth/prover/eth_req.c
@@ -25,6 +25,7 @@
 #include "beacon.h"
 #include "beacon_types.h"
 #include "eth_compute_units.h"
+#include "eth_verify.h"
 #include "json.h"
 #include "logger.h"
 #include "rlp.h"
@@ -252,6 +253,16 @@ c4_status_t c4_send_eth_rpc(prover_ctx_t* ctx, char* method, char* params, uint3
         json_t code = json_get(error, "code");
         if (code.len == 6 && strncmp(code.start, "-32602", 6) == 0)
           RETRY_REQUEST(data_request);
+        else if (strcmp(method, "eth_getProof") == 0 && eth_is_oblivious_unavailable(response)) {
+          // Oblivious node reported the requested state as not yet available.
+          // Retry the SAME node after a short delay (bounded), instead of
+          // failing the whole proof. Covers the locally generated
+          // colibri_proofCall in hybrid mode whose eth_getProof requests are
+          // routed to the oblivious node by the host.
+          if (c4_state_retry_after(data_request, ETH_OBLIVIOUS_RETRY_DELAY_MS, ETH_OBLIVIOUS_MAX_RETRIES))
+            return C4_PENDING;
+          THROW_ERROR_WITH("oblivious node did not provide the proof within the retry budget for %s (params: %s) : %j", method, params, json_get(error, "message"));
+        }
         else
           THROW_ERROR_WITH("Error when calling eth-rpc for %s (params: %s) : %j", method, params, json_get(error, "message"));
       }

--- a/src/chains/eth/verifier/call_ctx.c
+++ b/src/chains/eth/verifier/call_ctx.c
@@ -136,7 +136,7 @@ void call_account_lazy_fetch_storage(evmone_context_t* ctx, const address_t addr
       // (TEE/ORAM warm-up). Retry the SAME node after a short delay, bounded by
       // the retry budget, instead of treating the missing `result` as zero.
       if (eth_is_oblivious_unavailable(response)) {
-        if (c4_state_retry_after(req, eth_oblivious_retry_delay(req->retry_count), ETH_OBLIVIOUS_MAX_RETRIES))
+        if (c4_state_retry_after(req, eth_oblivious_retry_delay(req->chain_id, req->retry_count), ETH_OBLIVIOUS_MAX_RETRIES))
           ctx->storage_miss = true;
         else
           c4_state_add_error(&ctx->ctx->state, "oblivious node did not provide the proof within the retry budget");
@@ -155,6 +155,10 @@ void call_account_lazy_fetch_storage(evmone_context_t* ctx, const address_t addr
         bytes_t  b       = json_as_bytes(proof_item, &val_buf);
         if (b.len <= 32) memcpy(val + (32 - b.len), b.data, b.len);
       }
+      // Feed the adaptive learner. The oblivious flag confirms the request
+      // went through the oblivious code path, so even retry_count == 0 is
+      // meaningful (enables the slow downward probe).
+      eth_oblivious_retry_observe(req->chain_id, req->retry_count);
     }
     else {
       json_t val_json = json_get(response, "result");
@@ -180,7 +184,7 @@ void call_account_lazy_fetch_storage(evmone_context_t* ctx, const address_t addr
   else if (req && req->error) {
     // A transport-level error against the oblivious node may also be transient
     // (node still warming up). Retry the same node with delay before failing.
-    if (is_oblivious && c4_state_retry_after(req, eth_oblivious_retry_delay(req->retry_count), ETH_OBLIVIOUS_MAX_RETRIES)) {
+    if (is_oblivious && c4_state_retry_after(req, eth_oblivious_retry_delay(req->chain_id, req->retry_count), ETH_OBLIVIOUS_MAX_RETRIES)) {
       ctx->storage_miss = true;
       return;
     }

--- a/src/chains/eth/verifier/call_ctx.c
+++ b/src/chains/eth/verifier/call_ctx.c
@@ -117,7 +117,14 @@ call_account_t* call_account_get_or_create(evmone_context_t* ctx, const address_
 // :: PAP-mode lazy fetchers
 
 void call_account_lazy_fetch_storage(evmone_context_t* ctx, const address_t address, const bytes32_t key, bytes32_t result) {
-  bool      is_oblivious = ctx->ctx->flags & VERIFY_FLAG_OBLIVIOUS;
+#ifdef ETH_OBLIVIOUS
+  bool is_oblivious = (ctx->ctx->flags & VERIFY_FLAG_OBLIVIOUS) != 0;
+#else
+  // Without oblivious support the flag is meaningless; pinning to false lets the
+  // compiler dead-strip the oblivious branches below, so the linker can drop
+  // the adaptive retry-delay learner together with `eth_oblivious_*` helpers.
+  const bool is_oblivious = false;
+#endif
   char      tmp[256];
   buffer_t  buf    = stack_buffer(tmp);
   bytes32_t req_id = {0};
@@ -132,6 +139,7 @@ void call_account_lazy_fetch_storage(evmone_context_t* ctx, const address_t addr
     json_t    response = json_parse((char*) req->response.data);
     bytes32_t val      = {0};
     if (is_oblivious) {
+#ifdef ETH_OBLIVIOUS
       // The oblivious node may report the requested state as not yet available
       // (TEE/ORAM warm-up). Retry the SAME node after a short delay, bounded by
       // the retry budget, instead of treating the missing `result` as zero.
@@ -159,6 +167,7 @@ void call_account_lazy_fetch_storage(evmone_context_t* ctx, const address_t addr
       // went through the oblivious code path, so even retry_count == 0 is
       // meaningful (enables the slow downward probe).
       eth_oblivious_retry_observe(req->chain_id, req->retry_count);
+#endif // ETH_OBLIVIOUS
     }
     else {
       json_t val_json = json_get(response, "result");
@@ -182,12 +191,14 @@ void call_account_lazy_fetch_storage(evmone_context_t* ctx, const address_t addr
     return;
   }
   else if (req && req->error) {
+#ifdef ETH_OBLIVIOUS
     // A transport-level error against the oblivious node may also be transient
     // (node still warming up). Retry the same node with delay before failing.
     if (is_oblivious && c4_state_retry_after(req, eth_oblivious_retry_delay(req->chain_id, req->retry_count), ETH_OBLIVIOUS_MAX_RETRIES)) {
       ctx->storage_miss = true;
       return;
     }
+#endif
     c4_state_add_error(&ctx->ctx->state, req->error);
     return;
   }

--- a/src/chains/eth/verifier/call_ctx.c
+++ b/src/chains/eth/verifier/call_ctx.c
@@ -136,7 +136,7 @@ void call_account_lazy_fetch_storage(evmone_context_t* ctx, const address_t addr
       // (TEE/ORAM warm-up). Retry the SAME node after a short delay, bounded by
       // the retry budget, instead of treating the missing `result` as zero.
       if (eth_is_oblivious_unavailable(response)) {
-        if (c4_state_retry_after(req, ETH_OBLIVIOUS_RETRY_DELAY_MS, ETH_OBLIVIOUS_MAX_RETRIES))
+        if (c4_state_retry_after(req, eth_oblivious_retry_delay(req->retry_count), ETH_OBLIVIOUS_MAX_RETRIES))
           ctx->storage_miss = true;
         else
           c4_state_add_error(&ctx->ctx->state, "oblivious node did not provide the proof within the retry budget");
@@ -180,7 +180,7 @@ void call_account_lazy_fetch_storage(evmone_context_t* ctx, const address_t addr
   else if (req && req->error) {
     // A transport-level error against the oblivious node may also be transient
     // (node still warming up). Retry the same node with delay before failing.
-    if (is_oblivious && c4_state_retry_after(req, ETH_OBLIVIOUS_RETRY_DELAY_MS, ETH_OBLIVIOUS_MAX_RETRIES)) {
+    if (is_oblivious && c4_state_retry_after(req, eth_oblivious_retry_delay(req->retry_count), ETH_OBLIVIOUS_MAX_RETRIES)) {
       ctx->storage_miss = true;
       return;
     }

--- a/src/chains/eth/verifier/call_ctx.c
+++ b/src/chains/eth/verifier/call_ctx.c
@@ -129,21 +129,40 @@ void call_account_lazy_fetch_storage(evmone_context_t* ctx, const address_t addr
 
   data_request_t* req = c4_state_get_data_request_by_id(&ctx->ctx->state, req_id);
   if (req && req->response.data) {
-    json_t    val_json = json_get(json_parse((char*) req->response.data), "result");
+    json_t    response = json_parse((char*) req->response.data);
     bytes32_t val      = {0};
     if (is_oblivious) {
-      json_t proof_json = json_get(val_json, "storageProof");
-      json_t proof_item = json_get(json_at(proof_json, 0),"value");
+      // The oblivious node may report the requested state as not yet available
+      // (TEE/ORAM warm-up). Retry the SAME node after a short delay, bounded by
+      // the retry budget, instead of treating the missing `result` as zero.
+      if (eth_is_oblivious_unavailable(response)) {
+        if (c4_state_retry_after(req, ETH_OBLIVIOUS_RETRY_DELAY_MS, ETH_OBLIVIOUS_MAX_RETRIES))
+          ctx->storage_miss = true;
+        else
+          c4_state_add_error(&ctx->ctx->state, "oblivious node did not provide the proof within the retry budget");
+        return;
+      }
+      // Any other JSON-RPC error must surface as a failure rather than being
+      // silently interpreted as an empty storage slot.
+      json_t err = json_get(response, "error");
+      if (err.type == JSON_TYPE_OBJECT || err.type == JSON_TYPE_STRING) {
+        c4_state_add_error(&ctx->ctx->state, "oblivious eth_getProof returned an error");
+        return;
+      }
+      json_t proof_item = json_get(json_at(json_get(json_get(response, "result"), "storageProof"), 0), "value");
       if (proof_item.type == JSON_TYPE_STRING) {
         buffer_t val_buf = stack_buffer(val);
         bytes_t  b       = json_as_bytes(proof_item, &val_buf);
         if (b.len <= 32) memcpy(val + (32 - b.len), b.data, b.len);
       }
     }
-    else if (val_json.type == JSON_TYPE_STRING) {
-      buffer_t val_buf = stack_buffer(val);
-      bytes_t  b       = json_as_bytes(val_json, &val_buf);
-      if (b.len <= 32) memcpy(val + (32 - b.len), b.data, b.len);
+    else {
+      json_t val_json = json_get(response, "result");
+      if (val_json.type == JSON_TYPE_STRING) {
+        buffer_t val_buf = stack_buffer(val);
+        bytes_t  b       = json_as_bytes(val_json, &val_buf);
+        if (b.len <= 32) memcpy(val + (32 - b.len), b.data, b.len);
+      }
     }
     memcpy(result, val, 32);
 
@@ -159,6 +178,12 @@ void call_account_lazy_fetch_storage(evmone_context_t* ctx, const address_t addr
     return;
   }
   else if (req && req->error) {
+    // A transport-level error against the oblivious node may also be transient
+    // (node still warming up). Retry the same node with delay before failing.
+    if (is_oblivious && c4_state_retry_after(req, ETH_OBLIVIOUS_RETRY_DELAY_MS, ETH_OBLIVIOUS_MAX_RETRIES)) {
+      ctx->storage_miss = true;
+      return;
+    }
     c4_state_add_error(&ctx->ctx->state, req->error);
     return;
   }

--- a/src/chains/eth/verifier/eth_verify.c
+++ b/src/chains/eth/verifier/eth_verify.c
@@ -48,6 +48,14 @@ bool eth_check_latest_freshness(verify_ctx_t* ctx, bool is_latest, bool has_ts, 
   return true;
 }
 
+uint32_t eth_oblivious_retry_delay(uint16_t retry_count) {
+  uint32_t delay = ETH_OBLIVIOUS_RETRY_BASE_MS;
+  // Double per retry, but stop once the cap is reached to avoid shift overflow.
+  for (uint16_t i = 0; i < retry_count && delay < ETH_OBLIVIOUS_RETRY_MAX_MS; i++)
+    delay <<= 1;
+  return delay > ETH_OBLIVIOUS_RETRY_MAX_MS ? ETH_OBLIVIOUS_RETRY_MAX_MS : delay;
+}
+
 bool eth_is_oblivious_unavailable(json_t response) {
   if (response.type != JSON_TYPE_OBJECT) return false;
   json_t error = json_get(response, "error");

--- a/src/chains/eth/verifier/eth_verify.c
+++ b/src/chains/eth/verifier/eth_verify.c
@@ -48,6 +48,26 @@ bool eth_check_latest_freshness(verify_ctx_t* ctx, bool is_latest, bool has_ts, 
   return true;
 }
 
+bool eth_is_oblivious_unavailable(json_t response) {
+  if (response.type != JSON_TYPE_OBJECT) return false;
+  json_t error = json_get(response, "error");
+  if (error.type != JSON_TYPE_OBJECT) return false;
+
+  json_t code = json_get(error, "code");
+  if (code.type != JSON_TYPE_NUMBER || code.len != 6 || strncmp(code.start, "-32001", 6) != 0) return false;
+
+  json_t message = json_get(error, "message");
+  if (message.type != JSON_TYPE_STRING) return false;
+  // message.start/len spans the JSON string token (incl. quotes); a substring
+  // search is sufficient to recognise the oblivious node's availability signal.
+  static const char marker[] = "data non availability";
+  const uint32_t    marker_len = sizeof(marker) - 1;
+  for (uint32_t i = 0; i + marker_len <= message.len; i++) {
+    if (strncmp(message.start + i, marker, marker_len) == 0) return true;
+  }
+  return false;
+}
+
 // : Ethereum
 
 // :: Supported RPC-Methods

--- a/src/chains/eth/verifier/eth_verify.c
+++ b/src/chains/eth/verifier/eth_verify.c
@@ -26,12 +26,15 @@
 #include "chains.h"
 #include "eth_bloom.h"
 #include "json.h"
-#include "retry_delay.h"
 #include "ssz.h"
 #include "sync_committee.h"
 #include "verify.h"
 #include <stdint.h>
 #include <string.h>
+
+#ifdef ETH_OBLIVIOUS
+#include "retry_delay.h"
+#endif
 
 // :: Freshness gate for `"latest"` proofs (shared by all block-tag methods)
 
@@ -48,6 +51,8 @@ bool eth_check_latest_freshness(verify_ctx_t* ctx, bool is_latest, bool has_ts, 
   if (block_ts < ctx->min_latest_block_ts) RETURN_VERIFY_ERROR(ctx, "proof for latest too old");
   return true;
 }
+
+#ifdef ETH_OBLIVIOUS
 
 uint32_t eth_oblivious_retry_delay(chain_id_t chain, uint16_t retry_count) {
   return c4_retry_delay_for(C4_RETRY_CATEGORY_OBLIVIOUS, chain, retry_count);
@@ -76,6 +81,8 @@ bool eth_is_oblivious_unavailable(json_t response) {
   }
   return false;
 }
+
+#endif // ETH_OBLIVIOUS
 
 // : Ethereum
 

--- a/src/chains/eth/verifier/eth_verify.c
+++ b/src/chains/eth/verifier/eth_verify.c
@@ -26,6 +26,7 @@
 #include "chains.h"
 #include "eth_bloom.h"
 #include "json.h"
+#include "retry_delay.h"
 #include "ssz.h"
 #include "sync_committee.h"
 #include "verify.h"
@@ -48,12 +49,12 @@ bool eth_check_latest_freshness(verify_ctx_t* ctx, bool is_latest, bool has_ts, 
   return true;
 }
 
-uint32_t eth_oblivious_retry_delay(uint16_t retry_count) {
-  uint32_t delay = ETH_OBLIVIOUS_RETRY_BASE_MS;
-  // Double per retry, but stop once the cap is reached to avoid shift overflow.
-  for (uint16_t i = 0; i < retry_count && delay < ETH_OBLIVIOUS_RETRY_MAX_MS; i++)
-    delay <<= 1;
-  return delay > ETH_OBLIVIOUS_RETRY_MAX_MS ? ETH_OBLIVIOUS_RETRY_MAX_MS : delay;
+uint32_t eth_oblivious_retry_delay(chain_id_t chain, uint16_t retry_count) {
+  return c4_retry_delay_for(C4_RETRY_CATEGORY_OBLIVIOUS, chain, retry_count);
+}
+
+void eth_oblivious_retry_observe(chain_id_t chain, uint16_t retry_count) {
+  c4_retry_delay_observe(C4_RETRY_CATEGORY_OBLIVIOUS, chain, retry_count);
 }
 
 bool eth_is_oblivious_unavailable(json_t response) {

--- a/src/chains/eth/verifier/eth_verify.h
+++ b/src/chains/eth/verifier/eth_verify.h
@@ -120,13 +120,14 @@ bool eth_check_latest_freshness(verify_ctx_t* ctx, bool is_latest, bool has_ts, 
  * Delay (in milliseconds) between successive retries of an `eth_getProof`
  * request against an oblivious TEE node that reported the requested state as
  * not yet available. The node typically needs a few seconds to make the data
- * available (ORAM/TEE warm-up).
+ * available (ORAM/TEE warm-up). The effective spacing between attempts is this
+ * delay plus the request round-trip time.
  */
-#define ETH_OBLIVIOUS_RETRY_DELAY_MS 3000
+#define ETH_OBLIVIOUS_RETRY_DELAY_MS 2000
 
 /**
  * Maximum number of delayed retries for an oblivious `eth_getProof` request.
- * With `ETH_OBLIVIOUS_RETRY_DELAY_MS` this bounds the total wait (~45s) and avoids
+ * With `ETH_OBLIVIOUS_RETRY_DELAY_MS` this bounds the total wait (~30s) and avoids
  * endless loops if the node never returns the data.
  */
 #define ETH_OBLIVIOUS_MAX_RETRIES 15

--- a/src/chains/eth/verifier/eth_verify.h
+++ b/src/chains/eth/verifier/eth_verify.h
@@ -117,20 +117,41 @@ bool eth_check_latest_freshness(verify_ctx_t* ctx, bool is_latest, bool has_ts, 
 // :: Oblivious node delayed-retry
 
 /**
- * Delay (in milliseconds) between successive retries of an `eth_getProof`
+ * Initial delay (in milliseconds) before the first retry of an `eth_getProof`
  * request against an oblivious TEE node that reported the requested state as
- * not yet available. The node typically needs a few seconds to make the data
- * available (ORAM/TEE warm-up). The effective spacing between attempts is this
- * delay plus the request round-trip time.
+ * not yet available. Subsequent retries use exponential backoff (doubling),
+ * capped at `ETH_OBLIVIOUS_RETRY_MAX_MS`. Starting low polls fast for the
+ * common case (data ready after ~1s); the cap keeps the request count low for
+ * slow cases. The effective spacing is this delay plus the round-trip time.
  */
-#define ETH_OBLIVIOUS_RETRY_DELAY_MS 2000
+#define ETH_OBLIVIOUS_RETRY_BASE_MS 500
+
+/**
+ * Upper bound (in milliseconds) for the exponential backoff between oblivious
+ * `eth_getProof` retries. Caps the doubling so a slow node is not polled with
+ * ever-growing gaps.
+ */
+#define ETH_OBLIVIOUS_RETRY_MAX_MS 8000
 
 /**
  * Maximum number of delayed retries for an oblivious `eth_getProof` request.
- * With `ETH_OBLIVIOUS_RETRY_DELAY_MS` this bounds the total wait (~30s) and avoids
- * endless loops if the node never returns the data.
+ * With the capped backoff this bounds the total wait (~55s) and avoids endless
+ * loops if the node never returns the data.
  */
-#define ETH_OBLIVIOUS_MAX_RETRIES 15
+#define ETH_OBLIVIOUS_MAX_RETRIES 10
+
+/**
+ * Computes the exponential-backoff delay (in milliseconds) for the next
+ * oblivious `eth_getProof` retry, given how many retries have already happened.
+ *
+ * The delay is `ETH_OBLIVIOUS_RETRY_BASE_MS << retry_count`, capped at
+ * `ETH_OBLIVIOUS_RETRY_MAX_MS` (so the sequence is 500, 1000, 2000, 4000, 8000,
+ * 8000, ...). Pass `data_request_t.retry_count` *before* the retry is scheduled.
+ *
+ * @param retry_count number of delayed retries already performed for the request
+ * @return delay in milliseconds to wait before the next retry
+ */
+uint32_t eth_oblivious_retry_delay(uint16_t retry_count);
 
 /**
  * Returns `true` if a JSON-RPC response signals that an oblivious node could not

--- a/src/chains/eth/verifier/eth_verify.h
+++ b/src/chains/eth/verifier/eth_verify.h
@@ -117,42 +117,40 @@ bool eth_check_latest_freshness(verify_ctx_t* ctx, bool is_latest, bool has_ts, 
 // :: Oblivious node delayed-retry
 
 /**
- * Initial delay (in milliseconds) before the first retry of an `eth_getProof`
- * request against an oblivious TEE node that reported the requested state as
- * not yet available. Subsequent retries use exponential backoff (doubling),
- * capped at `ETH_OBLIVIOUS_RETRY_MAX_MS`. 1s matches the observed warm-up of
- * the node (a 500ms first retry was empirically still too early); the cap keeps
- * the request count low for slow cases. The effective spacing is this delay
- * plus the round-trip time.
- */
-#define ETH_OBLIVIOUS_RETRY_BASE_MS 1000
-
-/**
- * Upper bound (in milliseconds) for the exponential backoff between oblivious
- * `eth_getProof` retries. Caps the doubling so a slow node is not polled with
- * ever-growing gaps.
- */
-#define ETH_OBLIVIOUS_RETRY_MAX_MS 8000
-
-/**
  * Maximum number of delayed retries for an oblivious `eth_getProof` request.
- * With the capped backoff this bounds the total wait (~55s) and avoids endless
+ * With the capped backoff (see `C4_RETRY_DELAY_MAX_MS` in `retry_delay.h`)
+ * this bounds the total wait (~55s in the worst case) and prevents endless
  * loops if the node never returns the data.
  */
 #define ETH_OBLIVIOUS_MAX_RETRIES 10
 
 /**
- * Computes the exponential-backoff delay (in milliseconds) for the next
- * oblivious `eth_getProof` retry, given how many retries have already happened.
+ * Computes the next exponential-backoff delay (in milliseconds) for an
+ * oblivious `eth_getProof` retry. Thin wrapper around `c4_retry_delay_for`
+ * with the oblivious category, so the prover and verifier paths share a
+ * single, adaptive learner that persists per chain via the storage plugin.
  *
- * The delay is `ETH_OBLIVIOUS_RETRY_BASE_MS << retry_count`, capped at
- * `ETH_OBLIVIOUS_RETRY_MAX_MS` (so the sequence is 1000, 2000, 4000, 8000,
- * 8000, ...). Pass `data_request_t.retry_count` *before* the retry is scheduled.
+ * Pass `data_request_t.retry_count` *before* the retry is scheduled.
  *
+ * @param chain target chain (used as part of the persistence key)
  * @param retry_count number of delayed retries already performed for the request
  * @return delay in milliseconds to wait before the next retry
  */
-uint32_t eth_oblivious_retry_delay(uint16_t retry_count);
+uint32_t eth_oblivious_retry_delay(chain_id_t chain, uint16_t retry_count);
+
+/**
+ * Notifies the adaptive learner that an oblivious `eth_getProof` request
+ * eventually succeeded after `retry_count` delayed retries (0 means the very
+ * first request already succeeded).
+ *
+ * Thin wrapper around `c4_retry_delay_observe` with the oblivious category.
+ * Call this only when the request was actually routed to an oblivious node;
+ * otherwise the learner would be polluted by unrelated traffic.
+ *
+ * @param chain target chain (used as part of the persistence key)
+ * @param retry_count number of delayed retries that were performed
+ */
+void eth_oblivious_retry_observe(chain_id_t chain, uint16_t retry_count);
 
 /**
  * Returns `true` if a JSON-RPC response signals that an oblivious node could not

--- a/src/chains/eth/verifier/eth_verify.h
+++ b/src/chains/eth/verifier/eth_verify.h
@@ -114,4 +114,38 @@ bool eth_json_is_latest(json_t block_tag);
  */
 bool eth_check_latest_freshness(verify_ctx_t* ctx, bool is_latest, bool has_ts, uint64_t block_ts);
 
+// :: Oblivious node delayed-retry
+
+/**
+ * Delay (in milliseconds) between successive retries of an `eth_getProof`
+ * request against an oblivious TEE node that reported the requested state as
+ * not yet available. The node typically needs a few seconds to make the data
+ * available (ORAM/TEE warm-up).
+ */
+#define ETH_OBLIVIOUS_RETRY_DELAY_MS 3000
+
+/**
+ * Maximum number of delayed retries for an oblivious `eth_getProof` request.
+ * With `ETH_OBLIVIOUS_RETRY_DELAY_MS` this bounds the total wait (~45s) and avoids
+ * endless loops if the node never returns the data.
+ */
+#define ETH_OBLIVIOUS_MAX_RETRIES 15
+
+/**
+ * Returns `true` if a JSON-RPC response signals that an oblivious node could not
+ * (yet) provide the requested data and the request should be retried.
+ *
+ * Detects the oblivious-node specific signal `error.code == -32001` together
+ * with a `data non availability` message. The match is intentionally narrow so
+ * a regular RPC provider's unrelated `-32001` does not trigger pointless waits.
+ *
+ * Lives in the verifier library (MIT) so both the verifier (`call_ctx.c`) and
+ * the prover (`eth_req.c`, which depends on the verifier) can share it without
+ * the prover becoming a dependency of embedded verifier-only builds.
+ *
+ * @param response Parsed JSON-RPC response object (as returned by `json_parse`)
+ * @return `true` if the response is an oblivious "data not available" error
+ */
+bool eth_is_oblivious_unavailable(json_t response);
+
 #endif // eth_verify_h__

--- a/src/chains/eth/verifier/eth_verify.h
+++ b/src/chains/eth/verifier/eth_verify.h
@@ -114,7 +114,13 @@ bool eth_json_is_latest(json_t block_tag);
  */
 bool eth_check_latest_freshness(verify_ctx_t* ctx, bool is_latest, bool has_ts, uint64_t block_ts);
 
+#ifdef ETH_OBLIVIOUS
 // :: Oblivious node delayed-retry
+//
+// The entire oblivious helper surface is compiled out when `ETH_OBLIVIOUS` is
+// disabled at configure time. Call sites in the verifier and prover are gated
+// the same way, so the linker can drop the generic adaptive retry-delay
+// learner (`src/util/retry_delay.c`) as dead code when no chain references it.
 
 /**
  * Maximum number of delayed retries for an oblivious `eth_getProof` request.
@@ -168,5 +174,7 @@ void eth_oblivious_retry_observe(chain_id_t chain, uint16_t retry_count);
  * @return `true` if the response is an oblivious "data not available" error
  */
 bool eth_is_oblivious_unavailable(json_t response);
+
+#endif // ETH_OBLIVIOUS
 
 #endif // eth_verify_h__

--- a/src/chains/eth/verifier/eth_verify.h
+++ b/src/chains/eth/verifier/eth_verify.h
@@ -120,11 +120,12 @@ bool eth_check_latest_freshness(verify_ctx_t* ctx, bool is_latest, bool has_ts, 
  * Initial delay (in milliseconds) before the first retry of an `eth_getProof`
  * request against an oblivious TEE node that reported the requested state as
  * not yet available. Subsequent retries use exponential backoff (doubling),
- * capped at `ETH_OBLIVIOUS_RETRY_MAX_MS`. Starting low polls fast for the
- * common case (data ready after ~1s); the cap keeps the request count low for
- * slow cases. The effective spacing is this delay plus the round-trip time.
+ * capped at `ETH_OBLIVIOUS_RETRY_MAX_MS`. 1s matches the observed warm-up of
+ * the node (a 500ms first retry was empirically still too early); the cap keeps
+ * the request count low for slow cases. The effective spacing is this delay
+ * plus the round-trip time.
  */
-#define ETH_OBLIVIOUS_RETRY_BASE_MS 500
+#define ETH_OBLIVIOUS_RETRY_BASE_MS 1000
 
 /**
  * Upper bound (in milliseconds) for the exponential backoff between oblivious
@@ -145,7 +146,7 @@ bool eth_check_latest_freshness(verify_ctx_t* ctx, bool is_latest, bool has_ts, 
  * oblivious `eth_getProof` retry, given how many retries have already happened.
  *
  * The delay is `ETH_OBLIVIOUS_RETRY_BASE_MS << retry_count`, capped at
- * `ETH_OBLIVIOUS_RETRY_MAX_MS` (so the sequence is 500, 1000, 2000, 4000, 8000,
+ * `ETH_OBLIVIOUS_RETRY_MAX_MS` (so the sequence is 1000, 2000, 4000, 8000,
  * 8000, ...). Pass `data_request_t.retry_count` *before* the retry is scheduled.
  *
  * @param retry_count number of delayed retries already performed for the request

--- a/src/chains/eth/verifier/pap_tx_cache.c
+++ b/src/chains/eth/verifier/pap_tx_cache.c
@@ -28,7 +28,6 @@
 #include "pap_tx_cache_types.h"
 #include "plugin.h"
 #include "ssz.h"
-#include <stdio.h>
 #include <string.h>
 #include <time.h>
 
@@ -50,7 +49,11 @@ static void cache_free(void) {
 }
 
 static void tx_cache_storage_key(chain_id_t chain_id, char* buf, size_t buf_len) {
-  snprintf(buf, buf_len, "tx_cache_%u", (unsigned) chain_id);
+  // bprintf instead of snprintf so embedded/verifier-only builds stay free of
+  // the libc printf family. The buffer is treated as fixed-size (negative
+  // `allocated`); bprintf clamps + NUL-terminates within `buf_len`.
+  buffer_t b = (buffer_t) {.data = bytes((uint8_t*) buf, 0), .allocated = -(int32_t) buf_len};
+  bprintf(&b, "tx_cache_%d", (uint32_t) chain_id);
 }
 
 static bool parse_snapshot(bytes_t ssz_data) {
@@ -249,7 +252,8 @@ uint64_t pap_tx_cache_last_updated(chain_id_t chain_id) {
 #define PAP_PENDING_ENTRY_SIZE 40 /* 32 (tx_hash) + 8 (timestamp LE) */
 
 static void pending_storage_key(chain_id_t chain_id, char* buf, size_t buf_len) {
-  snprintf(buf, buf_len, "tx_pending_%u", (unsigned) chain_id);
+  buffer_t b = (buffer_t) {.data = bytes((uint8_t*) buf, 0), .allocated = -(int32_t) buf_len};
+  bprintf(&b, "tx_pending_%d", (uint32_t) chain_id);
 }
 
 static ssz_ob_t pending_load_list(chain_id_t chain_id) {

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(util STATIC
   logger.c
   chains.c
   state.c
+  retry_delay.c
   version.c
   witness.c
 )

--- a/src/util/retry_delay.c
+++ b/src/util/retry_delay.c
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2025,2026 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "retry_delay.h"
+#include "bytes.h"
+#include "plugin.h"
+#include <stdio.h>
+#include <string.h>
+
+// Asymmetric learning gains expressed as right-shifts (powers of two) so the
+// arithmetic is exact on integers and obvious from the code. Up: react fast
+// (1/2 of the gap); Down: probe slowly (1/8 of the gap). The factors were
+// chosen so that a single under-estimate quickly catches up (one extra retry
+// roughly doubles the base) while a slightly over-estimated base takes many
+// successful R=0 outcomes to drift down (avoiding an extra retry just to
+// "save" a few hundred ms).
+#define RETRY_DELAY_UP_SHIFT   1
+#define RETRY_DELAY_DOWN_SHIFT 3
+
+// On R == 0 (first request already succeeded) we have no measurement of how
+// much faster the node could be; probe downward by 25% as a conservative
+// guess. Combined with DOWN_SHIFT the effective base reduction is
+// (1 - 3/4) / 8 = 1/32 of the current base per R=0 success.
+#define RETRY_DELAY_R0_TARGET_NUM 3
+#define RETRY_DELAY_R0_TARGET_DEN 4
+
+// Persisted blob layout: 1 byte version || 4 bytes uint32 LE base_ms.
+// The version byte lets us evolve the format without breaking older state
+// files (rejected on mismatch -> falls back to the default).
+#define RETRY_DELAY_BLOB_VERSION 1u
+#define RETRY_DELAY_BLOB_SIZE    5u
+
+// Fixed-size in-memory cache. Sized to comfortably hold a handful of
+// (category, chain) pairs (today: 1 category x ~2-3 active chains). Overflow
+// reuses slot 0; the resulting churn just costs an extra storage lookup.
+#define RETRY_DELAY_CACHE_SIZE 8
+
+typedef struct {
+  const char* category;
+  chain_id_t  chain;
+  uint32_t    base_ms;
+  bool        in_use;
+} retry_delay_entry_t;
+
+static retry_delay_entry_t g_cache[RETRY_DELAY_CACHE_SIZE];
+
+static void build_key(const char* category, chain_id_t chain, char* buf, size_t len) {
+  snprintf(buf, len, "rdelay_%s_%llu", category, (unsigned long long) chain);
+}
+
+static uint32_t clamp_base(uint32_t base) {
+  if (base < C4_RETRY_DELAY_MIN_MS) return C4_RETRY_DELAY_MIN_MS;
+  if (base > C4_RETRY_DELAY_MAX_MS) return C4_RETRY_DELAY_MAX_MS;
+  return base;
+}
+
+static bool decode_base(bytes_t blob, uint32_t* out) {
+  if (blob.len != RETRY_DELAY_BLOB_SIZE || blob.data == NULL) return false;
+  if (blob.data[0] != RETRY_DELAY_BLOB_VERSION) return false;
+  uint32_t v = (uint32_t) blob.data[1] |
+               ((uint32_t) blob.data[2] << 8) |
+               ((uint32_t) blob.data[3] << 16) |
+               ((uint32_t) blob.data[4] << 24);
+  *out = clamp_base(v);
+  return true;
+}
+
+static void encode_base(uint32_t base, uint8_t buf[RETRY_DELAY_BLOB_SIZE]) {
+  buf[0] = (uint8_t) RETRY_DELAY_BLOB_VERSION;
+  buf[1] = (uint8_t) (base & 0xff);
+  buf[2] = (uint8_t) ((base >> 8) & 0xff);
+  buf[3] = (uint8_t) ((base >> 16) & 0xff);
+  buf[4] = (uint8_t) ((base >> 24) & 0xff);
+}
+
+static retry_delay_entry_t* lookup_entry(const char* category, chain_id_t chain) {
+  retry_delay_entry_t* free_slot = NULL;
+  for (size_t i = 0; i < RETRY_DELAY_CACHE_SIZE; i++) {
+    retry_delay_entry_t* e = &g_cache[i];
+    if (!e->in_use) {
+      if (!free_slot) free_slot = e;
+      continue;
+    }
+    if (e->chain == chain && e->category && strcmp(e->category, category) == 0) return e;
+  }
+  // Cache full: reuse slot 0. With only a few categories x chains this is a
+  // pathological case; the worst outcome is one extra storage lookup.
+  if (!free_slot) free_slot = &g_cache[0];
+
+  uint32_t         base   = C4_RETRY_DELAY_DEFAULT_MS;
+  storage_plugin_t plugin = {0};
+  c4_get_storage_config(&plugin);
+  if (plugin.get) {
+    char     key[64];
+    buffer_t buf = {0};
+    build_key(category, chain, key, sizeof(key));
+    if (plugin.get(key, &buf)) {
+      uint32_t parsed = 0;
+      if (decode_base(buf.data, &parsed)) base = parsed;
+    }
+    buffer_free(&buf);
+  }
+
+  free_slot->category = category;
+  free_slot->chain    = chain;
+  free_slot->base_ms  = base;
+  free_slot->in_use   = true;
+  return free_slot;
+}
+
+static void persist_entry(const retry_delay_entry_t* e) {
+  storage_plugin_t plugin = {0};
+  c4_get_storage_config(&plugin);
+  if (!plugin.set) return;
+
+  char    key[64];
+  uint8_t blob[RETRY_DELAY_BLOB_SIZE];
+  build_key(e->category, e->chain, key, sizeof(key));
+  encode_base(e->base_ms, blob);
+  plugin.set(key, bytes(blob, RETRY_DELAY_BLOB_SIZE));
+}
+
+uint32_t c4_retry_delay_for(const char* category, chain_id_t chain, uint16_t retry_count) {
+  if (!category) return C4_RETRY_DELAY_DEFAULT_MS;
+  retry_delay_entry_t* e     = lookup_entry(category, chain);
+  uint32_t             delay = e->base_ms;
+  for (uint16_t i = 0; i < retry_count && delay < C4_RETRY_DELAY_MAX_MS; i++)
+    delay <<= 1;
+  return delay > C4_RETRY_DELAY_MAX_MS ? C4_RETRY_DELAY_MAX_MS : delay;
+}
+
+void c4_retry_delay_observe(const char* category, chain_id_t chain, uint16_t retry_count) {
+  if (!category) return;
+  retry_delay_entry_t* e    = lookup_entry(category, chain);
+  uint32_t             base = e->base_ms;
+
+  // Translate the (retry_count, base) outcome into a target base for next time:
+  //   R == 0: server was already warm -> probe down to 0.75 * base.
+  //   R >= 1: warm-up time was approximately base * (2^R - 1) (the cumulative
+  //           scheduled wait at the successful retry). R == 1 hits target=base
+  //           exactly, which means "no change" -- the sweet spot.
+  uint32_t target;
+  if (retry_count == 0) {
+    target = (uint32_t) ((uint64_t) base * RETRY_DELAY_R0_TARGET_NUM / RETRY_DELAY_R0_TARGET_DEN);
+  }
+  else {
+    // Compute (2^R - 1), saturating in uint64_t to keep the multiplication
+    // safe. The final value is clamped to MAX anyway.
+    uint64_t mult = 0;
+    uint64_t cur  = 1;
+    for (uint16_t i = 0; i < retry_count; i++) {
+      mult += cur;
+      // Saturate the running shift; once mult exceeds MAX/base, further bits
+      // would only push us higher than the cap.
+      if (cur > (uint64_t) C4_RETRY_DELAY_MAX_MS) break;
+      cur <<= 1;
+    }
+    uint64_t t = mult * (uint64_t) base;
+    target     = t > (uint64_t) C4_RETRY_DELAY_MAX_MS ? C4_RETRY_DELAY_MAX_MS : (uint32_t) t;
+  }
+
+  // Round the (gap >> shift) step up so a 1-unit gap still moves us by 1.
+  // Without this, integer truncation would stall the base just shy of the
+  // target (e.g. forever at 7999 instead of reaching MAX=8000).
+  uint32_t new_base;
+  if (target > base) {
+    uint32_t gap  = target - base;
+    uint32_t step = (gap + (1u << RETRY_DELAY_UP_SHIFT) - 1u) >> RETRY_DELAY_UP_SHIFT;
+    new_base      = base + step;
+  }
+  else if (target < base) {
+    uint32_t gap  = base - target;
+    uint32_t step = (gap + (1u << RETRY_DELAY_DOWN_SHIFT) - 1u) >> RETRY_DELAY_DOWN_SHIFT;
+    new_base      = base - step;
+  }
+  else
+    new_base = base;
+
+  new_base = clamp_base(new_base);
+  if (new_base == e->base_ms) return;
+  e->base_ms = new_base;
+  persist_entry(e);
+}
+
+void c4_retry_delay_reset(void) {
+  memset(g_cache, 0, sizeof(g_cache));
+}

--- a/src/util/retry_delay.c
+++ b/src/util/retry_delay.c
@@ -76,20 +76,13 @@ static uint32_t clamp_base(uint32_t base) {
 static bool decode_base(bytes_t blob, uint32_t* out) {
   if (blob.len != RETRY_DELAY_BLOB_SIZE || blob.data == NULL) return false;
   if (blob.data[0] != RETRY_DELAY_BLOB_VERSION) return false;
-  uint32_t v = (uint32_t) blob.data[1] |
-               ((uint32_t) blob.data[2] << 8) |
-               ((uint32_t) blob.data[3] << 16) |
-               ((uint32_t) blob.data[4] << 24);
-  *out = clamp_base(v);
+  *out = clamp_base(uint32_from_le(blob.data + 1));
   return true;
 }
 
 static void encode_base(uint32_t base, uint8_t buf[RETRY_DELAY_BLOB_SIZE]) {
   buf[0] = (uint8_t) RETRY_DELAY_BLOB_VERSION;
-  buf[1] = (uint8_t) (base & 0xff);
-  buf[2] = (uint8_t) ((base >> 8) & 0xff);
-  buf[3] = (uint8_t) ((base >> 16) & 0xff);
-  buf[4] = (uint8_t) ((base >> 24) & 0xff);
+  uint32_to_le(buf + 1, base);
 }
 
 static retry_delay_entry_t* lookup_entry(const char* category, chain_id_t chain) {

--- a/src/util/retry_delay.c
+++ b/src/util/retry_delay.c
@@ -31,18 +31,17 @@
 // arithmetic is exact on integers and obvious from the code. Up: react fast
 // (1/2 of the gap); Down: probe slowly (1/8 of the gap). The factors were
 // chosen so that a single under-estimate quickly catches up (one extra retry
-// roughly doubles the base) while a slightly over-estimated base takes many
-// successful R=0 outcomes to drift down (avoiding an extra retry just to
+// roughly doubles the base) while an over-estimated base takes several
+// "server was ready"-outcomes to drift down (avoiding an extra retry just to
 // "save" a few hundred ms).
 #define RETRY_DELAY_UP_SHIFT   1
 #define RETRY_DELAY_DOWN_SHIFT 3
 
-// On R == 0 (first request already succeeded) we have no measurement of how
-// much faster the node could be; probe downward by 25% as a conservative
-// guess. Combined with DOWN_SHIFT the effective base reduction is
-// (1 - 3/4) / 8 = 1/32 of the current base per R=0 success.
-#define RETRY_DELAY_R0_TARGET_NUM 3
-#define RETRY_DELAY_R0_TARGET_DEN 4
+// Target for the "server was already ready" outcomes (R == 0 and R == 1).
+// Both observations only tell us T_warm <= base; the midpoint of the bound
+// (0, base] is base/2, which is what we use as the next-base target. The
+// slow DOWN_SHIFT prevents this from oscillating around the actual T_warm.
+#define RETRY_DELAY_READY_TARGET_SHIFT 1
 
 // Persisted blob layout: 1 byte version || 4 bytes uint32 LE base_ms.
 // The version byte lets us evolve the format without breaking older state
@@ -155,13 +154,17 @@ void c4_retry_delay_observe(const char* category, chain_id_t chain, uint16_t ret
   uint32_t             base = e->base_ms;
 
   // Translate the (retry_count, base) outcome into a target base for next time:
-  //   R == 0: server was already warm -> probe down to 0.75 * base.
-  //   R >= 1: warm-up time was approximately base * (2^R - 1) (the cumulative
-  //           scheduled wait at the successful retry). R == 1 hits target=base
-  //           exactly, which means "no change" -- the sweet spot.
+  //   R == 0 or R == 1: server was ready by base ms -> probe down to base/2.
+  //     We cannot tell whether T_warm was 0 or close to base from a single
+  //     observation, so we use the midpoint of the bound (0, base] as our
+  //     guess. The slow DOWN_SHIFT keeps this from oscillating; once the
+  //     base drifts too low we will see an R == 2 and jump back up.
+  //   R >= 2: warm-up time was in (base*(2^(R-1)-1), base*(2^R - 1)]; we
+  //     target the upper bound so the next attempt is again likely to hit
+  //     R == 1 (the optimum we then probe down from again).
   uint32_t target;
-  if (retry_count == 0) {
-    target = (uint32_t) ((uint64_t) base * RETRY_DELAY_R0_TARGET_NUM / RETRY_DELAY_R0_TARGET_DEN);
+  if (retry_count <= 1) {
+    target = base >> RETRY_DELAY_READY_TARGET_SHIFT;
   }
   else {
     // Compute (2^R - 1), saturating in uint64_t to keep the multiplication

--- a/src/util/retry_delay.c
+++ b/src/util/retry_delay.c
@@ -24,7 +24,6 @@
 #include "retry_delay.h"
 #include "bytes.h"
 #include "plugin.h"
-#include <stdio.h>
 #include <string.h>
 
 // Asymmetric learning gains expressed as right-shifts (powers of two) so the
@@ -64,7 +63,12 @@ typedef struct {
 static retry_delay_entry_t g_cache[RETRY_DELAY_CACHE_SIZE];
 
 static void build_key(const char* category, chain_id_t chain, char* buf, size_t len) {
-  snprintf(buf, len, "rdelay_%s_%llu", category, (unsigned long long) chain);
+  // Use `bprintf` so embedded/verifier-only builds don't pull in the libc
+  // printf family (saves ~5-10 KB on glibc/newlib targets). The buffer stays
+  // fixed-size by marking `allocated` negative; `bprintf` writes within the
+  // bound and adds the NUL terminator.
+  buffer_t b = (buffer_t) {.data = bytes((uint8_t*) buf, 0), .allocated = -(int32_t) len};
+  bprintf(&b, "rdelay_%s_%l", category, (uint64_t) chain);
 }
 
 static uint32_t clamp_base(uint32_t base) {

--- a/src/util/retry_delay.h
+++ b/src/util/retry_delay.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2025,2026 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef retry_delay_h__
+#define retry_delay_h__
+
+#include "chains.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// :: Adaptive same-node retry delay
+
+/**
+ * Use-case category for the oblivious-node (`-32001 data non availability`)
+ * delayed-retry loop. Pass this constant to `c4_retry_delay_for` and
+ * `c4_retry_delay_observe`.
+ *
+ * Distinct categories learn independent base delays so a future use case
+ * (e.g. waiting for a pending transaction receipt) can coexist without
+ * one polluting the other's learner.
+ *
+ * **Lifetime contract**: category strings are kept by reference (not copied)
+ * inside the in-memory cache. Only pass string literals or otherwise
+ * statically-allocated strings here; a heap pointer that is later freed
+ * would leave a dangling reference in the cache.
+ */
+#define C4_RETRY_CATEGORY_OBLIVIOUS "oblivious"
+
+/**
+ * Initial base delay (in milliseconds) used when no learned value exists yet.
+ * 1s matches the empirically observed warm-up of the reference oblivious node.
+ */
+#define C4_RETRY_DELAY_DEFAULT_MS 1000U
+
+/**
+ * Floor for the learned base delay (ms). Prevents the asymmetric downward
+ * probe from collapsing below realistic network-RTT territory.
+ */
+#define C4_RETRY_DELAY_MIN_MS 100U
+
+/**
+ * Cap for the learned base delay (ms) and for the exponential backoff. Bounds
+ * the total wait so a single very slow node cannot stall the request for
+ * arbitrarily long.
+ */
+#define C4_RETRY_DELAY_MAX_MS 8000U
+
+/**
+ * Computes the delay (in milliseconds) the host should wait before the next
+ * same-node retry for the given (`category`, `chain`) pair.
+ *
+ * The delay is `min(base << retry_count, C4_RETRY_DELAY_MAX_MS)` where `base`
+ * is loaded lazily from the storage plugin via the key
+ * `rdelay_<category>_<chain_id>` and falls back to
+ * `C4_RETRY_DELAY_DEFAULT_MS` if no persisted value exists (or the plugin is
+ * not registered).
+ *
+ * The returned delay is always >= `C4_RETRY_DELAY_MIN_MS` (the clamp is applied
+ * on load) and <= `C4_RETRY_DELAY_MAX_MS` (the shift saturates safely even for
+ * very large `retry_count` values).
+ *
+ * **Side effects**: in FILE_STORAGE / MEMORY_STORAGE builds the first call
+ * for an unseen `(category, chain)` pair may touch the storage plugin via
+ * `c4_get_storage_config`, which auto-installs the compile-time default
+ * backend when no host plugin is registered.
+ *
+ * **Threading**: not thread-safe. The learner uses module-level globals; if
+ * multiple threads can drive retries concurrently the caller must serialize
+ * access (see `src/util/AGENTS.md`).
+ *
+ * @param category    Use-case category (a `C4_RETRY_CATEGORY_*` string literal,
+ *                    see lifetime contract on `C4_RETRY_CATEGORY_OBLIVIOUS`)
+ * @param chain       Chain identifier (part of the persistence key)
+ * @param retry_count Number of delayed retries already performed (typically
+ *                    `data_request_t.retry_count` before scheduling the next)
+ * @return Delay in milliseconds before the next retry
+ */
+uint32_t c4_retry_delay_for(const char* category, chain_id_t chain, uint16_t retry_count);
+
+/**
+ * Feeds a successful request outcome back into the learner.
+ *
+ * `retry_count == 0` means the very first request succeeded (the node was
+ * already warm); the base is probed slightly downward. `retry_count > 0`
+ * means delayed retries were needed; the cumulative scheduled wait at the
+ * successful retry (`base * (2^retry_count - 1)`) is used as the warm-up
+ * estimate and the base is moved towards it.
+ *
+ * Adaptation is intentionally asymmetric: it reacts fast when more delay is
+ * needed (so a slow node converges quickly) and probes downward slowly (to
+ * avoid the converse — gradually drifting into an extra retry per request).
+ * The new base is clamped to `[C4_RETRY_DELAY_MIN_MS, C4_RETRY_DELAY_MAX_MS]`
+ * and persisted via the storage plugin when one is registered.
+ *
+ * Only call this from a code path where the same-node retry loop for the
+ * given category was active (e.g. for `C4_RETRY_CATEGORY_OBLIVIOUS`, only
+ * when the request was routed to an oblivious node). Otherwise the learner
+ * would be polluted by unrelated traffic.
+ *
+ * @param category    Same string previously passed to `c4_retry_delay_for`
+ * @param chain       Chain identifier
+ * @param retry_count Number of delayed retries that were performed before
+ *                    the request finally succeeded
+ */
+void c4_retry_delay_observe(const char* category, chain_id_t chain, uint16_t retry_count);
+
+/**
+ * Drops all cached (`category`, `chain`) -> base entries from the in-memory
+ * cache, forcing the next call to re-read from the storage plugin. Does not
+ * touch persisted values. Intended for tests and process-reset scenarios.
+ */
+void c4_retry_delay_reset(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/util/retry_delay.h
+++ b/src/util/retry_delay.h
@@ -104,17 +104,24 @@ uint32_t c4_retry_delay_for(const char* category, chain_id_t chain, uint16_t ret
 /**
  * Feeds a successful request outcome back into the learner.
  *
- * `retry_count == 0` means the very first request succeeded (the node was
- * already warm); the base is probed slightly downward. `retry_count > 0`
- * means delayed retries were needed; the cumulative scheduled wait at the
- * successful retry (`base * (2^retry_count - 1)`) is used as the warm-up
- * estimate and the base is moved towards it.
+ * The new target base is derived from `retry_count` as follows:
+ *
+ * - `retry_count == 0` or `retry_count == 1`: the server was ready within
+ *   `base` ms. Both outcomes give only an upper bound on the warm-up time
+ *   (`T_warm <= base`), so we use the midpoint `base/2` as the target and
+ *   let the slow downward gain (`DOWN_SHIFT`) probe carefully. Once the
+ *   base drifts too low we will see an `R == 2` and jump back up.
+ * - `retry_count >= 2`: the warm-up time fell into
+ *   `(base * (2^(R-1) - 1), base * (2^R - 1)]`. We target the upper bound
+ *   so the next attempt is again likely to hit `R == 1`, from which we can
+ *   probe down again.
  *
  * Adaptation is intentionally asymmetric: it reacts fast when more delay is
- * needed (so a slow node converges quickly) and probes downward slowly (to
- * avoid the converse — gradually drifting into an extra retry per request).
- * The new base is clamped to `[C4_RETRY_DELAY_MIN_MS, C4_RETRY_DELAY_MAX_MS]`
- * and persisted via the storage plugin when one is registered.
+ * needed (so a slow node converges quickly, `UP_SHIFT` half the gap) and
+ * probes downward slowly (`DOWN_SHIFT` an eighth of the gap, to avoid
+ * gradually drifting into an extra retry per request). The new base is
+ * clamped to `[C4_RETRY_DELAY_MIN_MS, C4_RETRY_DELAY_MAX_MS]` and persisted
+ * via the storage plugin when one is registered.
  *
  * Only call this from a code path where the same-node retry loop for the
  * given category was active (e.g. for `C4_RETRY_CATEGORY_OBLIVIOUS`, only

--- a/src/util/state.c
+++ b/src/util/state.c
@@ -96,6 +96,21 @@ bool c4_state_is_pending(data_request_t* req) {
   return !req->error && !req->response.data;
 }
 
+bool c4_state_retry_after(data_request_t* req, uint32_t delay_ms, uint16_t max_retries) {
+  if (!req || req->retry_count >= max_retries) return false;
+  if (req->response.data) {
+    safe_free(req->response.data);
+    req->response = NULL_BYTES;
+  }
+  if (req->error) {
+    safe_free(req->error);
+    req->error = NULL;
+  }
+  req->delay = delay_ms;
+  req->retry_count++;
+  return true;
+}
+
 void c4_state_add_request(c4_state_t* state, data_request_t* data_request) {
   log_debug("adding request type %d : %s %r", data_request->type, data_request->url ? "url" : "rpc", data_request->url ? bytes(data_request->url, strlen(data_request->url)) : data_request->payload);
   if (bytes_all_zero(bytes(data_request->id, C4_BYTES32_SIZE))) {

--- a/src/util/state.c
+++ b/src/util/state.c
@@ -106,7 +106,13 @@ bool c4_state_retry_after(data_request_t* req, uint32_t delay_ms, uint16_t max_r
     safe_free(req->error);
     req->error = NULL;
   }
-  req->delay = delay_ms;
+  // Retry on the SAME node: reset the host-side node selection. Hosts (e.g. the
+  // curl host) resume from `response_node_index` and skip already-tried nodes;
+  // without this reset the only oblivious node is skipped ("no more nodes to
+  // try"). Unlike `RETRY_REQUEST`, we explicitly do NOT exclude the node.
+  req->response_node_index = 0;
+  req->node_exclude_mask   = 0;
+  req->delay               = delay_ms;
   req->retry_count++;
   return true;
 }

--- a/src/util/state.h
+++ b/src/util/state.h
@@ -355,7 +355,7 @@ bool c4_state_is_pending(data_request_t* req);
  *
  * ```c
  * if (eth_is_oblivious_unavailable(response) &&
- *     !c4_state_retry_after(req, eth_oblivious_retry_delay(req->retry_count), ETH_OBLIVIOUS_MAX_RETRIES))
+ *     !c4_state_retry_after(req, eth_oblivious_retry_delay(req->chain_id, req->retry_count), ETH_OBLIVIOUS_MAX_RETRIES))
  *   THROW_ERROR("oblivious node did not provide the proof in time");
  * ```
  *

--- a/src/util/state.h
+++ b/src/util/state.h
@@ -355,7 +355,7 @@ bool c4_state_is_pending(data_request_t* req);
  *
  * ```c
  * if (eth_is_oblivious_unavailable(response) &&
- *     !c4_state_retry_after(req, ETH_OBLIVIOUS_RETRY_DELAY_MS, ETH_OBLIVIOUS_MAX_RETRIES))
+ *     !c4_state_retry_after(req, eth_oblivious_retry_delay(req->retry_count), ETH_OBLIVIOUS_MAX_RETRIES))
  *   THROW_ERROR("oblivious node did not provide the proof in time");
  * ```
  *

--- a/src/util/state.h
+++ b/src/util/state.h
@@ -246,7 +246,9 @@ typedef struct data_request {
   char*                   error;                 ///< Error message if request failed (NULL if no error)
   struct data_request*    next;                  ///< Pointer to next request in linked list
   bytes32_t               id;                    ///< Unique identifier for this request (32-byte hash)
-  uint32_t                ttl;                   ///< Time-to-live or retry counter for this request
+  uint32_t                ttl;                   ///< Time-to-live / node-rotation retry counter (see `RETRY_REQUEST`, which retries on a *different* node); distinct from `retry_count` below
+  uint32_t                delay;                 ///< Milliseconds the host must wait before (re-)executing this request (0 = no delay). Used for delayed same-node retries (e.g. oblivious node warm-up).
+  uint16_t                retry_count;           ///< Number of delayed *same-node* retries already performed (see `c4_state_retry_after`); managed by the chain module, not the host
   bool                    validated;             ///< Whether the response has been validated
 } data_request_t;
 
@@ -338,6 +340,31 @@ data_request_t* c4_state_get_data_request_by_url(c4_state_t* state, char* url);
  * @return true if pending, false if completed or failed
  */
 bool c4_state_is_pending(data_request_t* req);
+
+/**
+ * Schedules a delayed retry of a request on the **same** node.
+ *
+ * Unlike `RETRY_REQUEST`, this does **not** set `node_exclude_mask`: the request
+ * is meant to hit the same endpoint again after a short pause (e.g. an oblivious
+ * TEE node that needs a few seconds to make the requested state available).
+ *
+ * On success the response and error are cleared, `delay` is set and
+ * `retry_count` is incremented, so the host re-executes the request after
+ * waiting `delay_ms` milliseconds. The retry budget is bounded by `max_retries`
+ * to avoid endless loops.
+ *
+ * ```c
+ * if (eth_is_oblivious_unavailable(response) &&
+ *     !c4_state_retry_after(req, ETH_OBLIVIOUS_RETRY_DELAY_MS, ETH_OBLIVIOUS_MAX_RETRIES))
+ *   THROW_ERROR("oblivious node did not provide the proof in time");
+ * ```
+ *
+ * @param req Pointer to the request to retry
+ * @param delay_ms Milliseconds the host should wait before re-executing
+ * @param max_retries Maximum number of delayed retries allowed
+ * @return `true` if a retry was scheduled, `false` if the retry budget is exhausted
+ */
+bool c4_state_retry_after(data_request_t* req, uint32_t delay_ms, uint16_t max_retries);
 
 /**
  * Adds a new data request to the state.

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -67,6 +67,11 @@ foreach(test_source ${TEST_SOURCES})
     if(USE_CHECKPOINTZ)
         target_compile_definitions(${test_name} PRIVATE USE_CHECKPOINTZ)
     endif()
+    # Same for ETH_OBLIVIOUS: the oblivious helper declarations in eth_verify.h
+    # and the test bodies in test_oblivious_retry*.c are gated on this flag.
+    if(ETH_OBLIVIOUS)
+        target_compile_definitions(${test_name} PRIVATE ETH_OBLIVIOUS)
+    endif()
     
     if("${test_name}" STREQUAL "test_eth_precompiles")
         target_link_libraries(${test_name} PRIVATE eth_bn254 intx_wrapper eth_precompiles)

--- a/test/unittests/test_oblivious_retry.c
+++ b/test/unittests/test_oblivious_retry.c
@@ -30,6 +30,14 @@
 //
 // The detector lives in the eth verifier (eth_verify.h); it is declared here
 // to keep the test independent of the eth verifier's internal include paths.
+//
+// When `ETH_OBLIVIOUS` is disabled at configure time, the helpers under test
+// don't exist; we compile out to a no-op main so the test binary still links
+// and reports a clean pass.
+
+#include "unity.h"
+
+#ifdef ETH_OBLIVIOUS
 
 #include "bytes.h"
 #include "chains.h"
@@ -37,7 +45,6 @@
 #include "plugin.h"
 #include "retry_delay.h"
 #include "state.h"
-#include "unity.h"
 #include <string.h>
 
 extern bool     eth_is_oblivious_unavailable(json_t response);
@@ -140,3 +147,19 @@ int main(void) {
   RUN_TEST(test_retry_after_resets_node_selection);
   return UNITY_END();
 }
+
+#else // !ETH_OBLIVIOUS
+
+// Unity links setUp/tearDown unconditionally; provide empty stubs so the
+// stub-mode binary still resolves all symbols.
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(void) {
+  UNITY_BEGIN();
+  // ETH_OBLIVIOUS disabled: nothing to verify, exit with a clean pass so the
+  // CI matrix can still build this test binary.
+  return UNITY_END();
+}
+
+#endif // ETH_OBLIVIOUS

--- a/test/unittests/test_oblivious_retry.c
+++ b/test/unittests/test_oblivious_retry.c
@@ -91,13 +91,12 @@ void test_retry_after_clears_response_and_error(void) {
 
 void test_oblivious_retry_delay_backoff(void) {
   // Exponential backoff doubling from the base, capped at the max.
-  TEST_ASSERT_EQUAL_UINT32(500, eth_oblivious_retry_delay(0));
-  TEST_ASSERT_EQUAL_UINT32(1000, eth_oblivious_retry_delay(1));
-  TEST_ASSERT_EQUAL_UINT32(2000, eth_oblivious_retry_delay(2));
-  TEST_ASSERT_EQUAL_UINT32(4000, eth_oblivious_retry_delay(3));
-  TEST_ASSERT_EQUAL_UINT32(8000, eth_oblivious_retry_delay(4));
+  TEST_ASSERT_EQUAL_UINT32(1000, eth_oblivious_retry_delay(0));
+  TEST_ASSERT_EQUAL_UINT32(2000, eth_oblivious_retry_delay(1));
+  TEST_ASSERT_EQUAL_UINT32(4000, eth_oblivious_retry_delay(2));
+  TEST_ASSERT_EQUAL_UINT32(8000, eth_oblivious_retry_delay(3));
   // Capped from here on; large counts must not overflow the shift.
-  TEST_ASSERT_EQUAL_UINT32(8000, eth_oblivious_retry_delay(5));
+  TEST_ASSERT_EQUAL_UINT32(8000, eth_oblivious_retry_delay(4));
   TEST_ASSERT_EQUAL_UINT32(8000, eth_oblivious_retry_delay(40));
 }
 

--- a/test/unittests/test_oblivious_retry.c
+++ b/test/unittests/test_oblivious_retry.c
@@ -88,6 +88,19 @@ void test_retry_after_clears_response_and_error(void) {
   TEST_ASSERT_EQUAL_UINT32(1500, req.delay);
 }
 
+void test_retry_after_resets_node_selection(void) {
+  // A same-node retry must reset the host-side node selection: hosts resume
+  // from `response_node_index` and skip excluded nodes, so leaving these set
+  // would make the host skip the only oblivious node ("no more nodes to try").
+  data_request_t req     = {0};
+  req.response_node_index = 1;
+  req.node_exclude_mask   = 0x1;
+
+  TEST_ASSERT_TRUE(c4_state_retry_after(&req, 3000, 5));
+  TEST_ASSERT_EQUAL_UINT16(0, req.response_node_index);
+  TEST_ASSERT_EQUAL_UINT16(0, req.node_exclude_mask);
+}
+
 int main(void) {
   UNITY_BEGIN();
   RUN_TEST(test_detector_matches_oblivious_unavailable);
@@ -96,5 +109,6 @@ int main(void) {
   RUN_TEST(test_detector_rejects_valid_result);
   RUN_TEST(test_retry_after_schedules_and_bounds);
   RUN_TEST(test_retry_after_clears_response_and_error);
+  RUN_TEST(test_retry_after_resets_node_selection);
   return UNITY_END();
 }

--- a/test/unittests/test_oblivious_retry.c
+++ b/test/unittests/test_oblivious_retry.c
@@ -36,7 +36,8 @@
 #include "unity.h"
 #include <string.h>
 
-extern bool eth_is_oblivious_unavailable(json_t response);
+extern bool     eth_is_oblivious_unavailable(json_t response);
+extern uint32_t eth_oblivious_retry_delay(uint16_t retry_count);
 
 void setUp(void) {}
 void tearDown(void) {}
@@ -88,6 +89,18 @@ void test_retry_after_clears_response_and_error(void) {
   TEST_ASSERT_EQUAL_UINT32(1500, req.delay);
 }
 
+void test_oblivious_retry_delay_backoff(void) {
+  // Exponential backoff doubling from the base, capped at the max.
+  TEST_ASSERT_EQUAL_UINT32(500, eth_oblivious_retry_delay(0));
+  TEST_ASSERT_EQUAL_UINT32(1000, eth_oblivious_retry_delay(1));
+  TEST_ASSERT_EQUAL_UINT32(2000, eth_oblivious_retry_delay(2));
+  TEST_ASSERT_EQUAL_UINT32(4000, eth_oblivious_retry_delay(3));
+  TEST_ASSERT_EQUAL_UINT32(8000, eth_oblivious_retry_delay(4));
+  // Capped from here on; large counts must not overflow the shift.
+  TEST_ASSERT_EQUAL_UINT32(8000, eth_oblivious_retry_delay(5));
+  TEST_ASSERT_EQUAL_UINT32(8000, eth_oblivious_retry_delay(40));
+}
+
 void test_retry_after_resets_node_selection(void) {
   // A same-node retry must reset the host-side node selection: hosts resume
   // from `response_node_index` and skip excluded nodes, so leaving these set
@@ -109,6 +122,7 @@ int main(void) {
   RUN_TEST(test_detector_rejects_valid_result);
   RUN_TEST(test_retry_after_schedules_and_bounds);
   RUN_TEST(test_retry_after_clears_response_and_error);
+  RUN_TEST(test_oblivious_retry_delay_backoff);
   RUN_TEST(test_retry_after_resets_node_selection);
   return UNITY_END();
 }

--- a/test/unittests/test_oblivious_retry.c
+++ b/test/unittests/test_oblivious_retry.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// Unit tests for the oblivious-node delayed-retry primitives:
+//   - eth_is_oblivious_unavailable(): recognises the oblivious node's
+//     "data non availability" (-32001) signal and nothing else.
+//   - c4_state_retry_after(): schedules a same-node retry with a delay,
+//     bounded by a retry budget, and clears the previous response/error.
+//
+// The detector lives in the eth verifier (eth_verify.h); it is declared here
+// to keep the test independent of the eth verifier's internal include paths.
+
+#include "bytes.h"
+#include "json.h"
+#include "state.h"
+#include "unity.h"
+#include <string.h>
+
+extern bool eth_is_oblivious_unavailable(json_t response);
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_detector_matches_oblivious_unavailable(void) {
+  char r[] = "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32001,\"message\":\"Failed due to data non availability\"}}";
+  TEST_ASSERT_TRUE(eth_is_oblivious_unavailable(json_parse(r)));
+}
+
+void test_detector_rejects_other_error_code(void) {
+  char r[] = "{\"error\":{\"code\":-32000,\"message\":\"Failed due to data non availability\"}}";
+  TEST_ASSERT_FALSE(eth_is_oblivious_unavailable(json_parse(r)));
+}
+
+void test_detector_rejects_other_message(void) {
+  char r[] = "{\"error\":{\"code\":-32001,\"message\":\"resource not found\"}}";
+  TEST_ASSERT_FALSE(eth_is_oblivious_unavailable(json_parse(r)));
+}
+
+void test_detector_rejects_valid_result(void) {
+  char r[] = "{\"result\":{\"storageProof\":[{\"value\":\"0x01\"}]}}";
+  TEST_ASSERT_FALSE(eth_is_oblivious_unavailable(json_parse(r)));
+}
+
+void test_retry_after_schedules_and_bounds(void) {
+  data_request_t req = {0};
+
+  TEST_ASSERT_TRUE(c4_state_retry_after(&req, 3000, 2));
+  TEST_ASSERT_EQUAL_UINT32(3000, req.delay);
+  TEST_ASSERT_EQUAL_UINT16(1, req.retry_count);
+
+  TEST_ASSERT_TRUE(c4_state_retry_after(&req, 3000, 2));
+  TEST_ASSERT_EQUAL_UINT16(2, req.retry_count);
+
+  // budget exhausted -> no further retry, counter unchanged
+  TEST_ASSERT_FALSE(c4_state_retry_after(&req, 3000, 2));
+  TEST_ASSERT_EQUAL_UINT16(2, req.retry_count);
+}
+
+void test_retry_after_clears_response_and_error(void) {
+  data_request_t req = {0};
+  req.response       = bytes_dup(bytes((uint8_t*) "x", 1));
+  req.error          = strdup("transient error");
+
+  TEST_ASSERT_TRUE(c4_state_retry_after(&req, 1500, 5));
+  TEST_ASSERT_NULL(req.response.data);
+  TEST_ASSERT_EQUAL_UINT32(0, req.response.len);
+  TEST_ASSERT_NULL(req.error);
+  TEST_ASSERT_EQUAL_UINT32(1500, req.delay);
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_detector_matches_oblivious_unavailable);
+  RUN_TEST(test_detector_rejects_other_error_code);
+  RUN_TEST(test_detector_rejects_other_message);
+  RUN_TEST(test_detector_rejects_valid_result);
+  RUN_TEST(test_retry_after_schedules_and_bounds);
+  RUN_TEST(test_retry_after_clears_response_and_error);
+  return UNITY_END();
+}

--- a/test/unittests/test_oblivious_retry.c
+++ b/test/unittests/test_oblivious_retry.c
@@ -26,20 +26,34 @@
 //     "data non availability" (-32001) signal and nothing else.
 //   - c4_state_retry_after(): schedules a same-node retry with a delay,
 //     bounded by a retry budget, and clears the previous response/error.
+//   - eth_oblivious_retry_delay(): adaptive base * 2^retry_count, capped.
 //
 // The detector lives in the eth verifier (eth_verify.h); it is declared here
 // to keep the test independent of the eth verifier's internal include paths.
 
 #include "bytes.h"
+#include "chains.h"
 #include "json.h"
+#include "plugin.h"
+#include "retry_delay.h"
 #include "state.h"
 #include "unity.h"
 #include <string.h>
 
 extern bool     eth_is_oblivious_unavailable(json_t response);
-extern uint32_t eth_oblivious_retry_delay(uint16_t retry_count);
+extern uint32_t eth_oblivious_retry_delay(chain_id_t chain, uint16_t retry_count);
 
-void setUp(void) {}
+// Use distinct chain ids per test to avoid cross-test learner contamination,
+// plus reset the learner cache in setUp so we always start from the default.
+#define TEST_CHAIN_BACKOFF ((chain_id_t) 11155111u)
+
+void setUp(void) {
+  c4_retry_delay_reset();
+  // Detach any registered storage plugin to keep the learner in-memory only
+  // (no implicit fs writes during default unit-test runs).
+  storage_plugin_t empty = {0};
+  c4_set_storage_config(&empty);
+}
 void tearDown(void) {}
 
 void test_detector_matches_oblivious_unavailable(void) {
@@ -90,14 +104,15 @@ void test_retry_after_clears_response_and_error(void) {
 }
 
 void test_oblivious_retry_delay_backoff(void) {
-  // Exponential backoff doubling from the base, capped at the max.
-  TEST_ASSERT_EQUAL_UINT32(1000, eth_oblivious_retry_delay(0));
-  TEST_ASSERT_EQUAL_UINT32(2000, eth_oblivious_retry_delay(1));
-  TEST_ASSERT_EQUAL_UINT32(4000, eth_oblivious_retry_delay(2));
-  TEST_ASSERT_EQUAL_UINT32(8000, eth_oblivious_retry_delay(3));
+  // With a fresh learner (no persisted value), base falls back to
+  // C4_RETRY_DELAY_DEFAULT_MS (=1000) and we get the documented sequence.
+  TEST_ASSERT_EQUAL_UINT32(1000, eth_oblivious_retry_delay(TEST_CHAIN_BACKOFF, 0));
+  TEST_ASSERT_EQUAL_UINT32(2000, eth_oblivious_retry_delay(TEST_CHAIN_BACKOFF, 1));
+  TEST_ASSERT_EQUAL_UINT32(4000, eth_oblivious_retry_delay(TEST_CHAIN_BACKOFF, 2));
+  TEST_ASSERT_EQUAL_UINT32(8000, eth_oblivious_retry_delay(TEST_CHAIN_BACKOFF, 3));
   // Capped from here on; large counts must not overflow the shift.
-  TEST_ASSERT_EQUAL_UINT32(8000, eth_oblivious_retry_delay(4));
-  TEST_ASSERT_EQUAL_UINT32(8000, eth_oblivious_retry_delay(40));
+  TEST_ASSERT_EQUAL_UINT32(8000, eth_oblivious_retry_delay(TEST_CHAIN_BACKOFF, 4));
+  TEST_ASSERT_EQUAL_UINT32(8000, eth_oblivious_retry_delay(TEST_CHAIN_BACKOFF, 40));
 }
 
 void test_retry_after_resets_node_selection(void) {

--- a/test/unittests/test_oblivious_retry_edge.c
+++ b/test/unittests/test_oblivious_retry_edge.c
@@ -37,10 +37,13 @@
 //       response/error and must NOT set the delay (host keeps the failure)
 //     - the delay value is refreshed on a subsequent retry
 
+#include "unity.h"
+
+#ifdef ETH_OBLIVIOUS
+
 #include "bytes.h"
 #include "json.h"
 #include "state.h"
-#include "unity.h"
 #include <string.h>
 
 extern bool eth_is_oblivious_unavailable(json_t response);
@@ -141,3 +144,15 @@ int main(void) {
   RUN_TEST(test_retry_after_refreshes_delay);
   return UNITY_END();
 }
+
+#else // !ETH_OBLIVIOUS
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(void) {
+  UNITY_BEGIN();
+  return UNITY_END();
+}
+
+#endif // ETH_OBLIVIOUS

--- a/test/unittests/test_oblivious_retry_edge.c
+++ b/test/unittests/test_oblivious_retry_edge.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2025 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// Additional edge-case coverage for the oblivious-node delayed-retry primitives.
+// Complements test_oblivious_retry.c by exercising the branches most likely to
+// hide real bugs:
+//   eth_is_oblivious_unavailable():
+//     - error as a JSON string (not object) must NOT match
+//     - missing `message` field must NOT match
+//     - `code` encoded as a string ("-32001") must NOT match
+//     - a non-object top-level response must NOT match
+//     - the availability marker is matched as a substring anywhere in the message
+//     - exact-length boundary message ("data non availability")
+//   c4_state_retry_after():
+//     - NULL request is handled gracefully
+//     - an exhausted budget (max_retries == 0) must NOT clear the existing
+//       response/error and must NOT set the delay (host keeps the failure)
+//     - the delay value is refreshed on a subsequent retry
+
+#include "bytes.h"
+#include "json.h"
+#include "state.h"
+#include "unity.h"
+#include <string.h>
+
+extern bool eth_is_oblivious_unavailable(json_t response);
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// --- detector edge cases -----------------------------------------------------
+
+void test_detector_rejects_string_error(void) {
+  // A bare string `error` (not an object) carries no code/message and must not
+  // be mistaken for the oblivious availability signal.
+  char r[] = "{\"error\":\"Failed due to data non availability\"}";
+  TEST_ASSERT_FALSE(eth_is_oblivious_unavailable(json_parse(r)));
+}
+
+void test_detector_rejects_missing_message(void) {
+  char r[] = "{\"error\":{\"code\":-32001}}";
+  TEST_ASSERT_FALSE(eth_is_oblivious_unavailable(json_parse(r)));
+}
+
+void test_detector_rejects_numeric_code_as_string(void) {
+  // code as a JSON string must not match: the detector requires JSON_TYPE_NUMBER.
+  char r[] = "{\"error\":{\"code\":\"-32001\",\"message\":\"data non availability\"}}";
+  TEST_ASSERT_FALSE(eth_is_oblivious_unavailable(json_parse(r)));
+}
+
+void test_detector_rejects_non_object_response(void) {
+  char r[] = "[\"data non availability\"]";
+  TEST_ASSERT_FALSE(eth_is_oblivious_unavailable(json_parse(r)));
+}
+
+void test_detector_rejects_empty_object(void) {
+  char r[] = "{}";
+  TEST_ASSERT_FALSE(eth_is_oblivious_unavailable(json_parse(r)));
+}
+
+void test_detector_matches_marker_as_substring(void) {
+  // The marker may appear with surrounding text; a substring scan must catch it.
+  char r[] = "{\"error\":{\"code\":-32001,\"message\":\"request rejected: data non availability for slot 42\"}}";
+  TEST_ASSERT_TRUE(eth_is_oblivious_unavailable(json_parse(r)));
+}
+
+void test_detector_matches_exact_marker_message(void) {
+  // Boundary: message token is exactly the marker (plus the JSON quotes).
+  char r[] = "{\"error\":{\"code\":-32001,\"message\":\"data non availability\"}}";
+  TEST_ASSERT_TRUE(eth_is_oblivious_unavailable(json_parse(r)));
+}
+
+// --- c4_state_retry_after edge cases -----------------------------------------
+
+void test_retry_after_null_request_is_safe(void) {
+  TEST_ASSERT_FALSE(c4_state_retry_after(NULL, 3000, 5));
+}
+
+void test_retry_after_zero_budget_preserves_failure(void) {
+  // With max_retries == 0 the very first call must report exhaustion WITHOUT
+  // touching the request: the existing response/error stays so the host can
+  // surface the failure, and no spurious delay is scheduled.
+  data_request_t req = {0};
+  req.response       = bytes_dup(bytes((uint8_t*) "payload", 7));
+  req.error          = strdup("boom");
+
+  TEST_ASSERT_FALSE(c4_state_retry_after(&req, 3000, 0));
+  TEST_ASSERT_NOT_NULL(req.response.data);
+  TEST_ASSERT_EQUAL_UINT32(7, req.response.len);
+  TEST_ASSERT_NOT_NULL(req.error);
+  TEST_ASSERT_EQUAL_UINT32(0, req.delay);
+  TEST_ASSERT_EQUAL_UINT16(0, req.retry_count);
+
+  safe_free(req.response.data);
+  safe_free(req.error);
+}
+
+void test_retry_after_refreshes_delay(void) {
+  data_request_t req = {0};
+
+  TEST_ASSERT_TRUE(c4_state_retry_after(&req, 3000, 5));
+  TEST_ASSERT_EQUAL_UINT32(3000, req.delay);
+
+  // A later retry can carry a different delay; the field must be overwritten.
+  TEST_ASSERT_TRUE(c4_state_retry_after(&req, 1000, 5));
+  TEST_ASSERT_EQUAL_UINT32(1000, req.delay);
+  TEST_ASSERT_EQUAL_UINT16(2, req.retry_count);
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_detector_rejects_string_error);
+  RUN_TEST(test_detector_rejects_missing_message);
+  RUN_TEST(test_detector_rejects_numeric_code_as_string);
+  RUN_TEST(test_detector_rejects_non_object_response);
+  RUN_TEST(test_detector_rejects_empty_object);
+  RUN_TEST(test_detector_matches_marker_as_substring);
+  RUN_TEST(test_detector_matches_exact_marker_message);
+  RUN_TEST(test_retry_after_null_request_is_safe);
+  RUN_TEST(test_retry_after_zero_budget_preserves_failure);
+  RUN_TEST(test_retry_after_refreshes_delay);
+  return UNITY_END();
+}

--- a/test/unittests/test_retry_delay.c
+++ b/test/unittests/test_retry_delay.c
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) 2025,2026 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// Tests for the generic adaptive retry-delay learner (`retry_delay.h`).
+//
+// Covers:
+//   - default base when no value is persisted
+//   - persist + reload via a mock storage_plugin_t (in-memory map)
+//   - asymmetric adaptation: fast up (UP_SHIFT = 1/2), slow down (DOWN_SHIFT = 1/8)
+//   - bounds clamping at [MIN, MAX]
+//   - rejection of corrupt/unknown storage blobs (fallback to default)
+//   - category and chain separation
+//   - safety against NULL category
+
+#include "bytes.h"
+#include "chains.h"
+#include "plugin.h"
+#include "retry_delay.h"
+#include "unity.h"
+#include <stdlib.h>
+#include <string.h>
+
+// --- Mock storage plugin -----------------------------------------------------
+
+typedef struct mock_entry {
+  char*              key;
+  bytes_t            value;
+  struct mock_entry* next;
+} mock_entry_t;
+
+static mock_entry_t* g_mock_head;
+static int           g_mock_set_calls;
+
+static mock_entry_t* mock_find(const char* key) {
+  for (mock_entry_t* e = g_mock_head; e; e = e->next)
+    if (strcmp(e->key, key) == 0) return e;
+  return NULL;
+}
+
+static bool mock_get(char* key, buffer_t* out) {
+  mock_entry_t* e = mock_find(key);
+  if (!e) return false;
+  buffer_append(out, e->value);
+  return true;
+}
+
+static void mock_set(char* key, bytes_t value) {
+  g_mock_set_calls++;
+  mock_entry_t* e = mock_find(key);
+  if (e) {
+    safe_free(e->value.data);
+    e->value = bytes_dup(value);
+    return;
+  }
+  e        = safe_malloc(sizeof(mock_entry_t));
+  e->key   = strdup(key);
+  e->value = bytes_dup(value);
+  e->next  = g_mock_head;
+  g_mock_head = e;
+}
+
+static void mock_del(char* key) {
+  mock_entry_t** p = &g_mock_head;
+  while (*p) {
+    if (strcmp((*p)->key, key) == 0) {
+      mock_entry_t* e = *p;
+      *p              = e->next;
+      safe_free(e->key);
+      safe_free(e->value.data);
+      safe_free(e);
+      return;
+    }
+    p = &(*p)->next;
+  }
+}
+
+static void mock_clear(void) {
+  while (g_mock_head) {
+    mock_entry_t* next = g_mock_head->next;
+    safe_free(g_mock_head->key);
+    safe_free(g_mock_head->value.data);
+    safe_free(g_mock_head);
+    g_mock_head = next;
+  }
+  g_mock_set_calls = 0;
+}
+
+static void install_mock_plugin(void) {
+  storage_plugin_t p = {.get = mock_get, .set = mock_set, .del = mock_del, .max_sync_states = 3};
+  c4_set_storage_config(&p);
+}
+
+static void detach_plugin(void) {
+  storage_plugin_t empty = {0};
+  c4_set_storage_config(&empty);
+}
+
+#define TEST_CATEGORY      "test_cat"
+#define TEST_CATEGORY_ALT  "other_cat"
+#define TEST_CHAIN         ((chain_id_t) 11155111u)
+#define TEST_CHAIN_ALT     ((chain_id_t) 1u)
+#define EXPECTED_KEY       "rdelay_test_cat_11155111"
+
+void setUp(void) {
+  c4_retry_delay_reset();
+  mock_clear();
+  install_mock_plugin();
+}
+
+void tearDown(void) {
+  detach_plugin();
+  c4_retry_delay_reset();
+  mock_clear();
+}
+
+// --- default & backoff -------------------------------------------------------
+
+void test_default_when_storage_empty(void) {
+  TEST_ASSERT_EQUAL_UINT32(C4_RETRY_DELAY_DEFAULT_MS, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+  TEST_ASSERT_EQUAL_UINT32(C4_RETRY_DELAY_DEFAULT_MS * 2, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 1));
+  TEST_ASSERT_EQUAL_UINT32(C4_RETRY_DELAY_MAX_MS, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 100));
+}
+
+// --- asymmetric adaptation ---------------------------------------------------
+
+void test_observe_R1_keeps_base_unchanged(void) {
+  // R == 1 means: warm-up time ≈ base. target == base, delta == 0, no update,
+  // and therefore no persistence write either.
+  TEST_ASSERT_EQUAL_UINT32(C4_RETRY_DELAY_DEFAULT_MS, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+  c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 1);
+  TEST_ASSERT_EQUAL_UINT32(C4_RETRY_DELAY_DEFAULT_MS, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+  TEST_ASSERT_EQUAL_INT(0, g_mock_set_calls);
+}
+
+void test_observe_R2_jumps_up_fast(void) {
+  // R == 2 -> target = 3 * base = 3000. delta = 2000. UP_SHIFT=1 -> +1000.
+  // New base = 2000 (doubled). Verified via the backoff sequence.
+  c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 2);
+  TEST_ASSERT_EQUAL_UINT32(2000, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+  // Persisted.
+  TEST_ASSERT_EQUAL_INT(1, g_mock_set_calls);
+}
+
+void test_observe_R0_probes_down_slowly(void) {
+  // Start the learner at a known high value by feeding two R=2 observations.
+  c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 2); // 1000 -> 2000
+  c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 2); // 2000 -> 4000
+  TEST_ASSERT_EQUAL_UINT32(4000, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+
+  // R == 0 -> target = base*3/4 = 3000. delta = 1000. DOWN_SHIFT=3 -> -125.
+  // New base = 3875.
+  c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 0);
+  TEST_ASSERT_EQUAL_UINT32(3875, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+}
+
+void test_repeated_high_R_saturates_at_max(void) {
+  // Feeding very large R values must drive base to C4_RETRY_DELAY_MAX_MS and
+  // stay there (no overflow, no oscillation).
+  for (int i = 0; i < 50; i++) c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 8);
+  TEST_ASSERT_EQUAL_UINT32(C4_RETRY_DELAY_MAX_MS, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+}
+
+void test_repeated_R0_floors_at_min(void) {
+  // Many R == 0 observations should converge to (but never breach) the floor.
+  for (int i = 0; i < 1000; i++) c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 0);
+  uint32_t v = c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0);
+  TEST_ASSERT_TRUE_MESSAGE(v >= C4_RETRY_DELAY_MIN_MS, "base must respect MIN floor");
+  TEST_ASSERT_TRUE_MESSAGE(v <= C4_RETRY_DELAY_DEFAULT_MS, "base must have moved downward");
+}
+
+// --- persistence -------------------------------------------------------------
+
+void test_persist_and_reload(void) {
+  c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 3); // base 1000 -> 4000
+  TEST_ASSERT_EQUAL_UINT32(4000, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+
+  // A blob should have been written under the documented key.
+  TEST_ASSERT_NOT_NULL(mock_find(EXPECTED_KEY));
+
+  // Drop the in-memory cache: the next `for` call must re-load from storage
+  // and surface the same value.
+  c4_retry_delay_reset();
+  TEST_ASSERT_EQUAL_UINT32(4000, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+}
+
+void test_corrupt_blob_falls_back_to_default(void) {
+  // Wrong size.
+  uint8_t junk[3] = {0xff, 0x01, 0x02};
+  mock_set(EXPECTED_KEY, bytes(junk, sizeof(junk)));
+  c4_retry_delay_reset();
+  TEST_ASSERT_EQUAL_UINT32(C4_RETRY_DELAY_DEFAULT_MS, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+
+  // Right size, unknown version.
+  uint8_t bad_ver[5] = {0xff, 0xe8, 0x03, 0x00, 0x00};
+  mock_del(EXPECTED_KEY);
+  mock_set(EXPECTED_KEY, bytes(bad_ver, sizeof(bad_ver)));
+  c4_retry_delay_reset();
+  TEST_ASSERT_EQUAL_UINT32(C4_RETRY_DELAY_DEFAULT_MS, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+}
+
+void test_persisted_value_is_clamped_on_read(void) {
+  // Persisted base way above MAX should be clamped on load.
+  uint8_t huge[5] = {0x01, 0xff, 0xff, 0xff, 0x7f};
+  mock_set(EXPECTED_KEY, bytes(huge, sizeof(huge)));
+  c4_retry_delay_reset();
+  TEST_ASSERT_EQUAL_UINT32(C4_RETRY_DELAY_MAX_MS, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+
+  // Persisted base below MIN should be clamped upward.
+  uint8_t tiny[5] = {0x01, 0x01, 0x00, 0x00, 0x00};
+  mock_del(EXPECTED_KEY);
+  mock_set(EXPECTED_KEY, bytes(tiny, sizeof(tiny)));
+  c4_retry_delay_reset();
+  TEST_ASSERT_EQUAL_UINT32(C4_RETRY_DELAY_MIN_MS, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+}
+
+// --- key isolation -----------------------------------------------------------
+
+void test_categories_learn_independently(void) {
+  c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 3);     // boost cat A
+  c4_retry_delay_observe(TEST_CATEGORY_ALT, TEST_CHAIN, 0); // probe cat B down
+  uint32_t a = c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0);
+  uint32_t b = c4_retry_delay_for(TEST_CATEGORY_ALT, TEST_CHAIN, 0);
+  TEST_ASSERT_TRUE(a > C4_RETRY_DELAY_DEFAULT_MS);
+  TEST_ASSERT_TRUE(b < C4_RETRY_DELAY_DEFAULT_MS);
+}
+
+void test_chains_learn_independently(void) {
+  c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 3);
+  // The alt chain must still report the default; the learner is keyed by chain too.
+  TEST_ASSERT_EQUAL_UINT32(C4_RETRY_DELAY_DEFAULT_MS, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN_ALT, 0));
+}
+
+// --- defensive ---------------------------------------------------------------
+
+void test_null_category_is_safe(void) {
+  TEST_ASSERT_EQUAL_UINT32(C4_RETRY_DELAY_DEFAULT_MS, c4_retry_delay_for(NULL, TEST_CHAIN, 0));
+  c4_retry_delay_observe(NULL, TEST_CHAIN, 5); // must not crash, must not persist
+  TEST_ASSERT_EQUAL_INT(0, g_mock_set_calls);
+}
+
+// --- partial / absent storage plugin -----------------------------------------
+
+void test_observe_with_only_get_plugin_does_not_crash(void) {
+  // Replace the full mock with a get-only plugin (set==NULL). `observe` must
+  // detect the missing setter and skip persistence -- otherwise a NULL deref
+  // would crash the host. The in-memory cache still updates so subsequent
+  // `for` calls return the freshly learned value.
+  storage_plugin_t getter_only = {.get = mock_get, .set = NULL, .del = NULL};
+  c4_set_storage_config(&getter_only);
+
+  c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 2); // 1000 -> 2000
+  TEST_ASSERT_EQUAL_UINT32(2000, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+  TEST_ASSERT_EQUAL_INT_MESSAGE(0, g_mock_set_calls,
+                                "no setter installed -> persist_entry must be a no-op");
+}
+
+void test_null_get_plugin_is_overridden_by_default_storage(void) {
+  // Surfaces a non-obvious interaction between retry_delay and plugin.c:
+  // c4_get_storage_config() auto-installs the compile-time default backend
+  // (MEMORY_STORAGE or FILE_STORAGE) whenever storage_conf.get is NULL --
+  // regardless of what the host passed to c4_set_storage_config. As a
+  // consequence, a "set-only" plugin (get == NULL, set != NULL) is silently
+  // replaced and the host's set callback is never invoked by retry_delay.
+  //
+  // This test pins the observation so a future refactor of the fallback
+  // logic is forced to consider how partial plugins interact with the
+  // retry_delay learner.
+  storage_plugin_t set_only = {.get = NULL, .set = mock_set, .del = NULL};
+  c4_set_storage_config(&set_only);
+
+  c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 2);
+  TEST_ASSERT_EQUAL_INT_MESSAGE(0, g_mock_set_calls,
+                                "c4_get_storage_config auto-installs default storage when .get is NULL "
+                                "-> the host-supplied set callback is bypassed");
+}
+
+// --- cache eviction (> RETRY_DELAY_CACHE_SIZE distinct (category, chain)) ----
+
+void test_cache_eviction_round_trips_via_storage(void) {
+  // RETRY_DELAY_CACHE_SIZE = 8. Register 8 distinct chains for the same
+  // category; each observe(R=2) drives the base from 1000 to 2000 and
+  // persists. All 8 slots are then in use.
+  for (uint64_t c = 100; c < 108; c++)
+    c4_retry_delay_observe(TEST_CATEGORY, (chain_id_t) c, 2);
+  TEST_ASSERT_EQUAL_INT(8, g_mock_set_calls);
+
+  // Adding a 9th distinct chain triggers the pathological-case branch in
+  // lookup_entry, which reuses slot 0. The entry originally in slot 0
+  // (chain 100) is dropped from the in-memory cache but its persisted blob
+  // survives in storage.
+  c4_retry_delay_observe(TEST_CATEGORY, (chain_id_t) 108, 2);
+
+  // Reading chain 100 must round-trip through the storage plugin and surface
+  // the previously learned base. (The lookup itself evicts whatever sits in
+  // slot 0 right now, but the persisted blob makes that lossless.)
+  TEST_ASSERT_EQUAL_UINT32(2000, c4_retry_delay_for(TEST_CATEGORY, (chain_id_t) 100, 0));
+
+  // The 9th chain's value must also be readable.
+  TEST_ASSERT_EQUAL_UINT32(2000, c4_retry_delay_for(TEST_CATEGORY, (chain_id_t) 108, 0));
+}
+
+// --- saturation guards -------------------------------------------------------
+
+void test_observe_at_max_skips_persist(void) {
+  // Drive base to MAX first (saturated). Any further observe with R >= 1
+  // computes target >= MAX, gets clamped back to MAX, finds new_base ==
+  // current_base, and must short-circuit the persist write.
+  for (int i = 0; i < 50; i++) c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 8);
+  TEST_ASSERT_EQUAL_UINT32(C4_RETRY_DELAY_MAX_MS, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+
+  int before = g_mock_set_calls;
+  c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 8);
+  TEST_ASSERT_EQUAL_INT_MESSAGE(before, g_mock_set_calls,
+                                "observe at MAX with high R must be a no-op (no redundant write)");
+  c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 1); // R=1 -> target == base
+  TEST_ASSERT_EQUAL_INT_MESSAGE(before, g_mock_set_calls,
+                                "observe(R=1) at MAX must also short-circuit");
+}
+
+// --- reset semantics ---------------------------------------------------------
+
+void test_reset_does_not_touch_persisted_value(void) {
+  c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 3); // 1000 -> 4000
+  TEST_ASSERT_NOT_NULL(mock_find(EXPECTED_KEY));
+
+  // Reset only drops the in-memory cache; it must NOT delete the persisted
+  // blob (otherwise restart semantics would silently forget every learner).
+  c4_retry_delay_reset();
+  TEST_ASSERT_NOT_NULL_MESSAGE(mock_find(EXPECTED_KEY),
+                               "c4_retry_delay_reset() must not affect persisted state");
+  TEST_ASSERT_EQUAL_UINT32(4000, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+}
+
+// --- contract test for the prover-side gating in eth_req.c -------------------
+
+void test_observe_R0_is_a_meaningful_update(void) {
+  // Pins the precondition that motivates the explicit `retry_count > 0` gate
+  // in `eth_req.c::c4_send_eth_rpc` for `eth_getProof`: feeding R == 0 into
+  // the learner IS a non-trivial event (downward probe + persist write). If a
+  // refactor ever makes R == 0 a no-op, this test fails and the reviewer is
+  // reminded to also revisit the gating logic that prevents non-oblivious
+  // getProof successes from polluting the oblivious learner.
+  c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 0);
+  TEST_ASSERT_EQUAL_INT_MESSAGE(1, g_mock_set_calls,
+                                "observe(R=0) must trigger persistence -- prover code must gate it explicitly");
+  uint32_t v = c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0);
+  TEST_ASSERT_TRUE_MESSAGE(v < C4_RETRY_DELAY_DEFAULT_MS,
+                           "observe(R=0) must probe downward");
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_default_when_storage_empty);
+  RUN_TEST(test_observe_R1_keeps_base_unchanged);
+  RUN_TEST(test_observe_R2_jumps_up_fast);
+  RUN_TEST(test_observe_R0_probes_down_slowly);
+  RUN_TEST(test_repeated_high_R_saturates_at_max);
+  RUN_TEST(test_repeated_R0_floors_at_min);
+  RUN_TEST(test_persist_and_reload);
+  RUN_TEST(test_corrupt_blob_falls_back_to_default);
+  RUN_TEST(test_persisted_value_is_clamped_on_read);
+  RUN_TEST(test_categories_learn_independently);
+  RUN_TEST(test_chains_learn_independently);
+  RUN_TEST(test_null_category_is_safe);
+  RUN_TEST(test_observe_with_only_get_plugin_does_not_crash);
+  RUN_TEST(test_null_get_plugin_is_overridden_by_default_storage);
+  RUN_TEST(test_cache_eviction_round_trips_via_storage);
+  RUN_TEST(test_observe_at_max_skips_persist);
+  RUN_TEST(test_reset_does_not_touch_persisted_value);
+  RUN_TEST(test_observe_R0_is_a_meaningful_update);
+  return UNITY_END();
+}

--- a/test/unittests/test_retry_delay.c
+++ b/test/unittests/test_retry_delay.c
@@ -143,13 +143,16 @@ void test_default_when_storage_empty(void) {
 
 // --- asymmetric adaptation ---------------------------------------------------
 
-void test_observe_R1_keeps_base_unchanged(void) {
-  // R == 1 means: warm-up time ≈ base. target == base, delta == 0, no update,
-  // and therefore no persistence write either.
+void test_observe_R1_probes_down_slowly(void) {
+  // R == 1 only proves T_warm <= base; the learner treats it as evidence
+  // that the current base may be too generous and probes down toward the
+  // midpoint of (0, base]. With default base = 1000:
+  //   target = base/2 = 500. delta = 500. step = ceil(500/8) = 63.
+  //   new_base = 1000 - 63 = 937.
   TEST_ASSERT_EQUAL_UINT32(C4_RETRY_DELAY_DEFAULT_MS, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
   c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 1);
-  TEST_ASSERT_EQUAL_UINT32(C4_RETRY_DELAY_DEFAULT_MS, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
-  TEST_ASSERT_EQUAL_INT(0, g_mock_set_calls);
+  TEST_ASSERT_EQUAL_UINT32(937, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+  TEST_ASSERT_EQUAL_INT(1, g_mock_set_calls);
 }
 
 void test_observe_R2_jumps_up_fast(void) {
@@ -161,16 +164,16 @@ void test_observe_R2_jumps_up_fast(void) {
   TEST_ASSERT_EQUAL_INT(1, g_mock_set_calls);
 }
 
-void test_observe_R0_probes_down_slowly(void) {
+void test_observe_R0_probes_down(void) {
   // Start the learner at a known high value by feeding two R=2 observations.
   c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 2); // 1000 -> 2000
   c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 2); // 2000 -> 4000
   TEST_ASSERT_EQUAL_UINT32(4000, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
 
-  // R == 0 -> target = base*3/4 = 3000. delta = 1000. DOWN_SHIFT=3 -> -125.
-  // New base = 3875.
+  // R == 0 -> target = base/2 = 2000. delta = 2000. DOWN_SHIFT=3 -> -250.
+  // New base = 3750.
   c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 0);
-  TEST_ASSERT_EQUAL_UINT32(3875, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
+  TEST_ASSERT_EQUAL_UINT32(3750, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
 }
 
 void test_repeated_high_R_saturates_at_max(void) {
@@ -321,20 +324,18 @@ void test_cache_eviction_round_trips_via_storage(void) {
 
 // --- saturation guards -------------------------------------------------------
 
-void test_observe_at_max_skips_persist(void) {
-  // Drive base to MAX first (saturated). Any further observe with R >= 1
+void test_observe_at_max_skips_persist_for_high_r(void) {
+  // Drive base to MAX first (saturated). Any further observe with R >= 2
   // computes target >= MAX, gets clamped back to MAX, finds new_base ==
-  // current_base, and must short-circuit the persist write.
+  // current_base, and must short-circuit the persist write. (R == 0 / R == 1
+  // are a legitimate downward probe, so they are NOT short-circuited.)
   for (int i = 0; i < 50; i++) c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 8);
   TEST_ASSERT_EQUAL_UINT32(C4_RETRY_DELAY_MAX_MS, c4_retry_delay_for(TEST_CATEGORY, TEST_CHAIN, 0));
 
   int before = g_mock_set_calls;
   c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 8);
   TEST_ASSERT_EQUAL_INT_MESSAGE(before, g_mock_set_calls,
-                                "observe at MAX with high R must be a no-op (no redundant write)");
-  c4_retry_delay_observe(TEST_CATEGORY, TEST_CHAIN, 1); // R=1 -> target == base
-  TEST_ASSERT_EQUAL_INT_MESSAGE(before, g_mock_set_calls,
-                                "observe(R=1) at MAX must also short-circuit");
+                                "observe(R >= 2) at MAX must be a no-op (no redundant write)");
 }
 
 // --- reset semantics ---------------------------------------------------------
@@ -371,9 +372,9 @@ void test_observe_R0_is_a_meaningful_update(void) {
 int main(void) {
   UNITY_BEGIN();
   RUN_TEST(test_default_when_storage_empty);
-  RUN_TEST(test_observe_R1_keeps_base_unchanged);
+  RUN_TEST(test_observe_R1_probes_down_slowly);
   RUN_TEST(test_observe_R2_jumps_up_fast);
-  RUN_TEST(test_observe_R0_probes_down_slowly);
+  RUN_TEST(test_observe_R0_probes_down);
   RUN_TEST(test_repeated_high_R_saturates_at_max);
   RUN_TEST(test_repeated_R0_floors_at_min);
   RUN_TEST(test_persist_and_reload);
@@ -385,7 +386,7 @@ int main(void) {
   RUN_TEST(test_observe_with_only_get_plugin_does_not_crash);
   RUN_TEST(test_null_get_plugin_is_overridden_by_default_storage);
   RUN_TEST(test_cache_eviction_round_trips_via_storage);
-  RUN_TEST(test_observe_at_max_skips_persist);
+  RUN_TEST(test_observe_at_max_skips_persist_for_high_r);
   RUN_TEST(test_reset_does_not_touch_persisted_value);
   RUN_TEST(test_observe_R0_is_a_meaningful_update);
   return UNITY_END();


### PR DESCRIPTION
## Summary

Oblivious TEE/ORAM nodes answer the first `eth_getProof` with a
`{"error":{"code":-32001,"message":"...data non availability"}}` and only serve the proof after a short warm-up (~10s). Previously this failed the whole verification (and, due to a latent bug, could even be silently interpreted as an empty storage slot). This PR adds a **delayed retry against the same node** (no node rotation), bounded by a retry budget.

### Core

- **state** (`src/util/state.{c,h}`): new `delay` (ms) + `retry_count` fields on `data_request_t` and a new `c4_state_retry_after()` helper — clears response/error, sets the delay and increments the bounded retry counter (returns `false` when the budget is exhausted, *before* freeing anything, so callers can still surface the original error).
- **eth verifier** (`src/chains/eth/verifier/eth_verify.{c,h}`): shared `eth_is_oblivious_unavailable()` detector (`-32001` + `"data non availability"` substring) and `ETH_OBLIVIOUS_RETRY_DELAY_MS` (3000) / `ETH_OBLIVIOUS_MAX_RETRIES` (15) constants. Placed in the **verifier** so the prover (which depends on it) can reuse them without pulling the prover into embedded verifier-only builds.
- **call_ctx** (`call_account_lazy_fetch_storage`): detect the oblivious signal during PAP lazy storage fetch and retry with delay. Also stops silently treating a JSON-RPC error as zero storage in oblivious mode (**soundness fix**, since the TEE node is trusted).
- **eth_req** (`c4_send_eth_rpc`): retry the locally generated `colibri_proofCall` `eth_getProof` on the same signal (hybrid mode).

### Hosts

`delay` is serialized via `colibri_common.c` and honored before (re-)executing in: CLI/curl (blocking sleep), emscripten, python, dart, kotlin, swift.

### Out of scope

Server-side oblivious routing + **non-blocking** delay (uv_timer) is tracked in #289. The server currently does not route `eth_getProof` to oblivious nodes, so the detector does not fire there.

## Reviews

Ran security, code-reviewer and qa agents on the diff:
- **Security**: no critical/high; memory-safety, retry-budget bounding and UAF-across-PENDING behavior verified correct; soundness improved. Backoff-on-server note is covered by #289.
- **Code-reviewer**: "Good"; applied suggestions (derive marker length from the literal, merge the two `if (is_oblivious)` branches, `ETH_`-prefix the macros, clarify the `ttl` vs `retry_count` doc).
- **QA**: added `test_oblivious_retry_edge.c` (detector negatives + zero-budget/NULL safety).

## Test plan

- [x] `cmake --build build/default` clean
- [x] `ctest --test-dir build/default` → 44/44 pass (incl. `test_oblivious_retry` + `test_oblivious_retry_edge`)
- [ ] Follow-up: fixture-based integration tests for the call_ctx/eth_req retry-then-success paths (see #289 / QA recommendations)