### PR TITLE
fix(json): prevent OOB write in json_as_uint64 on oversized hex quantity

### DIFF
--- a/src/util/json.c
+++ b/src/util/json.c
@@ -365,7 +365,7 @@ uint64_t json_as_uint64(json_t value) {
   buffer_t buffer  = stack_buffer(tmp);
   if (value.len > 4 && value.start && value.start[1] == '0' && value.start[2] == 'x') {
     int len = hex_to_bytes(value.start + 1, value.len - 2, bytes(tmp, 20));
-    if (len == -1) return 0;
+    if (len < 0 || len > 8) return 0; // invalid hex, or the quantity does not fit into 64 bits
     memmove(tmp + 8 - len, tmp, len);
     memset(tmp, 0, 8 - len);
     return uint64_from_be(tmp);

--- a/test/unittests/test_core.c
+++ b/test/unittests/test_core.c
@@ -140,6 +140,29 @@ void test_json() {
     TEST_ASSERT_TRUE(strlen(esc_out) < sizeof(esc_buf_mem)); // no overflow, valid C string
   }
 
+  // regression: json_as_uint64 must not perform an out-of-bounds write when a hex
+  // quantity decodes to more than 8 bytes. Previously "8 - len" underflowed the
+  // pointer and the size_t passed to memset became ~SIZE_MAX (remote memory
+  // corruption reachable from any attacker-controlled hex quantity in an RPC
+  // response). Oversized values must fail closed (return 0) instead.
+  {
+    // valid values that fit into 64 bits are unaffected
+    TEST_ASSERT_EQUAL_HEX64(0x1234, json_as_uint64(json_parse("\"0x1234\"")));
+    TEST_ASSERT_EQUAL_HEX64(UINT64_MAX, json_as_uint64(json_parse("\"0xffffffffffffffff\""))); // exactly 8 bytes, upper valid edge
+
+    // 9 decoded bytes (18 hex digits): "8 - len" used to underflow and crash; caught by the len > 8 guard
+    TEST_ASSERT_EQUAL_HEX64(0, json_as_uint64(json_parse("\"0x010203040506070809\"")));
+
+    // full 256-bit quantity (32 bytes) exceeds the 20-byte scratch buffer -> hex_to_bytes returns -1 (len < 0 guard)
+    TEST_ASSERT_EQUAL_HEX64(0, json_as_uint64(json_parse("\"0x0102030405060708091011121314151617181920212223242526272829303132\"")));
+
+    // invalid hex nibble that still fits the buffer -> hex_to_bytes returns -1 (len < 0 guard)
+    TEST_ASSERT_EQUAL_HEX64(0, json_as_uint64(json_parse("\"0x12zz\"")));
+
+    // decimal (non-0x) path goes through strtoull
+    TEST_ASSERT_EQUAL_HEX64(255, json_as_uint64(json_parse("255")));
+  }
+
   // cleanup
   buffer_free(&buffer);
 }


### PR DESCRIPTION
## Summary

Fixes the single **Critical** finding (7.1 / `F-128A96`) from the security audit report (`build/audit3/REPORT.md`), verified against the actual source (the auditors never had the code and marked it *Disputed/Likely*).

`json_as_uint64` (`src/util/json.c`) decodes a `0x…` hex string into a 20-byte stack buffer, then right-aligns it into the low 8 bytes:

```c
memmove(tmp + 8 - len, tmp, len);
memset(tmp, 0, 8 - len);
```

`hex_to_bytes` returns the decoded byte count `len` (0..20). When `len > 8` — i.e. any hex quantity that does not fit into 64 bits, which is the **common** case for 256-bit EVM values — `8 - len` is negative:
- `memmove` writes **before** the buffer (pointer underflow), and
- `memset` receives `~SIZE_MAX` as its size → massive out-of-bounds write.

This is remotely reachable from attacker-controlled RPC responses, since `json_as_uint64` is applied broadly to untrusted RPC data (`verify_block.c`, `eth_account.c`, `http_client.c` block tags, …). Impact: guaranteed DoS, potential memory corruption / RCE — especially severe on the mobile/IoT verifier targets.

## Fix

Reject `len > 8` (and `len < 0`) before the shift and fail closed by returning `0`, consistent with the existing error and decimal paths:

```c
if (len < 0 || len > 8) return 0; // invalid hex, or the quantity does not fit into 64 bits
```

## Test plan

- [x] Added regression tests in `test_json()` (`test/unittests/test_core.c`): 8-byte boundary (`UINT64_MAX`), 9-byte underflow case (`len > 8` guard), 32-byte oversized and invalid-nibble cases (`len < 0` guard), and the decimal `strtoull` path.
- [x] Confirmed the new test **crashes** (signal) with the fix reverted and **passes** with the fix applied.
- [x] `test_core` passes (12/12).
- [x] Reviewed by security-agent (OOB fully eliminated for the whole `hex_to_bytes` range, no residual underflow) and qa-agent.

> Note: the full `build/default` build currently fails at the pre-existing kona_bridge (Rust/OP-Stack) step in this environment, unrelated to this change; the fix was verified with an OP-free test build.