### PR TITLE
Fix/sync fallback if state of cache is broken

### DIFF
--- a/bindings/emscripten/test/integration.test.mjs
+++ b/bindings/emscripten/test/integration.test.mjs
@@ -155,20 +155,27 @@ describe('Integration Tests', { skip: !RUN_INTEGRATION, timeout: TIMEOUT, concur
   });
 
   before(async () => {
-    const blockNum = await fetch('https://mainnet1.colibri-proof.tech/execution', {
-      method: 'POST',
-      body: JSON.stringify({ jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: 1 }),
-      headers: { 'Content-Type': 'application/json' },
-    })
-      .then(res => res.json())
-      .then(data => data.result);
-    const older = '0x' + (parseInt(blockNum, 16) - 10000).toString(16);
-    console.log({ blockNum, older });
+    // Populate `oldStateStorage` with a sync-committee state for the PREVIOUS period
+    // (P-1) so the "old storage" tests below genuinely exercise the forward update to
+    // the current period (P).
+    //
+    // Note: we can no longer do this by simply proving an old block. Historic blocks are
+    // now proven via `historical_summaries` anchored to the *current* finalized period,
+    // so fetching an old block leaves the cache at P (not P-1). Instead we bootstrap from
+    // a trusted checkpoint located one period back and prove the checkpoint's own block,
+    // which lives in that same period -- no forward sync happens, so the cache stays at P-1.
+    const checkpoint  = await resolveCheckpointByPeriods(BEACON_API, 1);
+    const cpBlockRes  = await fetchWithRetry(`${BEACON_API}/eth/v2/beacon/blocks/${checkpoint}`);
+    const cpBlockJson = await cpBlockRes.json();
+    const oldBlockNumber =
+      '0x' + Number(cpBlockJson.data.message.body.execution_payload.block_number).toString(16);
+    console.log({ checkpoint, oldBlockNumber });
+
     oldStateStorage = createMemoryStorage();
     Colibri.register_storage(oldStateStorage);
 
-    const c4 = new Colibri({ chainId: CHAIN_ID, zk_proof: true });
-    await c4.rpc('eth_getBlockByNumber', [older, false]);
+    const c4 = new Colibri({ chainId: CHAIN_ID, trusted_checkpoint: checkpoint, zk_proof: false });
+    await c4.rpc('eth_getBlockByNumber', [oldBlockNumber, false]);
     assert.ok(oldStateStorage._map.size > 0, 'Storage should be populated after initial request');
   });
 
@@ -285,6 +292,10 @@ describe('Integration Tests', { skip: !RUN_INTEGRATION, timeout: TIMEOUT, concur
       Colibri.register_storage(storage);
       const spy = createSpyCache();
 
+      // periods present in the starting (P-1) state
+      const syncKey        = (k) => k.startsWith(`sync_${CHAIN_ID}_`);
+      const periodsBefore  = [...storage._map.keys()].filter(syncKey);
+
       const c4 = new Colibri({ chainId: CHAIN_ID, zk_proof: true, cache: spy });
       const result = await c4.rpc('eth_blockNumber', []);
       assertIsHexBlockNumber(result);
@@ -293,6 +304,12 @@ describe('Integration Tests', { skip: !RUN_INTEGRATION, timeout: TIMEOUT, concur
         r.url && r.url.includes('light_client_bootstrap')
       );
       assert.strictEqual(bootstrapReqs.length, 0, 'Should NOT fetch bootstrap with existing state + zk_proof');
+
+      // Core scenario: the existing P-1 state must be updated FORWARD to the current
+      // period (P) via the ZK sync data -- a new sync-committee period gets persisted.
+      const periodsAfter = [...storage._map.keys()].filter(syncKey);
+      assert.ok(periodsAfter.length > periodsBefore.length,
+        `Existing state (${periodsBefore.join(',')}) should be updated forward to the current period via zk_proof (got ${periodsAfter.join(',')})`);
     });
 
     test('old storage + zk_proof false', { timeout: TIMEOUT }, async () => {

--- a/src/chains/eth/verifier/sync_committee_state.c
+++ b/src/chains/eth/verifier/sync_committee_state.c
@@ -546,6 +546,9 @@ static void clear_sync_state(chain_id_t chain_id) {
   storage_plugin_t storage_conf = {0};
   c4_get_storage_config(&storage_conf);
 
+  // A host may register a storage plugin without a delete hook; nothing to clear then.
+  if (!storage_conf.del) return;
+
   // Delete all sync states for this chain
   c4_chain_state_t chain_state = c4_get_chain_state(chain_id);
   for (uint32_t i = 0; chain_state.status == C4_STATE_SYNC_PERIODS && i < MAX_SYNC_PERIODS && chain_state.data.periods[i] != 0; i++) {
@@ -1076,7 +1079,56 @@ INTERNAL const c4_status_t c4_get_validators(verify_ctx_t* ctx, uint32_t period,
   if (sync_state.validators.data == NULL) {
     // Strategy 1: No cached periods exist - initialize from trusted checkpoint
     if (sync_state.lowest_period == 0) {
-      if (sync_state.highest_period) THROW_ERROR("the last sync state is higher than the required period, but we cannot sync backwards");
+      if (sync_state.highest_period) {
+        // The cache only holds periods *newer* than the requested one, so there is no
+        // period we could sync forward from. A forward-only light client cannot obtain an
+        // older committee, hence the "cannot sync backwards" error.
+        //
+        // We attempt a *one-time*, *evidence-gated* self-healing recovery for the single
+        // legitimate case that produces this state: the cache advanced ahead of the real
+        // finalized head (e.g. via an earlier head-based update near a period boundary) and
+        // a later request needs a finalized block from a slightly older period.
+        //
+        // SECURITY: `period` is derived from the slot of an untrusted proof header and is
+        // signature-verified only *after* this call (see beacon_header.c). We must therefore
+        // NOT clear the validated sync-committee cache based on `period` alone -- a malicious
+        // prover could otherwise supply an artificially old slot to force a repeated cache
+        // wipe + re-bootstrap (DoS). Instead we require independent evidence from the trusted
+        // checkpointz finalized head that the cache is genuinely ahead of the chain tip.
+        if (ctx->flags & VERIFY_FLAG_SYNC_REINIT_TRIED)
+          THROW_ERROR("the last sync state is higher than the required period, but we cannot sync backwards");
+
+#ifdef USE_CHECKPOINTZ
+        // Fail closed: never wipe a validated cache without a valid chain spec.
+        const chain_spec_t* spec = c4_eth_get_chain_spec(ctx->chain_id);
+        if (!spec) THROW_ERROR("unsupported chain id!");
+
+        uint64_t  checkpoint_epoch = 0;
+        bytes32_t checkpoint_root  = {0};
+        if (!c4_req_checkpointz_status(&ctx->state, ctx->chain_id, &checkpoint_epoch, checkpoint_root))
+          return ctx->state.error ? C4_ERROR : C4_PENDING;
+        uint32_t checkpoint_period = (uint32_t) (checkpoint_epoch >> spec->epochs_per_period_bits);
+
+        // Only self-heal the narrow legitimate case: the cache is genuinely ahead of the
+        // finalized head (`checkpoint_period < highest_period`) AND the requested period is
+        // reachable by re-bootstrapping to the finalized checkpoint and syncing forward
+        // (`period >= checkpoint_period`). Anything older than the finalized head is a true
+        // "cannot sync backwards" case that a forward-only client cannot serve -- surface the
+        // error without touching the validated cache.
+        if (checkpoint_period >= sync_state.highest_period || period < checkpoint_period)
+          THROW_ERROR("the last sync state is higher than the required period, but we cannot sync backwards");
+
+        // Discard the stale (ahead-of-finality) state and re-bootstrap from the trusted
+        // checkpoint. The guard flag (persisted on the ctx across C4_PENDING rounds) ensures
+        // this is attempted at most once, so a genuinely-older `period` cannot loop.
+        ctx->flags |= VERIFY_FLAG_SYNC_REINIT_TRIED;
+        clear_sync_state(ctx->chain_id);
+        TRY_ASYNC(init_sync_state(ctx));
+        return c4_get_validators(ctx, period, target_state, pubkey_hash);
+#else
+        THROW_ERROR("the last sync state is higher than the required period, but we cannot sync backwards");
+#endif
+      }
       TRY_ASYNC(init_sync_state(ctx));
       // Recursively call to retrieve the period after initialization
       return c4_get_validators(ctx, period, target_state, NULL);

--- a/src/chains/eth/verifier/verify_call.c
+++ b/src/chains/eth/verifier/verify_call.c
@@ -529,8 +529,10 @@ static bool pap_verify_proof_response(verify_ctx_t* ctx, call_account_t* call_ac
   // policy flags (VERIFY_FLAG_SKIP_WSP_CHECK, VERIFY_FLAG_HYBRID, VERIFY_FLAG_OBLIVIOUS, …)
   // behave consistently across both contexts. VERIFY_FLAG_FREE_DATA must be masked out:
   // proof_ctx.data points into the prover response (owned by the data_request_t), so
-  // c4_verify_free_data must not free it.
-  verify_flags_t inner_flags = ctx->flags & ~VERIFY_FLAG_FREE_DATA;
+  // c4_verify_free_data must not free it. VERIFY_FLAG_SYNC_REINIT_TRIED is a transient
+  // internal guard scoped to a single verification context; the inner sub-proof must be
+  // allowed its own one-time sync-state recovery, so it is masked out as well.
+  verify_flags_t inner_flags = ctx->flags & ~(VERIFY_FLAG_FREE_DATA | VERIFY_FLAG_SYNC_REINIT_TRIED);
   if (c4_verify_init(&proof_ctx, response, "eth_call", ctx->args, ctx->chain_id, inner_flags) != C4_SUCCESS) {
     if (proof_ctx.state.error) c4_state_add_error(&ctx->state, proof_ctx.state.error);
     goto cleanup;

--- a/src/verifier/verify.h
+++ b/src/verifier/verify.h
@@ -87,6 +87,7 @@ typedef enum {
   VERIFY_FLAG_REVERTED       = 1 << 5, // set by the verifier when an `eth_call` / `eth_estimateGas` was successfully verified but the underlying EVM execution reverted. The revert data is exposed via `verify_ctx_t.data` (raw `bytes` SSZ type). Bindings/hosts should surface this as a structured error (e.g. JSON-RPC code 3) so callers like ethers can decode `OffchainLookup` (EIP-3668 / CCIP-Read) reverts.
   VERIFY_FLAG_OBLIVIOUS      = 1 << 6, // if set, the verifier will use the oblivious_node
   VERIFY_FLAG_SKIP_WSP_CHECK = 1 << 7, // if set, skip the Weak Subjectivity Period check for prover-provided or fetched sync committee data. SECURITY: Only use when an alternative trust anchor (witness signatures, hard-coded checkpoint, signed package) is available. Disabling increases the risk of long-range attacks when syncing across periods older than the WSP.
+  VERIFY_FLAG_SYNC_REINIT_TRIED = 1 << 8, // internal transient flag: set by the verifier once it has attempted a full sync-state reinitialization (clear + re-bootstrap from a trusted checkpoint) during this verification. Prevents an infinite reinit loop when the requested period is genuinely older than any obtainable committee. Not intended to be set by hosts.
 } verify_flag_t;
 
 /**


### PR DESCRIPTION
## Summary

Makes the verifier self-heal when its sync-committee cache is in a broken/unusable state -- specifically when the newest cached period is *newer* than the period required to verify a request. Previously this dead-ended in a hard `"cannot sync backwards"` error; now the stale state is discarded and the cache is re-initialized from a fresh trusted checkpoint.

## Problem

Colibri's verifier is a forward-only light client: from a cached sync-committee period it can only sync *forward* to newer periods, never backward. This is normally fine, but the cache can legitimately end up *ahead* of the finalized head -- e.g. an earlier head-based update near a period boundary advances the cache to period `P`, and a later request then needs a finalized block from a slightly older period `P-1`.

In that situation `c4_get_validators()` held only periods newer than the one requested, had nothing to sync forward from, and threw:

```
the last sync state is higher than the required period, but we cannot sync backwards
```

The request failed permanently even though the data was perfectly verifiable after a re-bootstrap.

## Solution

In [`src/chains/eth/verifier/sync_committee_state.c`](src/chains/eth/verifier/sync_committee_state.c), `c4_get_validators()` now performs a **one-time, evidence-gated recovery** for exactly this case:

1. Query the trusted checkpointz finalized head (`c4_req_checkpointz_status`) to learn the real finalized period.
2. Only self-heal the narrow legitimate case where the cache is genuinely ahead of finality (`checkpoint_period < highest_period`) **and** the requested period is reachable by re-bootstrapping to the finalized checkpoint and syncing forward (`period >= checkpoint_period`).
3. Discard the stale state (`clear_sync_state`) and re-bootstrap from the trusted checkpoint (`init_sync_state`), then retry.

Anything genuinely older than the finalized head remains a true "cannot sync backwards" case and surfaces the error without touching the validated cache.

Supporting changes:

- **New flag `VERIFY_FLAG_SYNC_REINIT_TRIED`** ([`src/verifier/verify.h`](src/verifier/verify.h)): an internal, transient guard set once the reinit has been attempted, so a genuinely-unservable period cannot cause an infinite clear + re-bootstrap loop.
- **[`src/chains/eth/verifier/verify_call.c`](src/chains/eth/verifier/verify_call.c)**: mask `VERIFY_FLAG_SYNC_REINIT_TRIED` out of the inner `eth_call` sub-proof flags, so a nested verification is allowed its own independent one-time recovery.
- **`clear_sync_state`**: bail out early if the host registered a storage plugin without a `del` hook (nothing to clear).

The recovery path is compiled only when `USE_CHECKPOINTZ` is enabled; otherwise the original error is preserved.

## Security

- `period` is derived from the slot of an **untrusted** proof header and is signature-verified only *after* this call. The recovery therefore never wipes the validated cache based on `period` alone. Instead it requires independent evidence from the trusted checkpointz finalized head, preventing a malicious prover from supplying an artificially old slot to force repeated cache wipes + re-bootstraps (DoS).
- Fails closed: no valid chain spec or no checkpointz status -> no cache mutation.
- The one-time guard flag bounds the recovery to a single attempt per verification context.

## Tests

Reworked the `before` hook in [`bindings/emscripten/test/integration.test.mjs`](bindings/emscripten/test/integration.test.mjs) so the "old storage" scenarios genuinely exercise a forward update again. Seeding a `P-1` state by proving an old block no longer works (historic blocks are now proven via `historical_summaries` anchored to the *current* period, leaving the cache at `P`). The hook now bootstraps from a trusted checkpoint one period back and proves the checkpoint's own block (in that same period, so no forward sync happens), and the `old storage + zk_proof` test now asserts that a new period is actually persisted.

### Test plan

- [x] `cmake --build build/default` succeeds.
- [x] `cmake --build build/wasm-debug` succeeds.
- [x] `C4_RUN_INTEGRATION=1 node --test test/integration.test.mjs` passes (11 pass, 1 skip, 0 fail); `before` seeds `P-1` and the forward-update assertion holds.