### PR TITLE
feat(pap): use header cache for PAP tx lookups in hybrid mode

### DIFF
--- a/bindings/colibri_common.c
+++ b/bindings/colibri_common.c
@@ -570,6 +570,13 @@ static void free_request_prover(c4_rpc_ctx_t* ctx) {
   ctx->request_prover = NULL;
 }
 
+bool c4_is_remote_delegated_prover_method(const char* method) {
+  if (!method) return false;
+  return strcmp(method, "eth_getBlockHeader") == 0 ||
+         strcmp(method, "eth_getBlockByNumber") == 0 ||
+         strcmp(method, "eth_getBlockByHash") == 0;
+}
+
 static bool is_remote_delegated_method(data_request_t* req) {
   if (req->method != C4_DATA_METHOD_POST) return req->method == C4_DATA_METHOD_GET;
   if (!req->payload.data || !req->payload.len || req->payload.len > (UINT32_MAX - 1)) return false;
@@ -581,9 +588,7 @@ static bool is_remote_delegated_method(data_request_t* req) {
   bool   remote = false;
   if (method.type == JSON_TYPE_STRING) {
     char* m = bprintf(NULL, "%j", method);
-    remote  = strcmp(m, "eth_getBlockHeader") == 0 ||
-             strcmp(m, "eth_getBlockByNumber") == 0 ||
-             strcmp(m, "eth_getBlockByHash") == 0;
+    remote  = c4_is_remote_delegated_prover_method(m);
     safe_free(m);
   }
   safe_free(tmp);

--- a/bindings/colibri_common.h
+++ b/bindings/colibri_common.h
@@ -212,6 +212,21 @@ void c4_rpc_ctx_set_min_latest_block_ts(c4_rpc_ctx_t* ctx, uint64_t ts);
  */
 void c4_rpc_ctx_free(c4_rpc_ctx_t* ctx);
 
+/**
+ * Returns whether a prover request for `method` is delegated to the remote prover
+ * in hybrid mode (served via a CDN-cacheable block proof) instead of being handled
+ * by the local sub-prover.
+ *
+ * Only block/header methods that produce immutable, CDN-cacheable proofs are
+ * delegated. Internal whole-block methods such as `colibri_proofBlock` are handled
+ * locally so they can reuse the prover-side header cache without exposing the
+ * caller's intent (e.g. which transaction is being looked up) to the remote prover.
+ *
+ * @param method the JSON-RPC / internal method name (may be `NULL`)
+ * @return `true` if the method is delegated to the remote prover in hybrid mode
+ */
+bool c4_is_remote_delegated_prover_method(const char* method);
+
 /* ── JSON serialization helpers shared by colibri.c and ems.c ── */
 
 /**

--- a/src/chains/eth/prover/eth_prover.c
+++ b/src/chains/eth/prover/eth_prover.c
@@ -61,7 +61,7 @@ bool eth_prover_execute(prover_ctx_t* ctx) {
     c4_proof_logs(ctx);
   else if (strcmp(ctx->method, "eth_call") == 0 || strcmp(ctx->method, "eth_estimateGas") == 0 || strcmp(ctx->method, "colibri_simulateTransaction") == 0 || strcmp(ctx->method, "colibri_proofCall") == 0)
     c4_proof_call(ctx);
-  else if (strcmp(ctx->method, "eth_getBlockByHash") == 0 || strcmp(ctx->method, "eth_getBlockByNumber") == 0)
+  else if (strcmp(ctx->method, "eth_getBlockByHash") == 0 || strcmp(ctx->method, "eth_getBlockByNumber") == 0 || strcmp(ctx->method, "colibri_proofBlock") == 0)
     c4_proof_block(ctx);
   else if (strcmp(ctx->method, "eth_blockNumber") == 0)
     c4_proof_block_number(ctx);

--- a/src/chains/eth/verifier/eth_verify.h
+++ b/src/chains/eth/verifier/eth_verify.h
@@ -54,6 +54,7 @@ void        eth_set_block_data(verify_ctx_t* ctx, uint32_t mask, ssz_ob_t block,
 bool        eth_calculate_domain(chain_id_t chain_id, uint64_t slot, bytes32_t domain);
 bool        c4_eth_verify_accounts(verify_ctx_t* ctx, ssz_ob_t accounts, bytes32_t state_root);
 bool        verify_block_proof_for_block(verify_ctx_t* ctx, ssz_ob_t block_proof, json_t block_number, bytes32_t execution_payload_root);
+bool        c4_eth_matches_blocknumber(verify_ctx_t* ctx, ssz_ob_t block, json_t req_block);
 bool        verify_block_receipts_proof_for(verify_ctx_t* ctx, ssz_ob_t receipts_proof);
 
 typedef struct evm_call_ctx evm_call_ctx_t;

--- a/src/chains/eth/verifier/verify_block.c
+++ b/src/chains/eth/verifier/verify_block.c
@@ -120,7 +120,7 @@ void eth_set_block_data(verify_ctx_t* ctx, uint32_t mask, ssz_ob_t block, bytes3
   ctx->flags |= VERIFY_FLAG_FREE_DATA;
 }
 
-static bool matches_blocknumber(verify_ctx_t* ctx, ssz_ob_t block, json_t req_block) {
+bool c4_eth_matches_blocknumber(verify_ctx_t* ctx, ssz_ob_t block, json_t req_block) {
   const char* err = json_validate(req_block, req_block.len == 68 ? "bytes32" : "block", "params[0]");
   if (err) {
     c4_state_add_error(&ctx->state, err);
@@ -157,7 +157,7 @@ bool verify_block_proof_for_block(verify_ctx_t* ctx, ssz_ob_t block_proof, json_
   if (c4_verify_header(ctx, header, block_proof) != C4_SUCCESS) return false;
   ssz_hash_tree_root(ssz_get(&execution_payload, "withdrawals"), exec_root);
 
-  if (ctx->state.error || !matches_blocknumber(ctx, execution_payload, block_number)) return false;
+  if (ctx->state.error || !c4_eth_matches_blocknumber(ctx, execution_payload, block_number)) return false;
   if (execution_payload_root) memcpy(execution_payload_root,exec_root, 32);
   return true;
 }
@@ -174,7 +174,7 @@ bool verify_block_proof(verify_ctx_t* ctx) {
     bool     include_txs       = json_as_bool(json_at(ctx->args, 1));
     ssz_ob_t execution_payload = ssz_get(&ctx->proof, "executionPayload");
     if (!execution_payload.bytes.data) RETURN_VERIFY_ERROR(ctx, "missing executionPayload in hybrid block proof");
-    if (!matches_blocknumber(ctx, execution_payload, block_number)) return false;
+    if (!c4_eth_matches_blocknumber(ctx, execution_payload, block_number)) return false;
 
     if (!eth_check_latest_freshness(ctx, eth_json_is_latest(block_number), true,
                                     ssz_get_uint64(&execution_payload, "timestamp")))
@@ -316,7 +316,7 @@ bool verify_block_header_proof(verify_ctx_t* ctx) {
 
     ssz_ob_t header_data = ssz_get(&ctx->proof, "header_data");
     if (!header_data.bytes.data) RETURN_VERIFY_ERROR(ctx, "missing header_data in hybrid block header proof");
-    if (json_len(ctx->args) >= 1 && !matches_blocknumber(ctx, header_data, json_at(ctx->args, 0))) return false;
+    if (json_len(ctx->args) >= 1 && !c4_eth_matches_blocknumber(ctx, header_data, json_at(ctx->args, 0))) return false;
     if (!eth_check_latest_freshness(ctx, is_latest, true, ssz_get_uint64(&header_data, "timestamp"))) return false;
 
     ctx->data = header_data;
@@ -354,7 +354,7 @@ bool verify_block_header_proof(verify_ctx_t* ctx) {
   if (memcmp(body_root, ssz_get(&header, "bodyRoot").bytes.data, 32) != 0)
     RETURN_VERIFY_ERROR(ctx, "invalid body root!");
   if (c4_verify_header(ctx, header, ctx->proof) != C4_SUCCESS) return false;
-  if (json_len(ctx->args) >= 1 && !matches_blocknumber(ctx, ctx->data, json_at(ctx->args, 0))) return false;
+  if (json_len(ctx->args) >= 1 && !c4_eth_matches_blocknumber(ctx, ctx->data, json_at(ctx->args, 0))) return false;
   if (!eth_check_latest_freshness(ctx, is_latest, true, ssz_get_uint64(&ctx->data, "timestamp"))) return false;
 
   return verify_block_header_derived_methods(ctx);

--- a/src/chains/eth/verifier/verify_pap_tx.c
+++ b/src/chains/eth/verifier/verify_pap_tx.c
@@ -107,18 +107,45 @@ static c4_status_t ensure_tx_cache(verify_ctx_t* ctx) {
 
 /* ── block proof verification + tx extraction ── */
 
+// Selects the prover method used to fetch the whole block for a PAP tx lookup.
+// In hybrid mode `colibri_proofBlock` is used: it is not remote-delegated, so the
+// binding routes it to the local sub-prover, which reuses the prover-side header
+// cache (only header/block proofs are pulled from the remote prover on a miss).
+// In remote mode `eth_getBlockByNumber` is kept so the CDN GET cache keeps serving
+// immutable per-block proofs. The provider never learns which tx the caller wants;
+// it only ever sees a request for the whole block.
+static const char* pap_block_proof_method(verify_ctx_t* ctx) {
+  return (ctx->flags & VERIFY_FLAG_HYBRID) ? "colibri_proofBlock" : "eth_getBlockByNumber";
+}
+
 static bool extract_tx_from_block_proof(verify_ctx_t* ctx, ssz_ob_t proof_req,
                                         json_t          req_block,
                                         uint32_t        target_tx_index,
                                         const bytes32_t expected_tx_hash) {
-  ctx->sync_data = ssz_get(&proof_req, "sync_data");
-  if (c4_update_from_sync_data(ctx) != C4_SUCCESS) return false;
-
   ssz_ob_t block_proof = ssz_get(&proof_req, "proof");
+  bool     is_hybrid   = ssz_is_type(&block_proof, eth_ssz_verification_type(ETH_SSZ_VERIFY_HYBRID_BLOCK_PROOF));
+
 #ifdef ETH_BLOCK
-  if (!verify_block_proof_for_block(ctx, block_proof, req_block, NULL))
-    return false;
+  if (is_hybrid) {
+    // In hybrid mode a co-located, trusted prover has already verified the block header
+    // against the sync committee and cached it, so the executionPayload is trusted here.
+    // The VERIFY_FLAG_HYBRID gate prevents accepting such a proof when no local trusted
+    // prover exists (e.g. pure remote mode), mirroring `verify_block_proof`.
+    if (!(ctx->flags & VERIFY_FLAG_HYBRID))
+      RETURN_VERIFY_ERROR(ctx, "PAP: hybrid block proof requires hybrid mode");
+    ssz_ob_t hb_exec = ssz_get(&block_proof, "executionPayload");
+    if (!hb_exec.bytes.data)
+      RETURN_VERIFY_ERROR(ctx, "PAP: missing executionPayload in hybrid block proof");
+    if (!c4_eth_matches_blocknumber(ctx, hb_exec, req_block)) return false;
+  }
+  else {
+    ctx->sync_data = ssz_get(&proof_req, "sync_data");
+    if (c4_update_from_sync_data(ctx) != C4_SUCCESS) return false;
+    if (!verify_block_proof_for_block(ctx, block_proof, req_block, NULL))
+      return false;
+  }
 #else
+  (void) is_hybrid;
   RETURN_VERIFY_ERROR(ctx, "PAP: block proof verification requires ETH_BLOCK");
 #endif
 
@@ -270,7 +297,7 @@ static bool pap_tx_by_hash(verify_ctx_t* ctx) {
   ssz_ob_t  proof;
   if (h.len != 32) RETURN_VERIFY_ERROR(ctx, "PAP: invalid transaction hash");
   if (!get_tx_index_and_block(ctx, requested_hash, &block_number, &tx_index)) return false;
-  if (pap_request_proof(ctx, "eth_getBlockByNumber", bprintf(&buf, "[\"0x%lx\",true]", block_number), &proof) != C4_SUCCESS)
+  if (pap_request_proof(ctx, pap_block_proof_method(ctx), bprintf(&buf, "[\"0x%lx\",true]", block_number), &proof) != C4_SUCCESS)
     return false;
 
   char     bn[24];
@@ -278,8 +305,6 @@ static bool pap_tx_by_hash(verify_ctx_t* ctx) {
   return extract_tx_from_block_proof(ctx, proof,
                                      json_parse(bprintf(&bn_buf, "\"0x%lx\"", block_number)),
                                      tx_index, requested_hash);
-  ctx->success = true;
-  return true;
 }
 
 /* ── eth_getTransactionByBlockNumberAndIndex ── */
@@ -291,7 +316,7 @@ static bool pap_tx_by_block_and_index(verify_ctx_t* ctx) {
   uint8_t  tmp[200];
   buffer_t buf = stack_buffer(tmp);
   ssz_ob_t proof;
-  if (pap_request_proof(ctx, "eth_getBlockByNumber",
+  if (pap_request_proof(ctx, pap_block_proof_method(ctx),
                         bprintf(&buf, "[%J,true]", block_param), &proof) != C4_SUCCESS)
     return false;
 

--- a/test/unittests/test_eth_prover_dispatch.c
+++ b/test/unittests/test_eth_prover_dispatch.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025 corpus.core
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * Offline dispatch tests for the Ethereum prover method router
+ * (`eth_prover_execute` in `src/chains/eth/prover/eth_prover.c`).
+ *
+ * These tests do NOT require recorded fixtures: they only assert how a method
+ * name is routed. A recognized method dispatches to a proof generator, which
+ * emits a pending data request (C4_PENDING) without ever setting the
+ * "Unsupported method" error. An unrecognized method sets exactly that error.
+ *
+ * This locks in the change that added `colibri_proofBlock` as an alias handled
+ * by `c4_proof_block`, so a future refactor cannot silently drop it and fall
+ * through to the "Unsupported method" branch.
+ */
+
+#include "../../bindings/colibri_common.h"
+#include "json.h"
+#include "prover.h"
+#include "state.h"
+#include "unity.h"
+#include <stdlib.h>
+#include <string.h>
+
+#define UNSUPPORTED_METHOD_MSG "Unsupported method"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// Runs one prover pass for the given method/params and reports whether the
+// dispatcher rejected it with the "Unsupported method" error.
+static bool method_is_unsupported(const char* method, const char* params) {
+  prover_ctx_t* ctx = c4_prover_create((char*) method, (char*) params, C4_CHAIN_MAINNET, 0);
+  TEST_ASSERT_NOT_NULL(ctx);
+  c4_prover_execute(ctx);
+  bool unsupported = ctx->state.error != NULL && strcmp(ctx->state.error, UNSUPPORTED_METHOD_MSG) == 0;
+  c4_prover_free(ctx);
+  return unsupported;
+}
+
+// The new alias must be routed to c4_proof_block, i.e. recognized by the dispatcher.
+void test_colibri_proofBlock_is_recognized(void) {
+  TEST_ASSERT_FALSE_MESSAGE(method_is_unsupported("colibri_proofBlock", "[\"0x1\",true]"),
+                            "colibri_proofBlock must be routed to c4_proof_block, not rejected as unsupported");
+}
+
+// The pre-existing block aliases must keep working (regression guard).
+void test_block_aliases_recognized(void) {
+  TEST_ASSERT_FALSE_MESSAGE(method_is_unsupported("eth_getBlockByNumber", "[\"0x1\",true]"),
+                            "eth_getBlockByNumber must remain recognized");
+  TEST_ASSERT_FALSE_MESSAGE(method_is_unsupported("eth_getBlockByHash",
+                                                  "[\"0x0000000000000000000000000000000000000000000000000000000000000001\",true]"),
+                            "eth_getBlockByHash must remain recognized");
+}
+
+// Negative control: proves the detection mechanism actually distinguishes
+// recognized from unrecognized methods.
+void test_bogus_method_is_unsupported(void) {
+  TEST_ASSERT_TRUE_MESSAGE(method_is_unsupported("colibri_definitelyNotAMethod", "[]"),
+                           "an unknown method must be rejected with the Unsupported method error");
+}
+
+// colibri_proofBlock must NOT be remote-delegated: in hybrid mode it has to be
+// routed to the local sub-prover so it reuses the prover-side header cache and
+// never leaks which transaction the caller is resolving. This is the core
+// security guarantee behind the PAP hybrid tx path.
+void test_colibri_proofBlock_is_not_remote_delegated(void) {
+  TEST_ASSERT_FALSE_MESSAGE(c4_is_remote_delegated_prover_method("colibri_proofBlock"),
+                            "colibri_proofBlock must be handled locally, not remote-delegated");
+}
+
+// The three block/header methods remain delegated so their immutable proofs stay
+// CDN-cacheable (regression guard for the delegation list).
+void test_block_methods_are_remote_delegated(void) {
+  TEST_ASSERT_TRUE(c4_is_remote_delegated_prover_method("eth_getBlockHeader"));
+  TEST_ASSERT_TRUE(c4_is_remote_delegated_prover_method("eth_getBlockByNumber"));
+  TEST_ASSERT_TRUE(c4_is_remote_delegated_prover_method("eth_getBlockByHash"));
+  TEST_ASSERT_FALSE(c4_is_remote_delegated_prover_method(NULL));
+  TEST_ASSERT_FALSE(c4_is_remote_delegated_prover_method("eth_call"));
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_colibri_proofBlock_is_recognized);
+  RUN_TEST(test_block_aliases_recognized);
+  RUN_TEST(test_bogus_method_is_unsupported);
+  RUN_TEST(test_colibri_proofBlock_is_not_remote_delegated);
+  RUN_TEST(test_block_methods_are_remote_delegated);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary

In **PAP + HYBRID** mode, `eth_getTransactionByHash` and `eth_getTransactionByBlockNumberAndIndex` previously fetched the whole block via a **remote-delegated** `eth_getBlockByNumber` proof, bypassing the prover-side header cache. This defeats the whole point of hybrid mode, where the local prover should only pull block/header proofs from the remote (CDN-cached) and do everything else locally.

This PR routes the PAP whole-block fetch through the **local sub-prover** in hybrid mode so it reuses the verified `g_header_cache`, while keeping the CDN-cacheable path for pure remote mode.

### Changes

- **`prover/eth_prover.c`**: new internal method `colibri_proofBlock` mapped to `c4_proof_block`. It is intentionally **not** in the remote-delegated method list, so in hybrid mode the binding routes it to the local sub-prover (which reuses the header cache; only header/block proofs are pulled from the remote on a miss).
- **`verifier/verify_pap_tx.c`**:
  - `pap_block_proof_method()` selects `colibri_proofBlock` when `VERIFY_FLAG_HYBRID` is set, else `eth_getBlockByNumber` (keeps CDN GET caching in remote mode).
  - `extract_tx_from_block_proof()` gained a hybrid branch: for a `HybridBlockProof` it requires `VERIFY_FLAG_HYBRID`, trusts the `executionPayload` (a co-located trusted prover already verified the header against the sync committee), and binds it to the requested block number. The tx hash / index are still validated after extraction.
  - removed dead code after `return` in `pap_tx_by_hash`.
- **`verifier/verify_block.c` + `eth_verify.h`**: exported `matches_blocknumber` as `c4_eth_matches_blocknumber` (no logic change).
- **`bindings/colibri_common.{c,h}`**: extracted and exported `c4_is_remote_delegated_prover_method()` so the delegation guarantee is unit-testable.
- **`test/unittests/test_eth_prover_dispatch.c`** (new): offline unit tests that `colibri_proofBlock` is recognized by the prover dispatcher and is **not** remote-delegated, plus regression guards for the existing block methods.

### Privacy & trust model

- The remote provider never sees the tx hash or index — only a whole-block request. The hash→block-number resolution happens locally via the tx cache.
- A hybrid-typed proof is only accepted when `VERIFY_FLAG_HYBRID` is set, which is set **exclusively locally** based on the prover mode and can never originate from proof/response data. This mirrors the existing hybrid gates in `verify_block.c` and `verify_call.c`. Reviewed by the security agent — no HIGH/CRITICAL findings.

## Test plan

- [x] `cmake --build build/default` clean
- [x] Full suite: `ctest --test-dir build/default` (48/48 pass)
- [x] New `test_eth_prover_dispatch` (5/5 pass)
- [x] Regression: existing remote-mode PAP tx tests (`test_pap_tx_by_hash`, `_by_block_index`, `_pending`, `_fallback`) still pass
- [ ] **Follow-up (needs live data):** an end-to-end PAP+HYBRID tx test requires the test harness to select hybrid mode plus recorded fixtures (delegated header proofs + `colibri_proofBlock` execution response) captured via `scripts/create_test.sh`. Not included here because it cannot be generated offline.