### PR TITLE
feat(playground): oblivious-node URL + overridable system prompt

### DIFF
--- a/bindings/emscripten/packages/explainer/src/index.ts
+++ b/bindings/emscripten/packages/explainer/src/index.ts
@@ -55,7 +55,7 @@ export type {
     EnhancedContractStateChange,
 } from './types.js';
 
-export { buildPrompt } from './prompt.js';
+export { buildPrompt, DEFAULT_SYSTEM_PROMPT } from './prompt.js';
 export { createProvider } from './providers/index.js';
 export { WebLLMProvider, DEFAULT_WEBLLM_MODEL } from './providers/webllm.js';
 export { hexToBigInt, weiToEth, formatTokenAmount, formatGas, shortenAddress } from './format.js';

--- a/bindings/emscripten/packages/explainer/src/prompt.ts
+++ b/bindings/emscripten/packages/explainer/src/prompt.ts
@@ -28,7 +28,11 @@ import type {
 import { hexToBigInt, weiToEth, formatGas, shortenAddress, formatSelector } from './format.js';
 import { labelAddress } from './known_addresses.js';
 
-const BASE_SYSTEM_PROMPT = `You are a blockchain transaction analyst. Your job is to explain \
+/**
+ * Default base system prompt used by the explainer. Exposed so applications can
+ * use it as a starting point for a custom `PromptConfig.systemPrompt` override.
+ */
+export const DEFAULT_SYSTEM_PROMPT = `You are a blockchain transaction analyst. Your job is to explain \
 what an Ethereum transaction would do in clear, simple terms that a non-technical user can understand.
 
 Rules:
@@ -60,7 +64,9 @@ export function buildPrompt(
 const DEFAULT_MAX_SOURCE_CHARS = 10000;
 
 function buildSystemPrompt(config: PromptConfig): string {
-    let prompt = BASE_SYSTEM_PROMPT;
+    // A non-empty override fully replaces the built-in base prompt; the language
+    // hint and app-supplied context below are still appended in either case.
+    let prompt = config.systemPrompt?.trim() ? config.systemPrompt : DEFAULT_SYSTEM_PROMPT;
 
     if (config.language && config.language !== 'en') {
         prompt += `\n\nIMPORTANT: Respond in ${languageName(config.language)}.`;

--- a/bindings/emscripten/packages/explainer/src/types.ts
+++ b/bindings/emscripten/packages/explainer/src/types.ts
@@ -109,6 +109,14 @@ export interface ModelProgress {
 /** Prompt-related configuration (subset of ExplainerConfig). */
 export interface PromptConfig {
     /**
+     * Full override for the base system prompt. When set, it *replaces* the
+     * built-in analyst prompt (`DEFAULT_SYSTEM_PROMPT`). The language instruction
+     * and `systemPromptInclude` are still appended afterwards. Leave unset to use
+     * the default. Use `DEFAULT_SYSTEM_PROMPT` as a starting point if you only want
+     * to tweak it.
+     */
+    systemPrompt?: string;
+    /**
      * Additional context appended to the system prompt.
      * Use this to inject app-specific instructions, e.g.
      * `"This is a DeFi wallet. Focus on user-facing financial impact."`.

--- a/bindings/emscripten/packages/explainer/test/prompt.test.mjs
+++ b/bindings/emscripten/packages/explainer/test/prompt.test.mjs
@@ -48,6 +48,27 @@ describe('buildPrompt', () => {
         assert.ok(systemPrompt.includes(include), `Expected include text, got:\n${systemPrompt}`);
     });
 
+    it('fully replaces the base prompt when systemPrompt is set', () => {
+        const custom = 'You are a terse auditor. Reply in one line.';
+        const { systemPrompt } = buildPrompt(WETH_DEPOSIT_RESULT, TX_PARAMS, { systemPrompt: custom });
+        assert.ok(systemPrompt.startsWith(custom), `Expected custom prompt, got:\n${systemPrompt}`);
+        assert.ok(!systemPrompt.includes('blockchain transaction analyst'), 'default prompt must be replaced');
+    });
+
+    it('still appends language and include to a custom system prompt', () => {
+        const { systemPrompt } = buildPrompt(WETH_DEPOSIT_RESULT, TX_PARAMS, {
+            systemPrompt: 'Custom base.', language: 'de', systemPromptInclude: 'extra ctx',
+        });
+        assert.ok(systemPrompt.includes('Custom base.'));
+        assert.ok(systemPrompt.includes('German'), `Expected German instruction, got:\n${systemPrompt}`);
+        assert.ok(systemPrompt.includes('extra ctx'));
+    });
+
+    it('falls back to the default prompt for a blank systemPrompt', () => {
+        const { systemPrompt } = buildPrompt(WETH_DEPOSIT_RESULT, TX_PARAMS, { systemPrompt: '   ' });
+        assert.ok(systemPrompt.includes('blockchain transaction analyst'));
+    });
+
     it('handles a reverted transaction', () => {
         const revertedResult = { gasUsed: '0x5208', status: '0x0', returnValue: '0x', logs: [] };
         const { userPrompt } = buildPrompt(revertedResult, TX_PARAMS, {});

--- a/bindings/emscripten/packages/playground/index.html
+++ b/bindings/emscripten/packages/playground/index.html
@@ -93,61 +93,79 @@
             <summary>Configuration</summary>
 
             <div class="config-body">
-                <div class="row">
-                    <label>Chain ID
-                        <input id="chainId" type="number" value="1" min="1" />
+                <section class="config-group">
+                    <h4 class="config-group-title">Network</h4>
+                    <div class="row">
+                        <label>Chain ID
+                            <input id="chainId" type="number" value="1" min="1" />
+                        </label>
+                        <label class="grow">RPC endpoint (optional override)
+                            <input id="rpc" type="text" placeholder="https://mainnet1.colibri-proof.tech" />
+                            <small class="hint">Standard JSON-RPC node serving eth_* JSON responses.</small>
+                        </label>
+                        <label class="grow">Prover endpoint (optional override)
+                            <input id="prover" type="text" placeholder="https://mainnet1.colibri-proof.tech" />
+                            <small class="hint">Colibri prover returning SSZ-encoded proofs.</small>
+                        </label>
+                    </div>
+                </section>
+
+                <section class="config-group">
+                    <h4 class="config-group-title">Privacy &amp; verification</h4>
+                    <div class="row checks">
+                        <label class="check">
+                            <input id="privacy" type="checkbox" checked /> Privacy mode (PAP + ZK proof, hybrid prover)
+                        </label>
+                        <label class="check">
+                            <input id="enrich" type="checkbox" checked /> Enrich via Sourcify (decode + storage layout)
+                        </label>
+                    </div>
+                    <label class="grow" id="oblivious-wrap">Oblivious node URL (TEE, optional)
+                        <input id="oblivious" type="text" placeholder="https://oblivious.colibri-proof.tech" />
+                        <small class="hint">Terminates eth_getProof inside a TEE (ORAM) so the requested
+                            account/storage keys stay private. Leave empty to use standard PAP.</small>
                     </label>
-                    <label class="grow">RPC / Prover endpoint (optional override)
-                        <input id="endpoint" type="text" placeholder="https://mainnet1.colibri-proof.tech" />
+                </section>
+
+                <section class="config-group">
+                    <h4 class="config-group-title">LLM / explainer</h4>
+                    <div class="row">
+                        <label>Provider
+                            <select id="provider">
+                                <option value="webllm">Local (WebGPU / WebLLM)</option>
+                                <option value="openai">OpenAI</option>
+                                <option value="anthropic">Anthropic</option>
+                                <option value="ollama">Ollama (local server)</option>
+                            </select>
+                        </label>
+                        <label class="grow">Model
+                            <select id="model"></select>
+                        </label>
+                        <label>Language
+                            <input id="language" type="text" value="en" size="4" />
+                        </label>
+                    </div>
+                    <div class="row" id="apikey-row">
+                        <label class="grow" id="apikey-wrap">API key
+                            <input id="apiKey" type="password" placeholder="sk-..." />
+                        </label>
+                        <label class="grow" id="baseurl-wrap">Base URL (Ollama / custom)
+                            <input id="baseUrl" type="text" placeholder="http://localhost:11434" />
+                        </label>
+                    </div>
+                    <div class="row">
+                        <label>Max source chars (context budget)
+                            <input id="maxSourceChars" type="number" value="10000" min="0" step="500" />
+                        </label>
+                        <label id="contextWindow-wrap">Context window (webllm, optional)
+                            <input id="contextWindow" type="number" placeholder="4096" min="0" step="512" />
+                        </label>
+                    </div>
+                    <label class="grow">System prompt (optional override)
+                        <textarea id="systemPrompt" rows="4"
+                            placeholder="Leave empty to use the default analyst prompt. Anything here fully replaces it; the language hint is still appended."></textarea>
                     </label>
-                </div>
-                <div class="row">
-                    <label>Provider
-                        <select id="provider">
-                            <option value="webllm">Local (WebGPU / WebLLM)</option>
-                            <option value="openai">OpenAI</option>
-                            <option value="anthropic">Anthropic</option>
-                            <option value="ollama">Ollama (local server)</option>
-                        </select>
-                    </label>
-                    <label class="grow">Model
-                        <select id="model"></select>
-                    </label>
-                    <label>Language
-                        <input id="language" type="text" value="en" size="4" />
-                    </label>
-                </div>
-                <div class="row" id="apikey-row">
-                    <label class="grow" id="apikey-wrap">API key
-                        <input id="apiKey" type="password" placeholder="sk-..." />
-                    </label>
-                    <label class="grow" id="baseurl-wrap">Base URL (Ollama / custom)
-                        <input id="baseUrl" type="text" placeholder="http://localhost:11434" />
-                    </label>
-                </div>
-                <div class="row">
-                    <label>Max source chars (context budget)
-                        <input id="maxSourceChars" type="number" value="10000" min="0" step="500" />
-                    </label>
-                    <label id="contextWindow-wrap">Context window (webllm, optional)
-                        <input id="contextWindow" type="number" placeholder="4096" min="0" step="512" />
-                    </label>
-                <label class="check">
-                    <input id="enrich" type="checkbox" checked /> Enrich via Sourcify (decode + storage layout)
-                </label>
-                <label class="check">
-                    <input id="privacy" type="checkbox" checked /> Privacy mode (PAP + ZK proof, hybrid prover)
-                </label>
-                <label class="grow" id="oblivious-wrap">Oblivious node URL (TEE, optional)
-                    <input id="oblivious" type="text" placeholder="https://oblivious.colibri-proof.tech" />
-                    <small class="hint">Terminates eth_getProof inside a TEE (ORAM) so the requested account/storage
-                        keys stay private. Leave empty to use standard PAP.</small>
-                </label>
-                <label class="grow">System prompt (optional override)
-                    <textarea id="systemPrompt" rows="4"
-                        placeholder="Leave empty to use the default analyst prompt. Anything here fully replaces it; the language hint is still appended."></textarea>
-                </label>
-            </div>
+                </section>
             </div>
         </details>
 

--- a/bindings/emscripten/packages/playground/index.html
+++ b/bindings/emscripten/packages/playground/index.html
@@ -147,7 +147,18 @@
                             <select id="model"></select>
                         </label>
                         <label>Language
-                            <input id="language" type="text" value="en" size="4" />
+                            <select id="language">
+                                <option value="en">English</option>
+                                <option value="de">German</option>
+                                <option value="es">Spanish</option>
+                                <option value="fr">French</option>
+                                <option value="it">Italian</option>
+                                <option value="pt">Portuguese</option>
+                                <option value="zh">Chinese</option>
+                                <option value="ja">Japanese</option>
+                                <option value="ko">Korean</option>
+                                <option value="ru">Russian</option>
+                            </select>
                         </label>
                     </div>
                     <div class="row" id="apikey-row">
@@ -167,6 +178,8 @@
                         </label>
                     </div>
                     <label class="grow">System prompt (optional override)
+                        <small class="hint">Leave empty to use the default. <a href="#" id="load-default-prompt"
+                                class="config-link">Load the default as a template</a> to edit it.</small>
                         <textarea id="systemPrompt" rows="4"
                             placeholder="Leave empty to use the default analyst prompt. Anything here fully replaces it; the language hint is still appended."></textarea>
                     </label>

--- a/bindings/emscripten/packages/playground/index.html
+++ b/bindings/emscripten/packages/playground/index.html
@@ -96,8 +96,13 @@
                 <section class="config-group">
                     <h4 class="config-group-title">Network</h4>
                     <div class="row">
-                        <label>Chain ID
-                            <input id="chainId" type="number" value="1" min="1" />
+                        <label>Chain
+                            <select id="chainId">
+                                <option value="1">Ethereum Mainnet (1)</option>
+                                <option value="11155111">Sepolia (11155111)</option>
+                                <option value="100">Gnosis (100)</option>
+                                <option value="10200">Chiado (10200)</option>
+                            </select>
                         </label>
                         <label class="grow">RPC endpoint (optional override)
                             <input id="rpc" type="text" placeholder="https://mainnet1.colibri-proof.tech" />

--- a/bindings/emscripten/packages/playground/index.html
+++ b/bindings/emscripten/packages/playground/index.html
@@ -22,10 +22,27 @@
             <nav class="links">
                 <a href="https://corpus-core.gitbook.io/specification-colibri-stateless" target="_blank"
                     rel="noopener">Documentation</a>
-                <a href="https://github.com/corpus-core/colibri-stateless" target="_blank" rel="noopener">GitHub</a>
-                <a href="https://www.npmjs.com/package/@corpus-core/colibri-stateless" target="_blank"
-                    rel="noopener">npm</a>
-                <a href="https://x.com/CorpusCoreHQ" target="_blank" rel="noopener">X</a>
+                <a class="icon-link" href="https://github.com/corpus-core/colibri-stateless" target="_blank"
+                    rel="noopener" aria-label="GitHub" title="GitHub">
+                    <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+                        <path fill="currentColor"
+                            d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.65 7.65 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+                    </svg>
+                </a>
+                <a class="icon-link" href="https://www.npmjs.com/package/@corpus-core/colibri-stateless"
+                    target="_blank" rel="noopener" aria-label="npm" title="npm">
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        <path fill="currentColor"
+                            d="M1.763 0C.786 0 0 .786 0 1.763v20.474C0 23.214.786 24 1.763 24h20.474c.977 0 1.763-.786 1.763-1.763V1.763C24 .786 23.214 0 22.237 0zM5.13 5.323l13.837.019-.009 13.836h-3.464l.01-10.382h-3.456L12.04 19.17H5.113z" />
+                    </svg>
+                </a>
+                <a class="icon-link" href="https://x.com/CorpusCoreHQ" target="_blank" rel="noopener"
+                    aria-label="X (Twitter)" title="X (Twitter)">
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        <path fill="currentColor"
+                            d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z" />
+                    </svg>
+                </a>
                 <a class="report-issue" href="https://github.com/corpus-core/colibri-stateless/issues/new"
                     target="_blank" rel="noopener">Report an issue</a>
             </nav>

--- a/bindings/emscripten/packages/playground/index.html
+++ b/bindings/emscripten/packages/playground/index.html
@@ -26,6 +26,8 @@
                 <a href="https://www.npmjs.com/package/@corpus-core/colibri-stateless" target="_blank"
                     rel="noopener">npm</a>
                 <a href="https://x.com/CorpusCoreHQ" target="_blank" rel="noopener">X</a>
+                <a class="report-issue" href="https://github.com/corpus-core/colibri-stateless/issues/new"
+                    target="_blank" rel="noopener">Report an issue</a>
             </nav>
         </header>
 

--- a/bindings/emscripten/packages/playground/index.html
+++ b/bindings/emscripten/packages/playground/index.html
@@ -138,6 +138,15 @@
                 <label class="check">
                     <input id="privacy" type="checkbox" checked /> Privacy mode (PAP + ZK proof, hybrid prover)
                 </label>
+                <label class="grow" id="oblivious-wrap">Oblivious node URL (TEE, optional)
+                    <input id="oblivious" type="text" placeholder="https://oblivious.colibri-proof.tech" />
+                    <small class="hint">Terminates eth_getProof inside a TEE (ORAM) so the requested account/storage
+                        keys stay private. Leave empty to use standard PAP.</small>
+                </label>
+                <label class="grow">System prompt (optional override)
+                    <textarea id="systemPrompt" rows="4"
+                        placeholder="Leave empty to use the default analyst prompt. Anything here fully replaces it; the language hint is still appended."></textarea>
+                </label>
             </div>
             </div>
         </details>

--- a/bindings/emscripten/packages/playground/src/colibri.d.ts
+++ b/bindings/emscripten/packages/playground/src/colibri.d.ts
@@ -11,6 +11,13 @@ declare module '@corpus-core/colibri-stateless' {
         privacy_mode?: 'none' | 'basic';
         /** Proof generation mode. "hybrid" combines local + remote proving. */
         prover_mode?: 'local' | 'remote' | 'hybrid' | 'proxy' | 'light_client';
+        /**
+         * TEE RPC endpoints that terminate the privacy-critical eth_getProof
+         * requests inside a trusted enclave (ORAM-backed). When non-empty this
+         * enables the oblivious verify flag (and PAP), so even the requested
+         * account/storage keys are not leaked to the prover. One entry is enough.
+         */
+        oblivious_nodes?: string[];
         /** Request ZK-verified state proofs from the prover. */
         zk_proof?: boolean;
         /** Skip the Weak Subjectivity Period check (needed for older periods). */

--- a/bindings/emscripten/packages/playground/src/main.ts
+++ b/bindings/emscripten/packages/playground/src/main.ts
@@ -89,10 +89,18 @@ function setProgress(progress: number, text: string): void {
     ($('progress-fill') as HTMLDivElement).style.width = `${pct}%`;
     $('progress-pct').textContent = `${pct}%`;
 
+    // Surface the model name + size so the user understands what is being
+    // fetched and why a multi-GB download can take a while.
+    const model = ($('model') as HTMLSelectElement).value;
+    const prettyModel = model.replace(/-q4f16_1-MLC$/, '');
+    const size = WEBLLM_MODEL_SIZE[model];
+
     // WebLLM uses "Loading model from cache" once the weights are local and only
     // the GPU upload remains - that phase is not a download, so hide the hint.
     const isLoading = /loading model/i.test(text);
-    $('progress-label').textContent = isLoading ? 'Loading model into GPU…' : 'Downloading model…';
+    $('progress-label').textContent = isLoading
+        ? `Loading ${prettyModel} into GPU…`
+        : `Downloading ${prettyModel}${size ? ` (${size})` : ''}…`;
     show('progress-hint', !isLoading);
 
     const elapsedSec = (performance.now() - modelDownloadStart) / 1000;

--- a/bindings/emscripten/packages/playground/src/main.ts
+++ b/bindings/emscripten/packages/playground/src/main.ts
@@ -198,6 +198,7 @@ function buildExplainerConfig(useEnrichment: boolean, chainId: number): Explaine
     const language = ($('language') as HTMLInputElement).value.trim() || 'en';
     const maxSourceChars = Number(($('maxSourceChars') as HTMLInputElement).value) || undefined;
     const ctx = Number(($('contextWindow') as HTMLInputElement).value) || undefined;
+    const systemPrompt = ($('systemPrompt') as HTMLTextAreaElement).value.trim();
 
     const config: ExplainerConfig = {
         provider,
@@ -208,6 +209,7 @@ function buildExplainerConfig(useEnrichment: boolean, chainId: number): Explaine
     };
     if (apiKey) config.apiKey = apiKey;
     if (baseUrl) config.baseUrl = baseUrl;
+    if (systemPrompt) config.systemPrompt = systemPrompt;
     if (provider === 'webllm') {
         if (ctx) config.contextWindowSize = ctx;
         config.onModelProgress = ({ progress, text }) => setProgress(progress, text);
@@ -271,6 +273,10 @@ async function run(): Promise<void> {
             // via a TEE-backed hybrid prover and ZK-verified state proofs.
             clientConfig.privacy_mode = 'basic';
             clientConfig.prover_mode = 'hybrid';
+            // Optional: route the privacy-critical eth_getProof requests to a TEE
+            // (ORAM) node so even the requested storage keys are not leaked.
+            const oblivious = ($('oblivious') as HTMLInputElement).value.trim();
+            if (oblivious) clientConfig.oblivious_nodes = [oblivious];
         }
         const client = new C4Client(clientConfig);
         sim = (await client.rpc('colibri_simulateTransaction', [tx, 'latest'])) as SimulationResult;

--- a/bindings/emscripten/packages/playground/src/main.ts
+++ b/bindings/emscripten/packages/playground/src/main.ts
@@ -8,6 +8,7 @@ import {
     shortenAddress,
     labelAddress,
     hexToBigInt,
+    DEFAULT_SYSTEM_PROMPT,
 } from '@corpus-core/colibri-explainer';
 import type {
     ExplainerConfig,
@@ -33,6 +34,16 @@ const MODELS: Record<LLMProviderType, string[]> = {
     openai: ['gpt-4o-mini', 'gpt-4o'],
     anthropic: ['claude-sonnet-4-20250514', 'claude-3-5-haiku-latest'],
     ollama: ['qwen2.5-coder', 'llama3.1'],
+};
+
+// Approximate one-time download size per local WebLLM model (q4f16_1 weights),
+// shown in the dropdown so users can gauge the download before selecting. These
+// are rounded approximations derived from the MLC model sizes.
+const WEBLLM_MODEL_SIZE: Record<string, string> = {
+    'Qwen2.5-Coder-7B-Instruct-q4f16_1-MLC': '~4.7 GB',
+    'Qwen2.5-Coder-3B-Instruct-q4f16_1-MLC': '~2.0 GB',
+    'Llama-3.2-3B-Instruct-q4f16_1-MLC': '~1.9 GB',
+    'Llama-3.2-1B-Instruct-q4f16_1-MLC': '~0.9 GB',
 };
 
 // -- Tiny DOM helpers --------------------------------------------------------
@@ -125,7 +136,8 @@ function populateModels(): void {
     for (const m of MODELS[provider]) {
         const opt = document.createElement('option');
         opt.value = m;
-        opt.textContent = m;
+        const size = WEBLLM_MODEL_SIZE[m];
+        opt.textContent = size ? `${m} (${size})` : m;
         select.appendChild(opt);
     }
 
@@ -201,7 +213,7 @@ function buildExplainerConfig(useEnrichment: boolean, chainId: number): Explaine
     const model = ($('model') as HTMLSelectElement).value;
     const apiKey = ($('apiKey') as HTMLInputElement).value.trim();
     const baseUrl = ($('baseUrl') as HTMLInputElement).value.trim();
-    const language = ($('language') as HTMLInputElement).value.trim() || 'en';
+    const language = ($('language') as HTMLSelectElement).value.trim() || 'en';
     const maxSourceChars = Number(($('maxSourceChars') as HTMLInputElement).value) || undefined;
     const ctx = Number(($('contextWindow') as HTMLInputElement).value) || undefined;
     const systemPrompt = ($('systemPrompt') as HTMLTextAreaElement).value.trim();
@@ -456,6 +468,11 @@ function init(): void {
     updatePrivacyVisibility();
     $('provider').addEventListener('change', populateModels);
     $('privacy').addEventListener('change', updatePrivacyVisibility);
+    // Load the built-in base prompt into the textarea as an editable template.
+    $('load-default-prompt').addEventListener('click', (e) => {
+        e.preventDefault();
+        ($('systemPrompt') as HTMLTextAreaElement).value = DEFAULT_SYSTEM_PROMPT;
+    });
     $('run').addEventListener('click', () => void run());
 
     if (typeof navigator !== 'undefined' && !(navigator as { gpu?: unknown }).gpu) {

--- a/bindings/emscripten/packages/playground/src/main.ts
+++ b/bindings/emscripten/packages/playground/src/main.ts
@@ -254,7 +254,7 @@ async function run(): Promise<void> {
     let context: EnrichedContext = EMPTY_CONTEXT;
 
     try {
-        const chainId = Number(($('chainId') as HTMLInputElement).value);
+        const chainId = Number(($('chainId') as HTMLSelectElement).value);
         if (!Number.isFinite(chainId) || chainId <= 0) throw new Error('Invalid chain ID.');
         // The RPC node serves JSON eth_* responses; the prover returns SSZ-encoded
         // proofs. They are distinct roles, so they are configured independently.

--- a/bindings/emscripten/packages/playground/src/main.ts
+++ b/bindings/emscripten/packages/playground/src/main.ts
@@ -138,6 +138,12 @@ function populateModels(): void {
     show('contextWindow-wrap', isLocal);
 }
 
+// The oblivious-node option only applies to PAP, so it is hidden unless privacy
+// mode is enabled.
+function updatePrivacyVisibility(): void {
+    show('oblivious-wrap', ($('privacy') as HTMLInputElement).checked);
+}
+
 function bindTabs(): void {
     for (const tab of Array.from(document.querySelectorAll('.tab'))) {
         tab.addEventListener('click', () => {
@@ -250,7 +256,10 @@ async function run(): Promise<void> {
     try {
         const chainId = Number(($('chainId') as HTMLInputElement).value);
         if (!Number.isFinite(chainId) || chainId <= 0) throw new Error('Invalid chain ID.');
-        const endpoint = ($('endpoint') as HTMLInputElement).value.trim();
+        // The RPC node serves JSON eth_* responses; the prover returns SSZ-encoded
+        // proofs. They are distinct roles, so they are configured independently.
+        const rpc = ($('rpc') as HTMLInputElement).value.trim();
+        const prover = ($('prover') as HTMLInputElement).value.trim();
         const useEnrichment = ($('enrich') as HTMLInputElement).checked;
         const usePrivacy = ($('privacy') as HTMLInputElement).checked;
 
@@ -264,10 +273,8 @@ async function run(): Promise<void> {
         clientConfig.zk_proof = true;
         clientConfig.debug = true;
         clientConfig.skip_wsp_check = true;
-        if (endpoint) {
-            clientConfig.rpcs = [endpoint];
-            clientConfig.prover = [endpoint];
-        }
+        if (rpc) clientConfig.rpcs = [rpc];
+        if (prover) clientConfig.prover = [prover];
         if (usePrivacy) {
             // Pragmatic Adaptive Privacy: hides which account/storage is requested
             // via a TEE-backed hybrid prover and ZK-verified state proofs.
@@ -446,7 +453,9 @@ function meta(label: string, value: string): HTMLElement {
 function init(): void {
     bindTabs();
     populateModels();
+    updatePrivacyVisibility();
     $('provider').addEventListener('change', populateModels);
+    $('privacy').addEventListener('change', updatePrivacyVisibility);
     $('run').addEventListener('click', () => void run());
 
     if (typeof navigator !== 'undefined' && !(navigator as { gpu?: unknown }).gpu) {

--- a/bindings/emscripten/packages/playground/src/style.css
+++ b/bindings/emscripten/packages/playground/src/style.css
@@ -79,6 +79,18 @@ header .sub {
     color: var(--accent);
 }
 
+.links a.report-issue {
+    color: var(--accent);
+    border: 1px solid var(--accent);
+    border-radius: 6px;
+    padding: .25rem .6rem;
+}
+
+.links a.report-issue:hover {
+    background: var(--accent);
+    color: #111;
+}
+
 .features {
     display: grid;
     grid-template-columns: repeat(3, 1fr);

--- a/bindings/emscripten/packages/playground/src/style.css
+++ b/bindings/emscripten/packages/playground/src/style.css
@@ -172,6 +172,15 @@ label.grow {
     font-weight: 400;
 }
 
+.config-link {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.config-link:hover {
+    text-decoration: underline;
+}
+
 label.check {
     flex-direction: row;
     align-items: center;

--- a/bindings/emscripten/packages/playground/src/style.css
+++ b/bindings/emscripten/packages/playground/src/style.css
@@ -79,6 +79,18 @@ header .sub {
     color: var(--accent);
 }
 
+.links a.icon-link {
+    display: inline-flex;
+    align-items: center;
+    color: var(--muted);
+}
+
+.links a.icon-link svg {
+    width: 20px;
+    height: 20px;
+    display: block;
+}
+
 .links a.report-issue {
     color: var(--accent);
     border: 1px solid var(--accent);

--- a/bindings/emscripten/packages/playground/src/style.css
+++ b/bindings/emscripten/packages/playground/src/style.css
@@ -166,6 +166,12 @@ label.grow {
     flex: 1 1 200px;
 }
 
+.hint {
+    font-size: .72rem;
+    color: var(--muted);
+    font-weight: 400;
+}
+
 label.check {
     flex-direction: row;
     align-items: center;

--- a/bindings/emscripten/packages/playground/src/style.css
+++ b/bindings/emscripten/packages/playground/src/style.css
@@ -233,6 +233,32 @@ details.config[open]>summary::before {
     padding: 0 1.25rem 1.25rem;
 }
 
+.config-group {
+    padding: 1rem 0 0;
+    border-top: 1px solid var(--border);
+    margin-top: 1rem;
+}
+
+.config-group:first-child {
+    border-top: none;
+    margin-top: 0;
+    padding-top: 0;
+}
+
+.config-group-title {
+    margin: 0 0 .75rem;
+    font-size: .72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    color: var(--accent);
+}
+
+.row.checks {
+    align-items: center;
+    gap: 1.25rem;
+}
+
 .tabs {
     display: flex;
     gap: .4rem;


### PR DESCRIPTION
## Summary

Two small fine-tuning additions to the explainer playground (and the explainer
package), surfaced while building out the privacy showcase.

### 1. Oblivious node URL (TEE/ORAM) in the configs

`basic` privacy mode (PAP) hides the transaction by fetching whole blocks and
running the call optimistically, fetching missing storage via `eth_getStorageAt`
and verifying with `eth_getProof`. That still leaks the queried storage keys. The
`oblivious_nodes` option points `eth_getProof` at TEE nodes that terminate the
request inside an enclave and resolve the proof via ORAM, so the requested
account/storage keys stay private.

The binding already supported `oblivious_nodes` (`bindings/emscripten/src`); this
just exposes it in the playground:
- New optional **"Oblivious node URL"** input. When set (with privacy on) it is
  passed as the single-entry `oblivious_nodes` config.
- Added `oblivious_nodes` to the playground's ambient `C4Config` typing.

### 2. Overridable base system prompt

- `PromptConfig.systemPrompt` fully replaces the explainer's built-in analyst
  prompt; the language hint and `systemPromptInclude` are still appended. A blank
  value falls back to the default.
- The default is exported as `DEFAULT_SYSTEM_PROMPT` so applications can start
  from it.
- New optional **"System prompt"** textarea in the playground.

## Test plan

- [x] Explainer build (`tsc`) + tests green (127/127, incl. new override tests:
      full replacement, combination with language/include, blank fallback).
- [x] Playground typecheck (`tsc --noEmit`) green.
- [x] Browser: with an oblivious URL set, the `eth_getProof` request is routed to
      that URL (verified via fetch capture); steps 1-3 pass.
- [x] Browser: with a custom system prompt, the prompt sent to the LLM starts with
      the override and no longer contains the default analyst text.

## Related

- Follow-up issue #294 (flip prover default to `eth_createAccessList`).
- Follow-up issue #295 (harden `json_as_bytes` fixed-buffer bound).