### PR TITLE
fix(json): accept hex quantities with leading zero padding in json_as_uint64

### DIFF
--- a/src/util/json.c
+++ b/src/util/json.c
@@ -364,11 +364,22 @@ uint64_t json_as_uint64(json_t value) {
   uint8_t  tmp[20] = {0};
   buffer_t buffer  = stack_buffer(tmp);
   if (value.len > 4 && value.start && value.start[1] == '0' && value.start[2] == 'x') {
-    int len = hex_to_bytes(value.start + 1, value.len - 2, bytes(tmp, 20));
-    if (len < 0 || len > 8) return 0; // invalid hex, or the quantity does not fit into 64 bits
-    memmove(tmp + 8 - len, tmp, len);
-    memset(tmp, 0, 8 - len);
-    return uint64_from_be(tmp);
+    // Skip opening quote, "0x" prefix, and closing quote: hex digits sit at [start+3 .. start+len-2)
+    const char* hex     = value.start + 3;
+    size_t      hex_len = value.len - 4;
+    // Strip leading zero nibbles so that we compare significant nibbles against the 64-bit limit
+    while (hex_len > 0 && *hex == '0') {
+      hex++;
+      hex_len--;
+    }
+    if (hex_len == 0) return 0;
+    if (hex_len > 16) return 0; // more than 16 significant nibbles cannot fit into 64 bits
+    uint8_t hex_buf[8] = {0};
+    int     len        = hex_to_bytes(hex, (int) hex_len, bytes(hex_buf, 8));
+    if (len < 0) return 0; // invalid hex
+    memmove(hex_buf + 8 - len, hex_buf, len);
+    memset(hex_buf, 0, 8 - len);
+    return uint64_from_be(hex_buf);
   }
   return (uint64_t) strtoull(json_as_string(value, &buffer), NULL, 10);
 }

--- a/test/unittests/test_core.c
+++ b/test/unittests/test_core.c
@@ -161,6 +161,15 @@ void test_json() {
 
     // decimal (non-0x) path goes through strtoull
     TEST_ASSERT_EQUAL_HEX64(255, json_as_uint64(json_parse("255")));
+
+    // leading zero nibbles must be stripped: significant portion fits into 64 bits
+    TEST_ASSERT_EQUAL_HEX64(2, json_as_uint64(json_parse("\"0x0000000000000000000000000000000000000000000000000000000000000000000002\"")));
+    // 32-byte quantity padded with leading zeros, non-zero part is 8 bytes
+    TEST_ASSERT_EQUAL_HEX64(0xdeadbeefcafebabeULL, json_as_uint64(json_parse("\"0x000000000000000000000000000000000000000000000000deadbeefcafebabe\"")));
+    // all-zero hex quantity
+    TEST_ASSERT_EQUAL_HEX64(0, json_as_uint64(json_parse("\"0x00000000000000000000000000000000000000000000000000000000\"")));
+    // 17 significant nibbles -> does not fit into 64 bits even after stripping leading zeros
+    TEST_ASSERT_EQUAL_HEX64(0, json_as_uint64(json_parse("\"0x0010000000000000000\"")));
   }
 
   // cleanup


### PR DESCRIPTION
## Summary

`json_as_uint64` previously returned `0` for any hex string that decoded to more than 8 bytes, even when the numeric value clearly fit into 64 bits. RPC responses (Beacon API, EVM storage slots, EIP-2930 access-list quantities, etc.) commonly zero-pad uint64-sized values to 32 bytes, so inputs like `"0x000...0002"` were silently converted to `0`. Values padded beyond ~20 bytes additionally failed the internal `hex_to_bytes` bounds check on the 20-byte scratch buffer.

The fix strips leading zero nibbles before enforcing the 64-bit limit and decodes only the significant portion into a correctly sized 8-byte buffer:

- Skip opening quote, `0x` prefix, and closing quote explicitly.
- Strip leading `'0'` nibbles.
- Return `0` for the all-zero case and for >16 significant nibbles.
- Decode into `uint8_t hex_buf[8]`, keeping fail-closed behaviour for invalid hex.
- Use `size_t` for the working length to avoid a theoretical `size_t -> int` conversion on very large tokens.

The `strtoull` decimal fallback is unchanged.

## Test plan

- [x] `cmake --build build/default --target test_core`
- [x] `./build/default/test/unittests/test_core` -- 12 tests, 0 failures
- [x] New regression assertions in `test/unittests/test_core.c` cover:
  - leading-zero padding down to a single significant nibble (`0x000...0002` -> `2`),
  - 32-byte quantity with 8-byte significant portion (`0xdeadbeefcafebabe`),
  - all-zero input (`0`),
  - 17 significant nibbles -> fail closed (`0`).
- [x] Existing regression tests for the previous OOB-write fix (`len > 8`, `0x12zz`, decimal path, `UINT64_MAX` upper edge) still pass.
- [x] `security-agent` review of the diff: overall risk **Low**, no Critical/High/Medium findings; the sole Low finding (theoretical `size_t -> int` UB) was addressed by switching to `size_t`.