### PR TITLE
feat(eth): route pending/earliest block tags to direct RPC

### DIFF
--- a/src/chains/eth/verifier/eth_verify.c
+++ b/src/chains/eth/verifier/eth_verify.c
@@ -166,12 +166,59 @@ static bool is_pap_tx_method(char* method) {
 static bool no_proof(verify_ctx_t* ctx) {
   return ctx->proof.def->type == SSZ_TYPE_NONE;
 }
+
+// Returns true if `block_tag` is the JSON string `literal` (which must include the surrounding
+// quotes, e.g. `"\"pending\""`). Matches the exact-length comparison used by `eth_json_is_latest`.
+static bool eth_json_is_tag(json_t block_tag, const char* literal, size_t literal_len) {
+  return block_tag.type == JSON_TYPE_STRING &&
+         block_tag.len == literal_len &&
+         strncmp(block_tag.start, literal, literal_len) == 0;
+}
+
+// A block tag that cannot be proven via the beacon chain: `"pending"` has no beacon block and
+// `"earliest"` (genesis / block 0) predates the beacon chain. Such requests must fall back to a
+// direct RPC call instead of proof generation/verification.
+bool eth_json_is_unproofable_tag(json_t block_tag) {
+  return eth_json_is_tag(block_tag, "\"pending\"", sizeof("\"pending\"") - 1) ||
+         eth_json_is_tag(block_tag, "\"earliest\"", sizeof("\"earliest\"") - 1);
+}
+
+// Parameter index of the block-tag argument for a given method, or:
+//   -1 : the method has no block-tag argument
+//   -2 : the block tag lives inside the filter object at params[0] (`fromBlock`/`toBlock`)
+// Positions mirror the prover modules (proof_account.c, proof_call.c, proof_block.c, logs_cache.c).
+static int eth_block_tag_index(const char* method) {
+  if (strcmp(method, "eth_getStorageAt") == 0 || strcmp(method, "eth_getProof") == 0) return 2;
+  if (strcmp(method, "eth_call") == 0 || strcmp(method, "eth_estimateGas") == 0 ||
+      strcmp(method, "colibri_simulateTransaction") == 0 || strcmp(method, "eth_getBalance") == 0 ||
+      strcmp(method, "eth_getCode") == 0 || strcmp(method, "eth_getTransactionCount") == 0) return 1;
+  if (strcmp(method, "eth_getBlockByNumber") == 0 || strcmp(method, "eth_getBlockHeader") == 0 ||
+      strcmp(method, "eth_getBlockReceipts") == 0 || strcmp(method, "eth_getTransactionByBlockNumberAndIndex") == 0) return 0;
+  if (strcmp(method, "eth_getLogs") == 0 || strcmp(method, "eth_verifyLogs") == 0) return -2;
+  return -1;
+}
+
+// Returns true if the request targets an unprovable block tag (`"pending"`/`"earliest"`),
+// in which case the method must be treated as `METHOD_UNPROOFABLE`.
+static bool eth_has_unproofable_block_tag(char* method, json_t params) {
+  int idx = eth_block_tag_index(method);
+  if (idx == -1) return false;
+  if (idx == -2) {
+    json_t filter = json_at(params, 0);
+    return eth_json_is_unproofable_tag(json_get(filter, "fromBlock")) ||
+           eth_json_is_unproofable_tag(json_get(filter, "toBlock"));
+  }
+  return eth_json_is_unproofable_tag(json_at(params, idx));
+}
+
 method_type_t c4_eth_get_method_type(chain_id_t chain_id, char* method, json_t params, verify_flags_t flags) {
-  (void) params;
   if (c4_chain_type(chain_id) != C4_CHAIN_TYPE_ETHEREUM) return METHOD_UNDEFINED;
 
   for (int i = 0; i < sizeof(proofable_methods) / sizeof(proofable_methods[0]); i++) {
     if (strcmp(method, proofable_methods[i]) == 0) {
+      // Unprovable block tags (pending/earliest) fall back to a direct RPC call.
+      if (eth_has_unproofable_block_tag(method, params))
+        return METHOD_UNPROOFABLE;
       if (strcmp(method, "eth_estimateGas") == 0)
         return ((flags & VERIFY_FLAG_PAP) ? METHOD_LOCAL : METHOD_UNPROOFABLE);
 #ifdef PAP

--- a/src/chains/eth/verifier/eth_verify.h
+++ b/src/chains/eth/verifier/eth_verify.h
@@ -96,6 +96,18 @@ void c4_eth_eip191_digest_32(const bytes32_t message, bytes32_t out_digest);
 bool eth_json_is_latest(json_t block_tag);
 
 /**
+ * Returns `true` if `block_tag` is a block tag that cannot be proven via the beacon chain.
+ *
+ * These are `"pending"` (no beacon block exists yet) and `"earliest"` (genesis / block 0
+ * predates the beacon chain). Requests for such tags must fall back to a direct RPC call
+ * (`METHOD_UNPROOFABLE`) and must never be accepted as a wildcard match during verification.
+ *
+ * @param block_tag JSON token from `ctx->args` (usually `json_at(args, idx)`)
+ * @return `true` if the token is exactly `"pending"` or `"earliest"`
+ */
+bool eth_json_is_unproofable_tag(json_t block_tag);
+
+/**
  * Shared freshness gate for proofs targeting the `"latest"` block tag.
  *
  * Reject proofs whose block timestamp is older than `ctx->min_latest_block_ts`.

--- a/src/chains/eth/verifier/verify_block.c
+++ b/src/chains/eth/verifier/verify_block.c
@@ -128,7 +128,11 @@ bool c4_eth_matches_blocknumber(verify_ctx_t* ctx, ssz_ob_t block, json_t req_bl
     ctx->success = false;
     return false;
   }
-  if (req_block.start[1] != '0' || req_block.start[2] != 'x') return true; // already validated as 'latest' or 'finalized'
+  // Unprovable tags (pending/earliest) must never wildcard-match a proof: they are routed to a
+  // direct RPC call and can never legitimately back a sync-committee proof. Rejecting them here
+  // keeps the guard that `check_block` used to provide before it accepted these tags.
+  if (eth_json_is_unproofable_tag(req_block)) RETURN_VERIFY_ERROR(ctx, "block tag not provable");
+  if (req_block.start[1] != '0' || req_block.start[2] != 'x') return true; // already validated as 'latest'/'safe'/'finalized'
   if (req_block.len == 68) {                                               // hash
     bytes32_t hash = {0};
     buffer_t  buf  = stack_buffer(hash);

--- a/src/util/json_validate.c
+++ b/src/util/json_validate.c
@@ -171,7 +171,9 @@ static const char* check_hex(json_t val, int len, bool isuint, const char* error
 
 static const char* check_block(json_t val, const char* error_prefix) {
   if (val.type != JSON_TYPE_STRING) ERROR("%sExpected block number", error_prefix);
-  if (strncmp("\"latest\"", val.start, 8) == 0 || strncmp("\"safe\"", val.start, 6) == 0 || strncmp("\"finalized\"", val.start, 11) == 0) return NULL;
+  if (strncmp("\"latest\"", val.start, 8) == 0 || strncmp("\"safe\"", val.start, 6) == 0 ||
+      strncmp("\"finalized\"", val.start, 11) == 0 || strncmp("\"earliest\"", val.start, 10) == 0 ||
+      strncmp("\"pending\"", val.start, 9) == 0) return NULL;
   return check_hex(val, 0, true, error_prefix);
 }
 

--- a/test/unittests/test_core.c
+++ b/test/unittests/test_core.c
@@ -70,6 +70,23 @@ void test_json() {
   buffer_free(&buffer);
 }
 
+void test_json_validate_block() {
+  // All standard block tags must be accepted by the "block" type.
+  const char* tags[] = {"\"latest\"", "\"safe\"", "\"finalized\"", "\"earliest\"", "\"pending\"", "\"0x1b4\"", "\"0x0\""};
+  for (size_t i = 0; i < sizeof(tags) / sizeof(tags[0]); i++) {
+    const char* err = json_validate(json_parse(tags[i]), "block", "");
+    TEST_ASSERT_NULL_MESSAGE(err, tags[i]);
+  }
+
+  // Non-block strings and non-hex tags must be rejected.
+  const char* invalid[] = {"\"head\"", "\"0xzz\"", "\"foobar\"", "5"};
+  for (size_t i = 0; i < sizeof(invalid) / sizeof(invalid[0]); i++) {
+    const char* err = json_validate(json_parse(invalid[i]), "block", "");
+    TEST_ASSERT_NOT_NULL_MESSAGE(err, invalid[i]);
+    safe_free((char*) err);
+  }
+}
+
 void test_buffer() {
   // Test: buffer_append mit dynamischer Allokation
   buffer_t buf   = {0};
@@ -770,6 +787,7 @@ void test_edge_cases() {
 int main(void) {
   UNITY_BEGIN();
   RUN_TEST(test_json);
+  RUN_TEST(test_json_validate_block);
   RUN_TEST(test_bprintf);
   RUN_TEST(test_bprintf_extended);
   RUN_TEST(test_bprintf_json_ssz);

--- a/test/unittests/test_eth_method_type.c
+++ b/test/unittests/test_eth_method_type.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "chains.h"
+#include "json.h"
+#include "unity.h"
+#include "verify.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+static method_type_t method_type(const char* method, const char* params) {
+  return c4_get_method_type(C4_CHAIN_MAINNET, (char*) method, json_parse(params), 0);
+}
+
+// Requests with a normal (pinned or "latest") block tag stay proofable. The block-tag argument
+// sits at different parameter positions depending on the method.
+void test_method_type_proofable() {
+  TEST_ASSERT_EQUAL_INT(METHOD_PROOFABLE, method_type("eth_getBalance", "[\"0xabc\",\"latest\"]"));
+  TEST_ASSERT_EQUAL_INT(METHOD_PROOFABLE, method_type("eth_getTransactionCount", "[\"0xabc\",\"0x1\"]"));
+  TEST_ASSERT_EQUAL_INT(METHOD_PROOFABLE, method_type("eth_getStorageAt", "[\"0xabc\",\"0x0\",\"latest\"]"));
+  TEST_ASSERT_EQUAL_INT(METHOD_PROOFABLE, method_type("eth_getProof", "[\"0xabc\",[],\"finalized\"]"));
+  TEST_ASSERT_EQUAL_INT(METHOD_PROOFABLE, method_type("eth_getBlockByNumber", "[\"0x1\",false]"));
+  TEST_ASSERT_EQUAL_INT(METHOD_PROOFABLE, method_type("eth_call", "[{\"to\":\"0xabc\"},\"latest\"]"));
+  TEST_ASSERT_EQUAL_INT(METHOD_PROOFABLE, method_type("eth_getLogs", "[{\"fromBlock\":\"0x1\",\"toBlock\":\"0x2\"}]"));
+}
+
+// "pending" is not proofable at any of the supported block-tag positions.
+void test_method_type_pending_unproofable() {
+  TEST_ASSERT_EQUAL_INT(METHOD_UNPROOFABLE, method_type("eth_getBalance", "[\"0xabc\",\"pending\"]"));
+  TEST_ASSERT_EQUAL_INT(METHOD_UNPROOFABLE, method_type("eth_getTransactionCount", "[\"0xabc\",\"pending\"]"));
+  TEST_ASSERT_EQUAL_INT(METHOD_UNPROOFABLE, method_type("eth_getStorageAt", "[\"0xabc\",\"0x0\",\"pending\"]"));
+  TEST_ASSERT_EQUAL_INT(METHOD_UNPROOFABLE, method_type("eth_getBlockByNumber", "[\"pending\",false]"));
+  TEST_ASSERT_EQUAL_INT(METHOD_UNPROOFABLE, method_type("eth_call", "[{\"to\":\"0xabc\"},\"pending\"]"));
+  TEST_ASSERT_EQUAL_INT(METHOD_UNPROOFABLE, method_type("eth_getLogs", "[{\"fromBlock\":\"0x1\",\"toBlock\":\"pending\"}]"));
+}
+
+// "earliest" (genesis) is treated the same way as "pending".
+void test_method_type_earliest_unproofable() {
+  TEST_ASSERT_EQUAL_INT(METHOD_UNPROOFABLE, method_type("eth_getBalance", "[\"0xabc\",\"earliest\"]"));
+  TEST_ASSERT_EQUAL_INT(METHOD_UNPROOFABLE, method_type("eth_getProof", "[\"0xabc\",[],\"earliest\"]"));
+  TEST_ASSERT_EQUAL_INT(METHOD_UNPROOFABLE, method_type("eth_getBlockByNumber", "[\"earliest\",false]"));
+  TEST_ASSERT_EQUAL_INT(METHOD_UNPROOFABLE, method_type("eth_getLogs", "[{\"fromBlock\":\"earliest\",\"toBlock\":\"latest\"}]"));
+}
+
+// Methods without a block-tag argument are unaffected by pending/earliest handling.
+void test_method_type_no_block_tag() {
+  TEST_ASSERT_EQUAL_INT(METHOD_LOCAL, method_type("eth_chainId", "[]"));
+  // block-hash based lookups have no block tag, so a nonsense params array does not flip them
+  TEST_ASSERT_EQUAL_INT(METHOD_PROOFABLE, method_type("eth_getTransactionByHash", "[\"0xabc\"]"));
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_method_type_proofable);
+  RUN_TEST(test_method_type_pending_unproofable);
+  RUN_TEST(test_method_type_earliest_unproofable);
+  RUN_TEST(test_method_type_no_block_tag);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary

RPC-Requests mit einem nicht beweisbaren Block-Tag (`pending` oder `earliest`) werden jetzt korrekt behandelt: Statt bei der Proof-Erzeugung zu scheitern, werden sie als `METHOD_UNPROOFABLE` erkannt und der bestehende Direct-RPC-Fallback (`rpc_handle_unproofable`) beantwortet sie.

Hintergrund: `pending` hat keinen Beacon-Block, `earliest`/Genesis liegt vor der Beacon-Chain -- beide sind ueber den Sync-Committee-Ansatz grundsaetzlich nicht beweisbar.

## Changes

- **`c4_eth_get_method_type`** (`src/chains/eth/verifier/eth_verify.c`): wertet die Request-Params aus und liefert `METHOD_UNPROOFABLE`, wenn der relevante Block-Tag `pending`/`earliest` ist. Neue Helper ermitteln die Block-Tag-Position je Methode (Index 0/1/2 bzw. `fromBlock`/`toBlock` im Filter-Objekt bei `eth_getLogs`).
- **`check_block`** (`src/util/json_validate.c`): akzeptiert `earliest` und `pending` zusaetzlich zu `latest`/`safe`/`finalized` + Hex.
- **Härtung `c4_eth_matches_blocknumber`** (`src/chains/eth/verifier/verify_block.c`): nicht beweisbare Tags duerfen nie als Wildcard einen Proof matchen. Dies bewahrt die Schutzwirkung, die `check_block` vor der Lockerung implizit hatte (verhindert eine latente Proof-Substitution).
- **Tests**: `test_json_validate_block` in `test_core.c` und neue Datei `test_eth_method_type.c` (deckt alle Block-Tag-Positionen sowie Positiv-/Negativ-Faelle ab).

Umgesetzt nach Reviews durch security-agent (M2-Haertung in `verify_block.c` uebernommen) und qa-agent (Tests ergaenzt).

## Test plan

- [x] `cmake --build build/default` erfolgreich
- [x] `test_eth_method_type` und `test_core` gruen
- [x] relevante Verifier-Tests (`block|account|logs|storage|call|verify`) gruen
- [ ] Review

## Hinweis (Design)

Der `pending`/`earliest`-Pfad liefert bewusst unverifizierte RPC-Daten zurueck (inhaerent, da nicht beweisbar). Serverseitig (`handle_verify.c`) fuehrt `METHOD_UNPROOFABLE` weiterhin zu HTTP 400; nur die Client-Bindings machen den Direct-RPC-Fallback.