### PR TITLE
fix(json,eth): harden JSON parser and access-list builder against OOB access

### DIFF
--- a/src/chains/eth/prover/eth_req.c
+++ b/src/chains/eth/prover/eth_req.c
@@ -145,6 +145,11 @@ c4_status_t eth_debug_trace_call(prover_ctx_t* ctx, json_t tx, json_t* trace, ui
 c4_status_t eth_create_access_list(prover_ctx_t* ctx, json_t tx, json_t* trace, uint64_t block_number, json_t state_overrides) {
   buffer_t        buf = {0};
   data_request_t* req = NULL;
+  // The tx object is validated upstream (CHECK_JSON in c4_proof_call), but guard
+  // defensively: never decrement an unsigned length without confirming tx is a
+  // non-empty object, otherwise tx.len would wrap and %J would emit an
+  // out-of-bounds slice into the outbound request.
+  if (tx.type != JSON_TYPE_OBJECT || tx.len < 2) THROW_ERROR("invalid tx object for access list");
   tx.len--; // removing the closing '}', so we can add arguments
             //  TRY_ASYNC_FINAL(c4_send_eth_rpc(ctx, "eth_createAccessList", bprintf(&buf, "[%J,\"maxFeePerGas\":\"0x1\",\"maxPriorityFeePerGas\":\"0x1\"},\"0x%lx\"]", tx, block_number), 12, trace), buffer_free(&buf));
   if (state_overrides.type == JSON_TYPE_OBJECT)

--- a/src/util/json.c
+++ b/src/util/json.c
@@ -72,7 +72,7 @@ static const char* find_end(const char* pos, char start, char end) {
     }
     else if (*pos == '"') {
       in_string = !in_string;
-      if (!in_string && *pos == end) return pos;
+      if (!in_string && end == '"') return pos; // closing quote of a top-level string reached
     }
   }
   return NULL;
@@ -202,17 +202,21 @@ json_t json_get_path(json_t parent, const char* path) {
   const char* next_idx  = strchr(path, '[');
   const char* next      = (next_prop && next_idx) ? (next_prop < next_idx ? next_prop : next_idx) : (next_prop ? next_prop : next_idx);
   if (!next) return json_get(parent, path);
-  strncpy(tmp, path, next - path);
-  tmp[next - path] = '\0';
-  json_t value     = json_get(parent, tmp);
+  size_t seg = (size_t) (next - path);
+  if (seg >= sizeof(tmp)) return JSON_INVALID(parent.start); // reject over-long segment instead of overflowing tmp
+  memcpy(tmp, path, seg);
+  tmp[seg]     = '\0';
+  json_t value = json_get(parent, tmp);
   if (value.type == JSON_TYPE_INVALID) return value;
   if (next && strlen(next + 1) > 0) {
     if (*next == '[') {
       const char* end_idx = strchr(next + 1, ']');
       if (!end_idx) return JSON_INVALID(parent.start);
-      strncpy(tmp, next + 1, end_idx - next - 1);
-      tmp[end_idx - next - 1] = '\0';
-      json_t item             = json_at(value, atoi(tmp));
+      size_t idx_len = (size_t) (end_idx - next - 1);
+      if (idx_len >= sizeof(tmp)) return JSON_INVALID(parent.start); // reject over-long index instead of overflowing tmp
+      memcpy(tmp, next + 1, idx_len);
+      tmp[idx_len] = '\0';
+      json_t item  = json_at(value, atoi(tmp));
       if (item.type == JSON_TYPE_INVALID) return item;
       if (end_idx[1] == '.')
         return json_get_path(item, end_idx + 2);
@@ -339,7 +343,8 @@ char* json_as_string(json_t value, buffer_t* buffer) {
   buffer->data.len = 0;
   buffer_grow(buffer, value.len + 1);
   if (value.type == JSON_TYPE_STRING) {
-    buffer_append(buffer, bytes((uint8_t*) value.start + 1, value.len - 2));
+    if (value.len >= 2) // guard against size_t underflow of value.len - 2 for malformed/synthesized short STRING nodes
+      buffer_append(buffer, bytes((uint8_t*) value.start + 1, value.len - 2));
     if (buffer_grow(buffer, buffer->data.len + 1) > buffer->data.len) { // room for the NULL-Terminator?
       buffer->data.data[buffer->data.len] = '\0';
       buffer->data.len++;
@@ -387,9 +392,14 @@ bytes_t json_as_bytes(json_t value, buffer_t* buffer) {
     return buffer->data;
   }
   if (value.type != JSON_TYPE_STRING) return NULL_BYTES;
+  if (value.len < 2) return NULL_BYTES; // guard against size_t underflow of value.len - 2 for malformed short STRING nodes
 
-  buffer_grow(buffer, value.len / 2);
-  buffer->data.len = value.len;
+  // Advertise the *real* capacity to hex_to_bytes: buffer_grow returns the
+  // actually available size (the requested size for growable buffers, or the
+  // fixed capacity for stack/fixed buffers where growth is impossible). Using
+  // value.len here would over-state the capacity of a fixed target buffer and
+  // let hex_to_bytes write past its end.
+  buffer->data.len = buffer_grow(buffer, value.len / 2);
   int len          = hex_to_bytes(value.start + 1, value.len - 2, buffer->data);
   if (len == -1) return NULL_BYTES;
   buffer->data.len = (uint32_t) len;

--- a/src/util/json.c
+++ b/src/util/json.c
@@ -401,7 +401,10 @@ bytes_t json_as_bytes(json_t value, buffer_t* buffer) {
   // let hex_to_bytes write past its end.
   buffer->data.len = buffer_grow(buffer, value.len / 2);
   int len          = hex_to_bytes(value.start + 1, value.len - 2, buffer->data);
-  if (len == -1) return NULL_BYTES;
+  if (len == -1) {
+    if (buffer == &tmp) buffer_free(&tmp); // only the locally-owned fallback buffer; a caller-provided buffer is freed by the caller
+    return NULL_BYTES;
+  }
   buffer->data.len = (uint32_t) len;
   return buffer->data;
 }

--- a/test/unittests/test_core.c
+++ b/test/unittests/test_core.c
@@ -163,6 +163,69 @@ void test_json() {
     TEST_ASSERT_EQUAL_HEX64(255, json_as_uint64(json_parse("255")));
   }
 
+  // regression (F-ED20B2): json_to_bytes / json_as_bytes must not overflow a fixed
+  // target buffer when the hex string decodes to more bytes than the target holds.
+  // Previously json_as_bytes advertised value.len (the hex string length) as capacity
+  // to hex_to_bytes, defeating its bounds check on fixed (non-growable) buffers.
+  {
+    struct {
+      uint8_t target[32];
+      uint8_t canary[16];
+    } g;
+    memset(&g, 0xAA, sizeof(g));
+
+    // oversized (38-byte) hex value into a 32-byte target -> must fail closed (0 written), no overflow
+    uint32_t n = json_to_bytes(json_parse("\"0x0102030405060708091011121314151617181920212223242526272829303132333435363738\""), bytes(g.target, 32));
+    TEST_ASSERT_EQUAL_UINT32(0, n);
+    for (int i = 0; i < 16; i++) TEST_ASSERT_EQUAL_HEX8(0xAA, g.canary[i]); // canary intact -> no overflow
+
+    // exact 32-byte value still decodes correctly into the fixed target
+    uint32_t m = json_to_bytes(json_parse("\"0x0102030405060708091011121314151617181920212223242526272829303132\""), bytes(g.target, 32));
+    TEST_ASSERT_EQUAL_UINT32(32, m);
+    TEST_ASSERT_EQUAL_HEX8(0x01, g.target[0]);
+    TEST_ASSERT_EQUAL_HEX8(0x32, g.target[31]);
+    for (int i = 0; i < 16; i++) TEST_ASSERT_EQUAL_HEX8(0xAA, g.canary[i]);
+  }
+
+  // regression (F-07C606): json_get_path must not overflow its 256-byte scratch
+  // buffer when a path segment is >= 256 bytes. A well-formed lookup still works.
+  {
+    char longpath[300];
+    memset(longpath, 'a', 298);
+    longpath[298] = '.'; // segment of 298 chars followed by a separator triggers the old strncpy overflow
+    longpath[299] = '\0';
+    json_t r = json_get_path(json_parse("{\"a\":1}"), longpath);
+    TEST_ASSERT_TRUE(r.type == JSON_TYPE_INVALID || r.type == JSON_TYPE_NOT_FOUND); // rejected, no crash
+
+    // second overflow site: an over-long array-index segment "a[999...9]" must also be rejected
+    char idxpath[320];
+    idxpath[0] = 'a';
+    idxpath[1] = '[';
+    memset(idxpath + 2, '9', 300);
+    idxpath[302] = ']';
+    idxpath[303] = '\0';
+    json_t r2    = json_get_path(json_parse("{\"a\":[1,2,3]}"), idxpath);
+    TEST_ASSERT_TRUE(r2.type == JSON_TYPE_INVALID || r2.type == JSON_TYPE_NOT_FOUND); // rejected, no crash
+
+    // sanity: normal path lookups keep working (property and array index)
+    json_t ok = json_get_path(json_parse("{\"a\":{\"b\":42}}"), "a.b");
+    TEST_ASSERT_EQUAL_INT(42, json_as_uint32(ok));
+    json_t ok_idx = json_get_path(json_parse("{\"a\":[7,8,9]}"), "a[1]");
+    TEST_ASSERT_EQUAL_INT(8, json_as_uint32(ok_idx));
+  }
+
+  // regression (F-16D6F1): json_as_string must not underflow value.len - 2 for a
+  // malformed/synthesized STRING node with len < 2 (not producible by json_parse,
+  // but reachable via hand-built json_t). Must yield a valid (empty) C string.
+  {
+    json_t   short_str = {.type = JSON_TYPE_STRING, .start = "\"", .len = 1};
+    buffer_t sbuf      = {0};
+    char*    out       = json_as_string(short_str, &sbuf);
+    TEST_ASSERT_NOT_NULL(out);
+    TEST_ASSERT_EQUAL_STRING("", out);
+    buffer_free(&sbuf);
+  }
+
   // cleanup
   buffer_free(&buffer);
 }

--- a/test/unittests/test_core.c
+++ b/test/unittests/test_core.c
@@ -185,6 +185,18 @@ void test_json() {
     TEST_ASSERT_EQUAL_HEX8(0x01, g.target[0]);
     TEST_ASSERT_EQUAL_HEX8(0x32, g.target[31]);
     for (int i = 0; i < 16; i++) TEST_ASSERT_EQUAL_HEX8(0xAA, g.canary[i]);
+
+    // regression: on invalid hex, json_as_bytes must not leak the locally-owned
+    // fallback buffer it allocates when called with a NULL buffer (checked by valgrind).
+    buffer_t* null_buf = NULL;
+    bytes_t   inv      = json_as_bytes(json_parse("\"0xzz\""), null_buf);
+    TEST_ASSERT_NULL(inv.data);
+
+    // caller-provided buffer on invalid hex: returns NULL_BYTES, caller still owns/frees it
+    buffer_t owned = {0};
+    bytes_t  inv2  = json_as_bytes(json_parse("\"0xzz\""), &owned);
+    TEST_ASSERT_NULL(inv2.data);
+    buffer_free(&owned);
   }
 
   // regression (F-07C606): json_get_path must not overflow its 256-byte scratch


### PR DESCRIPTION
## Summary

Addresses the memory-safety **High** findings from the security audit (`build/audit3/REPORT.md`), each verified against the actual source. Several were marked *Rejected/Disputed* by the audit panel, but a line-by-line review confirmed the ones below are real (notably F-ED20B2, which the panel dismissed by only considering the growable-heap path).

| Finding | Location | Issue | Fix |
|---|---|---|---|
| **F-ED20B2** | `json_as_bytes` | Advertised `value.len` (hex string length) as capacity to `hex_to_bytes`. On a **fixed** buffer (`json_to_bytes`/`json_to_var`, e.g. 32/65-byte targets fed from untrusted RPC/Beacon data), `buffer_grow` can't grow, so the bounds check was defeated → write past target end. | Advertise the real capacity returned by `buffer_grow`; oversized hex now fails closed. |
| **F-07C606** | `json_get_path` | Two unbounded `strncpy` into `char tmp[256]` → stack overflow on path segments ≥ 256 bytes. | Reject over-long segments at both sites. |
| **F-16D6F1** | `json_as_string` / `json_as_bytes` | `value.len - 2` underflows `size_t` for STRING nodes with `len < 2`. | Guard `value.len >= 2` before the subtraction. |
| **F-9386EE** | `eth_create_access_list` | Unconditional `tx.len--` wraps the unsigned length for an empty/non-object `tx`, so `%J` emits an out-of-bounds slice into the outbound request. | Guard that `tx` is a non-empty object before decrementing. |
| **F-CD2BA1** | `find_end` | Report claimed a dead sub-condition. Verified it is **not** dead for top-level string parsing (`end == '"'`); clarified without behavior change. |

## Why the audit's proof-of-absence Highs (F-72F262 / F-932B16) are **not** fixed here

`get_eth_tx` treating a pending/absent tx as null, and the verifier accepting an empty proof for nullable methods (`eth_verify.c:377-383`), are an **intentional light-client design**: non-existence of a tx by hash is not cryptographically provable. A malicious RPC returning null is indistinguishable from a genuine null and gains nothing extra by mangling `transactionIndex` (same empty-proof outcome). These are a design/documentation matter, not a code defect, and are left unchanged to avoid breaking liveness for legitimate pending/absent transactions.

## Test plan

- [x] New regression tests in `test_json()`: fixed-buffer overflow with a 16-byte canary (returns 0, canary intact), both `json_get_path` overflow sites (property + array-index segment), and the short-STRING underflow.
- [x] Verified the fix catches the bug: reverting the `json.c` changes makes the `json_to_bytes` test fail with `Expected 0 Was 38` (pre-fix wrote 38 bytes into a 32-byte buffer).
- [x] Full suite: **50/50 ctest pass** (OP-free build; `test_proof_call_accesslist` confirms the access-list happy path is unaffected).
- [x] Reviewed by security-agent (all 5 fixes correct, no regressions) and qa-agent.

> Note: the full `build/default` build fails at the pre-existing kona_bridge (Rust/OP-Stack) step in this environment, unrelated to this change; verified with an OP-free build.