### PR TITLE
fix(eth): prevent eth_getLogs payload truncation and json_as_string overflow

### DIFF
--- a/src/chains/eth/prover/eth_req.c
+++ b/src/chains/eth/prover/eth_req.c
@@ -85,10 +85,11 @@ c4_status_t eth_getBlockReceipts(prover_ctx_t* ctx, json_t block, json_t* receip
 }
 
 c4_status_t eth_get_logs(prover_ctx_t* ctx, json_t params, json_t* logs) {
-  uint8_t         tmp[1000];
-  buffer_t        buf = stack_buffer(tmp);
+  // Use a growable heap buffer: eth_getLogs params can be large (many addresses/topics)
+  // and would be silently truncated by a fixed stack buffer, producing an invalid request.
+  buffer_t        buf = {0};
   data_request_t* req = NULL;
-  TRY_ASYNC(c4_send_eth_rpc(ctx, "eth_getLogs", json_as_string(params, &buf), 12, logs, &req));
+  TRY_ASYNC_FINAL(c4_send_eth_rpc(ctx, "eth_getLogs", json_as_string(params, &buf), 12, logs, &req), buffer_free(&buf));
   if (req && !req->validated) {
     CHECK_JSON(*logs, "[" JSON_LOG_FIELDS "]", "Invalid results for Logs: ");
     req->validated = true;

--- a/src/util/json.c
+++ b/src/util/json.c
@@ -340,13 +340,22 @@ char* json_as_string(json_t value, buffer_t* buffer) {
   buffer_grow(buffer, value.len + 1);
   if (value.type == JSON_TYPE_STRING) {
     buffer_append(buffer, bytes((uint8_t*) value.start + 1, value.len - 2));
-    buffer->data.data[buffer->data.len] = '\0';
-    buffer->data.len++;
+    if (buffer_grow(buffer, buffer->data.len + 1) > buffer->data.len) { // room for the NULL-Terminator?
+      buffer->data.data[buffer->data.len] = '\0';
+      buffer->data.len++;
+    }
+    else if (buffer->data.len > 0)                             // fixed buffer is full: no room for the terminator,
+      buffer->data.data[buffer->data.len - 1] = '\0';          // so overwrite the last byte to keep the string valid
     json_deescape_string(buffer);
   }
   else {
     buffer_append(buffer, bytes((uint8_t*) value.start, value.len));
-    buffer->data.data[buffer->data.len] = '\0';
+    if (buffer_grow(buffer, buffer->data.len + 1) > buffer->data.len) // room for the NULL-Terminator?
+      buffer->data.data[buffer->data.len] = '\0';                     // then add it
+    else if (buffer->data.len > 0) {                                  // fixed buffer is full: drop the last byte
+      buffer->data.len--;                                            // to make room for the terminator
+      buffer->data.data[buffer->data.len] = '\0';
+    }
   }
   return (char*) buffer->data.data;
 }

--- a/test/unittests/test_core.c
+++ b/test/unittests/test_core.c
@@ -66,6 +66,80 @@ void test_json() {
   TEST_ASSERT_NOT_NULL(err);
   safe_free((char*) err);
 
+  // regression: json_as_string must not overflow a fixed/too-small stack buffer.
+  // Previously the NULL-terminator was written one byte past the end of a full
+  // fixed buffer, which corrupted the stack (SIGABRT under stack protector).
+  {
+    // array value (else-branch of json_as_string)
+    uint8_t  small_arr[8];
+    buffer_t small_arr_buf = stack_buffer(small_arr);
+    char*    arr_out       = json_as_string(json_parse("[\"0x0102030405060708\"]"), &small_arr_buf);
+    TEST_ASSERT_TRUE(strlen(arr_out) < sizeof(small_arr)); // truncated but valid, no overflow
+
+    // string value (string-branch of json_as_string)
+    uint8_t  small_str[8];
+    buffer_t small_str_buf = stack_buffer(small_str);
+    char*    str_out       = json_as_string(json_parse("\"0123456789abcdef\""), &small_str_buf);
+    TEST_ASSERT_TRUE(strlen(str_out) < sizeof(small_str)); // truncated but valid, no overflow
+  }
+
+  // regression: a large value must be serialized completely into a growable heap
+  // buffer (this is the eth_getLogs case that used to be silently truncated).
+  {
+    char   big_json[4096];
+    size_t pos     = 0;
+    big_json[pos++] = '[';
+    for (int i = 0; i < 48; i++) {
+      if (i) big_json[pos++] = ',';
+      memcpy(big_json + pos, "\"0x0e401e3924394a743231f3b96ced8a1b1ec849b2\"", 44);
+      pos += 44;
+    }
+    big_json[pos++] = ']';
+    big_json[pos]   = '\0';
+
+    buffer_t big_buf = {0};
+    char*    big_out = json_as_string(json_parse(big_json), &big_buf);
+    TEST_ASSERT_EQUAL_INT((int) pos, (int) strlen(big_out)); // nothing truncated
+    TEST_ASSERT_EQUAL_STRING(big_json, big_out);
+    buffer_free(&big_buf);
+  }
+
+  // edge cases for json_as_string boundaries.
+  {
+    // empty string value "" (string-branch, inner length 0)
+    buffer_t empty_str_buf = {0};
+    TEST_ASSERT_EQUAL_STRING("", json_as_string(json_parse("\"\""), &empty_str_buf));
+    buffer_free(&empty_str_buf);
+
+    // empty array value [] (else-branch, no truncation)
+    buffer_t empty_arr_buf = {0};
+    TEST_ASSERT_EQUAL_STRING("[]", json_as_string(json_parse("[]"), &empty_arr_buf));
+    buffer_free(&empty_arr_buf);
+
+    // fixed buffer with capacity exactly equal to needed length (content + terminator):
+    // must NOT truncate. "[]" needs 2 bytes + 1 terminator = 3.
+    uint8_t  exact_arr[3];
+    buffer_t exact_arr_buf = stack_buffer(exact_arr);
+    TEST_ASSERT_EQUAL_STRING("[]", json_as_string(json_parse("[]"), &exact_arr_buf));
+
+    // same for the string-branch: "ab" needs 2 bytes + 1 terminator = 3.
+    uint8_t  exact_str[3];
+    buffer_t exact_str_buf = stack_buffer(exact_str);
+    TEST_ASSERT_EQUAL_STRING("ab", json_as_string(json_parse("\"ab\""), &exact_str_buf));
+  }
+
+  // regression: escaped-string deescaping combined with a too-small fixed buffer.
+  // The raw (still-escaped) bytes are truncated to fit, then json_deescape_string
+  // runs over the truncated content -- this must stay in bounds even when the
+  // truncation leaves a dangling backslash at the end.
+  {
+    uint8_t  esc_buf_mem[8];
+    buffer_t esc_buf = stack_buffer(esc_buf_mem);
+    char*    esc_out = json_as_string(json_parse("\"\\n\\n\\n\\n\\n\\n\""), &esc_buf);
+    TEST_ASSERT_NOT_NULL(esc_out);
+    TEST_ASSERT_TRUE(strlen(esc_out) < sizeof(esc_buf_mem)); // no overflow, valid C string
+  }
+
   // cleanup
   buffer_free(&buffer);
 }


### PR DESCRIPTION
## Summary

Fixes silent truncation of large `eth_getLogs` payloads (which caused `-32700 parse error` at the upstream RPC node) and the underlying 1-byte buffer overflow in `json_as_string`.

### Root cause (two bugs)

- **Truncation (functional):** `eth_get_logs` used a fixed 1000-byte stack buffer (`stack_buffer(tmp)`). For large params (many addresses/topics, e.g. 2614 bytes), `buffer_append` enforces the fixed-buffer bound and **silently truncates to 1000 bytes**. `c4_send_eth_rpc` then embeds the truncated string via `%s` -> invalid JSON -> node returns `-32700 parse error`.
- **Overflow (memory safety):** `json_as_string` wrote the NUL terminator with `buffer->data.data[buffer->data.len] = '\0'` without checking for room. On a full fixed buffer this writes **one byte past the end** (stack buffer overflow). The STRING branch additionally did `data.len++`, pushing `data.len` beyond capacity. In a Debug build (stack protector) this triggers `SIGABRT` (`__stack_chk_fail`); in Release the 1-byte UB may not crash but the truncation remains.

### Changes

- `eth_get_logs` ([src/chains/eth/prover/eth_req.c](src/chains/eth/prover/eth_req.c)): use a growable heap buffer `buffer_t buf = {0}` + `TRY_ASYNC_FINAL(..., buffer_free(&buf))`, matching the existing `eth_get_proof` / `eth_call` pattern. No more truncation, no leak on `C4_PENDING`.
- `json_as_string` ([src/util/json.c](src/util/json.c)): guard both NUL-terminator writes with the established `bprintf` idiom (`if (buffer_grow(buffer, len+1) > len) ...`). Fixed buffers are now truncated safely instead of overflowing. This also hardens every other fixed-buffer caller (e.g. `json_as_uint64`).
- Regression tests ([test/unittests/test_core.c](test/unittests/test_core.c)): fixed vs. heap buffers, empty string/array, exact-capacity boundary, and escaped-string deescaping in a too-small buffer.

### Reviews

Security review: no findings (memory-safe on all paths, correct buffer lifecycle). QA review: added edge-case tests; existing `test_logs_cache` / `test_eth_verify_logs` cover the normal path.

## Test plan

- [x] `cmake --build build/default` (Debug + stack protector) builds clean
- [x] `ctest -R "logs|core"` passes (test_core, test_eth_verify_logs, test_logs_cache)
- [x] `test_core`: 12 tests, 0 failures (incl. new regression cases)
- [ ] Manual: run the original large `eth_getLogs` request against a local server and confirm no truncation / no SIGABRT