### PR TITLE
fix(prover): PAP call proof in browser + explainer playground UX

### DIFF
--- a/bindings/emscripten/packages/explainer/src/providers/index.ts
+++ b/bindings/emscripten/packages/explainer/src/providers/index.ts
@@ -36,6 +36,7 @@ export function createProvider(config: ExplainerConfig): LLMProvider {
         temperature: config.temperature,
         contextWindowSize: config.contextWindowSize,
         onModelProgress: config.onModelProgress,
+        onToken: config.onToken,
         webllmEngine: config.webllmEngine,
     };
 

--- a/bindings/emscripten/packages/explainer/src/providers/webllm.ts
+++ b/bindings/emscripten/packages/explainer/src/providers/webllm.ts
@@ -36,8 +36,16 @@ interface ChatCompletionLike {
     choices?: { message?: { content?: string } }[];
 }
 
+interface ChatCompletionChunkLike {
+    choices?: { delta?: { content?: string } }[];
+}
+
 interface MLCEngineLike {
-    chat: { completions: { create(request: unknown): Promise<ChatCompletionLike> } };
+    chat: {
+        completions: {
+            create(request: unknown): Promise<ChatCompletionLike | AsyncIterable<ChatCompletionChunkLike>>;
+        };
+    };
 }
 
 interface WebLLMModule {
@@ -67,6 +75,7 @@ export class WebLLMProvider implements LLMProvider {
     private temperature: number;
     private contextWindowSize?: number;
     private onProgress?: (progress: ModelProgress) => void;
+    private onToken?: (delta: string, full: string) => void;
     private injectedEngine?: MLCEngineLike;
 
     constructor(config: LLMProviderConfig) {
@@ -75,20 +84,44 @@ export class WebLLMProvider implements LLMProvider {
         this.temperature = config.temperature ?? 0.2;
         this.contextWindowSize = config.contextWindowSize;
         this.onProgress = config.onModelProgress;
+        this.onToken = config.onToken;
         this.injectedEngine = config.webllmEngine as MLCEngineLike | undefined;
     }
 
     async complete(systemPrompt: string, userPrompt: string): Promise<string> {
         const engine = await this.getEngine();
+        const messages = [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: userPrompt },
+        ];
 
-        const res = await engine.chat.completions.create({
-            messages: [
-                { role: 'system', content: systemPrompt },
-                { role: 'user', content: userPrompt },
-            ],
+        // Stream token-by-token when a callback is provided so callers can render
+        // the answer live (generation can take 10-20s on consumer hardware).
+        if (this.onToken) {
+            const stream = (await engine.chat.completions.create({
+                messages,
+                max_tokens: this.maxTokens,
+                temperature: this.temperature,
+                stream: true,
+            })) as AsyncIterable<ChatCompletionChunkLike>;
+
+            let full = '';
+            for await (const chunk of stream) {
+                const delta = chunk.choices?.[0]?.delta?.content;
+                if (delta) {
+                    full += delta;
+                    this.onToken(delta, full);
+                }
+            }
+            if (!full) throw new Error('WebLLM returned an empty response');
+            return full;
+        }
+
+        const res = (await engine.chat.completions.create({
+            messages,
             max_tokens: this.maxTokens,
             temperature: this.temperature,
-        });
+        })) as ChatCompletionLike;
 
         const content = res.choices?.[0]?.message?.content;
         if (!content) {

--- a/bindings/emscripten/packages/explainer/src/types.ts
+++ b/bindings/emscripten/packages/explainer/src/types.ts
@@ -142,6 +142,13 @@ export interface LLMProviderConfig {
      */
     onModelProgress?: (progress: ModelProgress) => void;
     /**
+     * Streaming callback invoked while the answer is generated. `delta` is the
+     * newly produced fragment, `full` the accumulated text so far. Enables live
+     * rendering of the response. Currently only the `webllm` provider streams;
+     * other providers ignore it and return the full text via the promise.
+     */
+    onToken?: (delta: string, full: string) => void;
+    /**
      * Pre-initialized WebLLM engine to reuse across calls (avoids re-downloading
      * the model). Only used by the `webllm` provider. Typed as `unknown` so the
      * core package stays free of a hard dependency on `@mlc-ai/web-llm`.

--- a/bindings/emscripten/packages/playground/index.html
+++ b/bindings/emscripten/packages/playground/index.html
@@ -63,22 +63,22 @@
             <div id="mode-object" class="mode">
                 <div class="row">
                     <label class="grow">To
-                        <input id="to" type="text" placeholder="0x..." />
+                        <input id="to" type="text" placeholder="0x..." value="0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" />
                     </label>
                     <label class="grow">From
-                        <input id="from" type="text" placeholder="0x... (optional)" />
+                        <input id="from" type="text" placeholder="0x... (optional)" value="0x4838B106FCe9647Bdf1E7877BF73cE8B0BAD5f97" />
                     </label>
                 </div>
                 <div class="row">
                     <label>Value (wei or 0x)
-                        <input id="value" type="text" placeholder="0x16345785d8a0000" />
+                        <input id="value" type="text" placeholder="0x16345785d8a0000" value="0x100bac21cac2ce9" />
                     </label>
                     <label>Gas (optional)
                         <input id="gas" type="text" placeholder="0x..." />
                     </label>
                 </div>
                 <label>Data
-                    <textarea id="data" rows="3" placeholder="0xd0e30db0"></textarea>
+                    <textarea id="data" rows="3" placeholder="0xd0e30db0">0x</textarea>
                 </label>
             </div>
 

--- a/bindings/emscripten/packages/playground/index.html
+++ b/bindings/emscripten/packages/playground/index.html
@@ -155,7 +155,16 @@
         <div id="status" class="status"></div>
 
         <div id="progress-wrap" class="progress-wrap hidden">
+            <div class="progress-head">
+                <span id="progress-label" class="progress-label">Downloading model…</span>
+                <span id="progress-pct" class="progress-pct">0%</span>
+            </div>
             <div class="progress-bar"><div id="progress-fill"></div></div>
+            <div class="progress-info">
+                <span id="progress-eta" class="progress-eta"></span>
+                <span id="progress-hint" class="progress-hint">One-time download — the model is cached in your
+                    browser, so later visits start instantly.</span>
+            </div>
             <span id="progress-text" class="progress-text"></span>
         </div>
 

--- a/bindings/emscripten/packages/playground/package.json
+++ b/bindings/emscripten/packages/playground/package.json
@@ -14,7 +14,9 @@
     "dependencies": {
         "@corpus-core/colibri-explainer": "file:../explainer",
         "@mlc-ai/web-llm": "^0.2.84",
-        "ethers": "^6.16.0"
+        "dompurify": "^3.2.4",
+        "ethers": "^6.16.0",
+        "marked": "^15.0.0"
     },
     "devDependencies": {
         "typescript": "^5.5.0",

--- a/bindings/emscripten/packages/playground/src/main.ts
+++ b/bindings/emscripten/packages/playground/src/main.ts
@@ -53,9 +53,44 @@ function show(id: string, visible: boolean): void {
     $(id).classList.toggle('hidden', !visible);
 }
 
+// Wall-clock anchor for the current model download, used to estimate the
+// remaining time. Reset at the start of every run.
+let modelDownloadStart = 0;
+
+function formatDuration(seconds: number): string {
+    const s = Math.max(0, Math.round(seconds));
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    const rem = s % 60;
+    return rem ? `${m}m ${rem}s` : `${m}m`;
+}
+
+/**
+ * Update the model download/loading progress bar. WebLLM reports `progress`
+ * (fetchedBytes / totalBytes) and a human-readable `text`; the remaining time is
+ * estimated from the elapsed wall-clock time and the current progress.
+ */
 function setProgress(progress: number, text: string): void {
     show('progress-wrap', true);
-    ($('progress-fill') as HTMLDivElement).style.width = `${Math.round(progress * 100)}%`;
+    if (modelDownloadStart === 0) modelDownloadStart = performance.now();
+
+    const pct = Math.max(0, Math.min(100, Math.round(progress * 100)));
+    ($('progress-fill') as HTMLDivElement).style.width = `${pct}%`;
+    $('progress-pct').textContent = `${pct}%`;
+
+    // WebLLM uses "Loading model from cache" once the weights are local and only
+    // the GPU upload remains - that phase is not a download, so hide the hint.
+    const isLoading = /loading model/i.test(text);
+    $('progress-label').textContent = isLoading ? 'Loading model into GPU…' : 'Downloading model…';
+    show('progress-hint', !isLoading);
+
+    const elapsedSec = (performance.now() - modelDownloadStart) / 1000;
+    let eta = '';
+    if (progress > 0.01 && progress < 0.999 && elapsedSec > 1) {
+        const remaining = (elapsedSec * (1 - progress)) / progress;
+        eta = `~${formatDuration(remaining)} remaining`;
+    }
+    $('progress-eta').textContent = eta;
     $('progress-text').textContent = text;
 }
 
@@ -176,6 +211,12 @@ function buildExplainerConfig(useEnrichment: boolean, chainId: number): Explaine
     if (provider === 'webllm') {
         if (ctx) config.contextWindowSize = ctx;
         config.onModelProgress = ({ progress, text }) => setProgress(progress, text);
+        // Render the answer live as the local model streams it. Once tokens
+        // arrive the download/load is finished, so the progress bar can go away.
+        config.onToken = (_delta, full) => {
+            show('progress-wrap', false);
+            renderMarkdown('explanation', full);
+        };
     }
     return config;
 }
@@ -193,6 +234,7 @@ async function run(): Promise<void> {
     show('result', false);
     show('error', false);
     show('progress-wrap', false);
+    modelDownloadStart = 0;
     clearDebug();
     resetSteps();
     const runBtn = $('run') as HTMLButtonElement;
@@ -218,6 +260,7 @@ async function run(): Promise<void> {
         setStep(1, 'active');
         const clientConfig: Record<string, unknown> = { chainId };
         clientConfig.zk_proof = true;
+        clientConfig.debug = true;
         clientConfig.skip_wsp_check = true;
         if (endpoint) {
             clientConfig.rpcs = [endpoint];

--- a/bindings/emscripten/packages/playground/src/main.ts
+++ b/bindings/emscripten/packages/playground/src/main.ts
@@ -18,6 +18,8 @@ import type {
     LLMProviderType,
 } from '@corpus-core/colibri-explainer';
 import { Transaction } from 'ethers';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
 
 // -- Model catalogs per provider --------------------------------------------
 
@@ -215,6 +217,8 @@ async function run(): Promise<void> {
         setStatus('Running colibri_simulateTransaction (verified)...');
         setStep(1, 'active');
         const clientConfig: Record<string, unknown> = { chainId };
+        clientConfig.zk_proof = true;
+        clientConfig.skip_wsp_check = true;
         if (endpoint) {
             clientConfig.rpcs = [endpoint];
             clientConfig.prover = [endpoint];
@@ -224,8 +228,6 @@ async function run(): Promise<void> {
             // via a TEE-backed hybrid prover and ZK-verified state proofs.
             clientConfig.privacy_mode = 'basic';
             clientConfig.prover_mode = 'hybrid';
-            clientConfig.zk_proof = true;
-            clientConfig.skip_wsp_check = true;
         }
         const client = new C4Client(clientConfig);
         sim = (await client.rpc('colibri_simulateTransaction', [tx, 'latest'])) as SimulationResult;
@@ -257,7 +259,7 @@ async function run(): Promise<void> {
         const explanation = await provider.complete(prompt.systemPrompt, prompt.userPrompt);
         setStep(4, 'done');
 
-        $('explanation').textContent = explanation;
+        renderMarkdown('explanation', explanation);
         $('enhanced-json').textContent = JSON.stringify(toEnhancedResult(sim, context, explanation), null, 2);
         show('progress-wrap', false);
         setStatus('Done.');
@@ -366,6 +368,13 @@ function formatEventParam(param: { name: string; type: string; value: string }):
         value = hexToBigInt(param.value).toString();
     }
     return `${param.name}=${value}`;
+}
+
+// Render LLM output (which is typically Markdown) into the target element.
+// The text is untrusted, so the parsed HTML is sanitized before insertion.
+function renderMarkdown(id: string, markdown: string): void {
+    const html = marked.parse(markdown, { async: false }) as string;
+    $(id).innerHTML = DOMPurify.sanitize(html);
 }
 
 function badge(text: string, kind: 'ok' | 'bad'): HTMLElement {

--- a/bindings/emscripten/packages/playground/src/style.css
+++ b/bindings/emscripten/packages/playground/src/style.css
@@ -214,7 +214,7 @@ details.config>summary::-webkit-details-marker {
 }
 
 details.config>summary::before {
-    content: "▸";
+    content: "\25B8";
     display: inline-block;
     transition: transform .15s ease;
 }
@@ -308,7 +308,7 @@ details.config[open]>summary::before {
 }
 
 .steps li.done .step-icon::after {
-    content: "✓";
+    content: "\2713";
 }
 
 .steps li.done .step-label {
@@ -316,7 +316,7 @@ details.config[open]>summary::before {
 }
 
 .steps li.skipped .step-icon::after {
-    content: "–";
+    content: "\2013";
 }
 
 .steps li.skipped {
@@ -330,7 +330,7 @@ details.config[open]>summary::before {
 }
 
 .steps li.error .step-icon::after {
-    content: "✕";
+    content: "\2715";
 }
 
 @keyframes spin {
@@ -366,16 +366,37 @@ details.config[open]>summary::before {
 
 .progress-wrap {
     display: flex;
-    align-items: center;
-    gap: .75rem;
+    flex-direction: column;
+    gap: .5rem;
     margin-bottom: 1rem;
+    padding: 1rem 1.25rem;
+    background: #0d1117;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+}
+
+.progress-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.progress-label {
+    font-weight: 600;
+    font-size: .95rem;
+}
+
+.progress-pct {
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    color: var(--accent);
 }
 
 .progress-bar {
-    flex: 1;
-    height: 8px;
-    background: #0d1117;
-    border-radius: 4px;
+    height: 12px;
+    background: #06080b;
+    border-radius: 6px;
     overflow: hidden;
     border: 1px solid var(--border);
 }
@@ -384,13 +405,32 @@ details.config[open]>summary::before {
     height: 100%;
     width: 0;
     background: var(--accent);
-    transition: width .2s ease;
+    transition: width .3s ease;
+}
+
+.progress-info {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.progress-eta {
+    font-size: .85rem;
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+}
+
+.progress-hint {
+    font-size: .78rem;
+    color: var(--muted);
 }
 
 .progress-text {
-    font-size: .78rem;
+    font-size: .72rem;
     color: var(--muted);
-    min-width: 40%;
+    opacity: .7;
 }
 
 .explanation {

--- a/bindings/emscripten/packages/playground/src/style.css
+++ b/bindings/emscripten/packages/playground/src/style.css
@@ -394,11 +394,99 @@ details.config[open]>summary::before {
 }
 
 .explanation {
-    white-space: pre-wrap;
     background: #0d1117;
     border: 1px solid var(--border);
     border-radius: 8px;
-    padding: 1rem;
+    padding: 1rem 1.25rem;
+    line-height: 1.6;
+}
+
+/* Markdown rendered from the LLM output */
+.explanation> :first-child {
+    margin-top: 0;
+}
+
+.explanation> :last-child {
+    margin-bottom: 0;
+}
+
+.explanation p {
+    margin: 0.6rem 0;
+}
+
+.explanation ul,
+.explanation ol {
+    margin: 0.6rem 0;
+    padding-left: 1.5rem;
+}
+
+.explanation li {
+    margin: 0.25rem 0;
+}
+
+.explanation h1,
+.explanation h2,
+.explanation h3,
+.explanation h4 {
+    margin: 1rem 0 0.5rem;
+    line-height: 1.3;
+}
+
+.explanation h1 {
+    font-size: 1.3rem;
+}
+
+.explanation h2 {
+    font-size: 1.15rem;
+}
+
+.explanation h3 {
+    font-size: 1.05rem;
+}
+
+.explanation code {
+    background: #161b22;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.1rem 0.35rem;
+    font-size: 0.9em;
+}
+
+.explanation pre {
+    background: #161b22;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.75rem 1rem;
+    overflow-x: auto;
+}
+
+.explanation pre code {
+    background: none;
+    border: none;
+    padding: 0;
+}
+
+.explanation a {
+    color: var(--accent);
+}
+
+.explanation blockquote {
+    margin: 0.6rem 0;
+    padding-left: 0.9rem;
+    border-left: 3px solid var(--border);
+    color: var(--muted);
+}
+
+.explanation table {
+    border-collapse: collapse;
+    margin: 0.6rem 0;
+}
+
+.explanation th,
+.explanation td {
+    border: 1px solid var(--border);
+    padding: 0.35rem 0.6rem;
+    text-align: left;
 }
 
 /* Always-visible decoded summary */

--- a/bindings/emscripten/packages/playground/vite.config.ts
+++ b/bindings/emscripten/packages/playground/vite.config.ts
@@ -3,14 +3,25 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../../../../');
 
 // The compiled `@corpus-core/colibri-stateless` browser bundle is produced by
 // the Emscripten/CMake build and is NOT published in this monorepo checkout.
-// Point COLIBRI_DIST at the built `index.js` (with embedded WASM, SINGLE_FILE=1),
-// or rely on the default location produced by `cmake --preset wasm`.
+// It is resolved via the alias below (not from node_modules), so the playground
+// always loads exactly the bundle that was just built on disk.
+//
+//   - `cmake --preset wasm`        -> build/wasm/emscripten/index.js (default,
+//                                     WASM_EMBED=ON, single-file, no extra assets)
+//   - `cmake --preset wasm-debug`  -> build/wasm-debug/emscripten/index.js
+//                                     (WASM_EMBED=OFF -> separate c4w.wasm +
+//                                      c4w.wasm.debug.wasm DWARF for the debugger)
+//
+// Override the location with the COLIBRI_DIST env var, e.g.:
+//   COLIBRI_DIST="$PWD/build/wasm-debug/emscripten/index.js" npm run dev
 const colibriDist =
     process.env.COLIBRI_DIST ||
-    resolve(here, '../../../../build/wasm/emscripten/index.js');
+    resolve(repoRoot, 'build/wasm/emscripten/index.js');
+const colibriDir = dirname(colibriDist);
 
 export default defineConfig({
     resolve: {
@@ -18,12 +29,22 @@ export default defineConfig({
             '@corpus-core/colibri-stateless': colibriDist,
         },
     },
-    // WebLLM ships its own worker/WASM assets; let Vite serve them as-is rather
-    // than trying to pre-bundle the large dependency.
     optimizeDeps: {
-        exclude: ['@mlc-ai/web-llm'],
+        // WebLLM ships its own worker/WASM assets; serve them as-is.
+        // The colibri bundle must NOT be pre-bundled either: for non-embedded
+        // builds it locates its sibling `c4w.wasm` via `new URL('./c4w.wasm',
+        // import.meta.url)`, which only resolves correctly when the module is
+        // served from its real on-disk location instead of `.vite/deps`.
+        exclude: ['@mlc-ai/web-llm', '@corpus-core/colibri-stateless'],
     },
     server: {
         port: 5173,
+        fs: {
+            // The colibri bundle lives outside the playground package, and the
+            // debug build additionally serves its sibling c4w.wasm / DWARF file.
+            // Allow the repo root (covers build output, the explainer package and
+            // hoisted node_modules) so Vite can read all of them.
+            allow: [repoRoot, colibriDir],
+        },
     },
 });

--- a/src/chains/eth/prover/proof_call.c
+++ b/src/chains/eth/prover/proof_call.c
@@ -232,9 +232,15 @@ c4_status_t c4_get_eth_proofs(prover_ctx_t* ctx, json_t trace, uint64_t block_nu
     json_as_bytes(to_json, &to_buf);
   }
 
-  if (ctx->flags & C4_PROVER_FLAG_USE_ACCESSLIST) {
-    json_t access_list = json_get(trace, "accessList");
-    accounts_len       = json_len(access_list);
+  // For colibri_proofCall the trace IS the access-list object ({"accessList":[...]})
+  // independent of the USE_ACCESSLIST prover flag (that flag only selects the trace
+  // builder for eth_call). Branch on the actual trace shape so the access-list parser
+  // is used whenever a list is present; otherwise a missing flag would make us fall
+  // into the prestate-trace branch and treat the property name "accessList" as an
+  // account address (producing eth_getProof("accessList", ...)).
+  json_t access_list = json_get(trace, "accessList");
+  if ((ctx->flags & C4_PROVER_FLAG_USE_ACCESSLIST) || access_list.type == JSON_TYPE_ARRAY) {
+    accounts_len = json_len(access_list);
     json_for_each_value(access_list, values) {
       buffer_t buf = stack_buffer(address);
       json_as_bytes(json_get(values, "address"), &buf);

--- a/src/chains/eth/verifier/verify_call.c
+++ b/src/chains/eth/verifier/verify_call.c
@@ -296,10 +296,14 @@ static bool match_call_result(verify_ctx_t* ctx, evm_call_ctx_t* evm) {
     ctx->flags |= VERIFY_FLAG_REVERTED;
     return true;
   }
-  if (evm->call_result.data && (ctx->data.def == NULL || ctx->data.def->type == SSZ_TYPE_NONE)) {
-    ctx->data = (ssz_ob_t) {.bytes = evm->call_result, .def = eth_ssz_verification_type(ETH_SSZ_DATA_BYTES)};
-    ctx->flags |= VERIFY_FLAG_FREE_DATA;
-    evm->call_result = NULL_BYTES;
+  if (ctx->data.def == NULL || ctx->data.def->type == SSZ_TYPE_NONE) {
+    if (evm->call_result.data) {
+      ctx->data = (ssz_ob_t) {.bytes = evm->call_result, .def = eth_ssz_verification_type(ETH_SSZ_DATA_BYTES)};
+      ctx->flags |= VERIFY_FLAG_FREE_DATA;
+      evm->call_result = NULL_BYTES;
+    }
+    else 
+      ctx->data = (ssz_ob_t) {.bytes = bytes(ctx, 0), .def = eth_ssz_verification_type(ETH_SSZ_DATA_BYTES)};
     return true;
   }
   return evm->call_result.data && bytes_eq(evm->call_result, ctx->data.bytes);
@@ -431,7 +435,6 @@ static c4_status_t call_apply_authorization_list(verify_ctx_t* ctx, call_account
   return C4_SUCCESS;
 }
 
-
 // Freshness check for eth_call/eth_estimateGas/colibri_simulateTransaction.
 //
 // `ctx` always supplies the request args, the host-supplied lower bound and
@@ -446,7 +449,6 @@ static bool verify_call_freshness(verify_ctx_t* ctx, verify_ctx_t* proof_ctx) {
   bool                     has_ts    = eth_get_call_block_context_from_proof(proof_ctx, &bctx);
   return eth_check_latest_freshness(ctx, is_latest, has_ts, bctx.timestamp);
 }
-
 
 // shared helper: resolve codes, apply state overrides and EIP-7702 authorization list
 static bool prepare_evm_call(verify_ctx_t* ctx, evm_call_ctx_t* evm, bool apply_overrides) {

--- a/test/unittests/test_proof_call_accesslist.c
+++ b/test/unittests/test_proof_call_accesslist.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2025 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// Regression coverage for the `colibri_proofCall` access-list parser selection
+// in `c4_get_eth_proofs` (src/chains/eth/prover/proof_call.c).
+//
+// For `colibri_proofCall` the prover's `trace` is *always* the access-list
+// object `{"accessList":[{"address":...,"storageKeys":[...]}]}`, regardless of
+// the `C4_PROVER_FLAG_USE_ACCESSLIST` prover flag (that flag only selects which
+// trace builder is used for a plain `eth_call`).
+//
+// The bug: parser selection used to depend solely on the flag. With the flag
+// UNSET the prestate-trace branch ran and iterated the object's PROPERTY NAMES,
+// treating the literal key "accessList" as an account address. That produced an
+// `eth_getProof("accessList", [], block)` request which upstream nodes reject.
+//
+// The fix branches on the actual trace shape (presence of an `"accessList"`
+// array) so the access-list parser is used whenever a list is present.
+//
+// These tests drive `c4_get_eth_proofs` directly with an access-list-shaped
+// trace and inspect the first pending `eth_getProof` request. They assert the
+// queried account is the real address and never the literal "accessList".
+
+#include "bytes.h"
+#include "crypto.h"
+#include "eth_tools.h"
+#include "json.h"
+#include "prover.h"
+#include "ssz.h"
+#include "state.h"
+#include "unity.h"
+#include <string.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+#define TEST_ACCOUNT_ADDR "0xdac17f958d2ee523a2206206994597c13d831ec7"
+
+// Drive c4_get_eth_proofs with the given prover flags and assert the resulting
+// eth_getProof request targets the real account address (not "accessList").
+static void run_accesslist_case(prover_flags_t flags) {
+  // The access-list object is exactly what the prover receives as `trace` for
+  // colibri_proofCall. params[0] is that same object (no "to" key), params[1]
+  // is the block tag. Kept in a stack buffer so the zero-copy json_t stays valid.
+  char params_str[] =
+      "[{\"accessList\":[{\"address\":\"" TEST_ACCOUNT_ADDR "\","
+      "\"storageKeys\":[\"0x0000000000000000000000000000000000000000000000000000000000000001\"]}]},"
+      "\"latest\"]";
+
+  prover_ctx_t ctx   = {0};
+  ctx.method         = "colibri_proofCall";
+  ctx.params         = json_parse(params_str);
+  ctx.chain_id       = C4_CHAIN_MAINNET;
+  ctx.flags          = flags;
+
+  json_t        trace    = json_at(ctx.params, 0);
+  ssz_builder_t builder  = {0};
+  address_t     miner    = {0};
+
+  c4_status_t status = c4_get_eth_proofs(&ctx, trace, 0x1234, &builder, miner, NULL);
+
+  // The first eth_getProof request is created synchronously and returns PENDING.
+  TEST_ASSERT_EQUAL_INT_MESSAGE(C4_PENDING, status,
+                                ctx.state.error ? ctx.state.error : "expected C4_PENDING from c4_get_eth_proofs");
+
+  data_request_t* req = c4_state_get_pending_request(&ctx.state);
+  TEST_ASSERT_NOT_NULL_MESSAGE(req, "no pending request was created");
+  TEST_ASSERT_NOT_NULL_MESSAGE(req->payload.data, "pending request has no payload");
+
+  json_t payload = json_parse((char*) req->payload.data);
+  char*  method  = json_as_string(json_get(payload, "method"), NULL);
+  char*  account = json_as_string(json_at(json_get(payload, "params"), 0), NULL);
+
+  TEST_ASSERT_EQUAL_STRING_MESSAGE("eth_getProof", method, "wrong RPC method for the proof request");
+
+  // The core regression assertion: the queried account must be the real address
+  // and must never be the literal property name "accessList".
+  TEST_ASSERT_EQUAL_STRING_MESSAGE(TEST_ACCOUNT_ADDR, account,
+                                   "eth_getProof must query the access-list address, not the property name");
+  TEST_ASSERT_NULL_MESSAGE(strstr(account, "accessList"),
+                           "eth_getProof account must not contain the literal \"accessList\"");
+
+  safe_free(method);
+  safe_free(account);
+  ssz_builder_free(&builder);
+  c4_state_free(&ctx.state);
+}
+
+// :: Regression: USE_ACCESSLIST flag UNSET (the previously broken path)
+//
+// Before the fix this fell into the prestate-trace branch and built
+// eth_getProof("accessList", ...). The access-list parser must now be selected
+// purely from the trace shape.
+void test_proof_call_accesslist_without_flag(void) {
+  run_accesslist_case(0);
+}
+
+// :: Control: USE_ACCESSLIST flag SET (was always correct)
+//
+// Pins that the flag-set path keeps producing the correct request, so both
+// branches of the new condition converge on the same behaviour.
+void test_proof_call_accesslist_with_flag(void) {
+  run_accesslist_case(C4_PROVER_FLAG_USE_ACCESSLIST);
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_proof_call_accesslist_without_flag);
+  RUN_TEST(test_proof_call_accesslist_with_flag);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary

This branch fixes the PAP/hybrid call proof failing in the browser and rounds out
the explainer playground showcase (local verification → full privacy → on-device LLM).

### Core fixes

- **`fix(prover)`: access-list parser for `colibri_proofCall` regardless of flag.**
  In hybrid mode the client builds the call proof locally. `c4_get_eth_proofs`
  chose the access-list vs prestate-trace parser solely from
  `C4_PROVER_FLAG_USE_ACCESSLIST`. For `colibri_proofCall` the trace is *always*
  the access-list object (`{"accessList":[...]}`). When the flag was unset — the
  case for the WASM/browser binding (it only sets it on `config.use_accesslist`,
  unlike the CLI `verifier.c` and the HTTP server `eth_conf.c`) — the prestate
  branch iterated the object's *property names* and used the literal key
  `"accessList"` as the account address, producing
  `eth_getProof("accessList", [], block)`, which the upstream rejected with
  `cannot unmarshal hex string without 0x prefix into common.Address`.
  The fix branches on the actual trace shape (presence of an `"accessList"` array),
  so the access-list parser is used whenever a list is present, independent of the
  flag. CLI and server were unaffected (they set the flag).
  Follow-up tracked in #294 (flip the prover default to `eth_createAccessList`).

- **`fix: empty eth_call response`.** `match_call_result` now also handles the case
  where the EVM produced no return data: instead of leaving `ctx->data` unset it is
  set to an empty `DATA_BYTES` value, so empty `eth_call` results verify correctly.

### Explainer / playground UX

- **Token streaming**: optional `onToken` callback on `LLMProviderConfig`; the
  WebLLM provider streams the completion so callers can render the answer live.
  Non-streaming providers are unchanged.
- **Playground**: prominent model-download progress bar (percentage, estimated
  remaining time, one-time-download hint), live-streamed answer rendered as
  sanitized Markdown (`marked` + `DOMPurify`), sensible default transaction values,
  and CSS unicode escapes for the step/expander icons (robust against mis-decoding).

## Test plan

- [x] Native build (`cmake --build build/default`) green.
- [x] `wasm-debug` build green.
- [x] Browser, **Privacy mode on**: `eth_getProof` now uses the correct address and
      returns a proof; steps *Tx simulated / State verified / Code verified* pass.
- [x] End-to-end with **local WebGPU LLM** (Llama-3.2-1B): download progress + ETA,
      live-streamed Markdown explanation, all four steps green.
- [x] Regression test `test/unittests/test_proof_call_accesslist.c` added — drives
      `c4_get_eth_proofs` with an access-list trace and the `USE_ACCESSLIST` flag
      unset, asserting `eth_getProof` queries the real address (fails on the old
      code, passes with the fix). Full suite 46/46 green.
- [x] Security review: no exploitable issues (2 low/informational notes, incl. a
      latent `json_as_bytes` fixed-buffer hardening suggestion).

> Note: this branch carries both the core fixes and the playground UX work. The
> branch name reflects the original PAP investigation.