### PR TITLE
feat(eth): eth_getLogs completeness proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,93 +1,120 @@
-<img src="c4_logo.png" alt="C4 Logo" width="300"/>
+<img src="c4_logo.png" alt="Colibri Logo" width="300"/>
 
 # Colibri Stateless
 
-![ETH2.0_Spec_Version 1.4.0](https://img.shields.io/badge/ETH2.0_Spec_Version-1.4.0-2e86c1.svg)
+**Verify Ethereum RPC data cryptographically — without running a full node.**
 
-Colibri Stateless is a highly efficient prover/verifier for Ethereum and upcoming support for various Layer-2 solutions and other blockchains. The core library is written in C and provides bindings for JavaScript/TypeScript, Swift, Kotlin/Java, Python, and Dart.
+Colibri Stateless is a highly efficient prover/verifier for Ethereum (with upcoming support for Layer-2s such as OP-Stack). The core is written in portable C and ships with bindings for JavaScript/TypeScript, Swift, Kotlin/Java, Python, and Dart — small enough to run in browsers, mobile apps, and embedded devices.
 
-## Overview
+![ETH2.0 Spec Version 1.4.0](https://img.shields.io/badge/ETH2.0_Spec_Version-1.4.0-2e86c1.svg)
+![License](https://img.shields.io/badge/license-MIT-green.svg)
+[![npm](https://img.shields.io/npm/v/@corpus-core/colibri-stateless.svg)](https://www.npmjs.com/package/@corpus-core/colibri-stateless)
+
+🌐 [**Website**](https://www.corpuscore.tech/colibri) · 📖 [**Docs**](https://corpus-core.gitbook.io/specification-colibri-stateless) · 📄 [**Whitepaper**](https://corpus-core.gitbook.io/whitepaper-colibri-stateless) · 🔒 [**Privacy (PAP)**](https://corpus-core.gitbook.io/pap-colibri-stateless)
 
 ```mermaid
-flowchart
-    P[Prover] --> V[Verifier]
-    V --> P
-    P -.-> RPC
+flowchart LR
+    P[Prover] -->|proof| V[Verifier]
+    RPC -.-> P
 ```
 
-Colibri Stateless enables the creation of an ultra-light client or verifier that can be used in websites, mobile applications, and especially in embedded systems. The prover creates cryptographic proofs for the validity of blockchain data, while the verifier validates these proofs - almost statelessly.
+## Why Colibri?
 
-The verifier only needs to store the state of the sync committee, which changes every 27 hours. With the current sync committee, it can verify any proof with the corresponding BLS signatures without having to process every block header.
+- 🪶 **Almost stateless** — the verifier only stores the current sync committee state (rotates every ~27h). No block-by-block header processing, no full node.
+- 🔐 **Cryptographically verified RPC** — the prover creates proofs for the validity of RPC responses; the verifier checks them against BLS signatures.
+- 💤 **On-demand, not always-on** — Colibri only does work when you actually make a request. It does **not** continuously sync in the background, so it never burns bandwidth, CPU, or battery while your app is idle (see [How is Colibri different?](#how-is-colibri-different-from-other-light-clients) below).
+- 🕰️ **Verifies historical data (older than ~27h / 8192 blocks)** — a unique capability: using `historical_summaries` Merkle proofs from the beacon state, Colibri cleanly verifies old transactions and receipts where other light clients simply fail.
+- 📜 **`eth_getLogs` completeness proofs** — cryptographic guarantee that for a requested block range **no matching event was omitted** ([PR #318](https://github.com/corpus-core/colibri-stateless/pull/318)). No other light client offers this today.
+- 🧪 **Fully verified local transaction simulation** — `colibri_simulateTransaction` lets wallets simulate a transaction against verified state *before signing*, so users can be shown exactly what a transaction will do.
+- ⚡ **Tiny & fast** — a portable C core for websites, mobile apps, and embedded systems. Most requests are barely slower than a plain RPC call — see the [benchmarks](https://corpus-core.gitbook.io/specification-colibri-stateless/specifications/ethereum/benchmark).
+- 🔗 **Multi-chain** — Ethereum today, Layer-2s (OP-Stack) and more coming.
+- 🧩 **Bindings everywhere** — JavaScript/TypeScript, Swift, Kotlin/Java, Python, and Dart.
+- 🕵️ **Privacy-aware** — Pragmatic Adaptive Privacy (PAP) mode. See the [Privacy Whitepaper](https://corpus-core.gitbook.io/pap-colibri-stateless).
 
-## Quickstart
+## How is Colibri different from other light clients?
 
-### Clone and Build
+Classic light clients (e.g. Helios) keep a **continuous sync** running: they follow the chain and fetch every block header, even while your app sits in the background — which costs bandwidth, CPU, and battery. Colibri takes the opposite, **request-driven** approach:
 
-```bash
-# Clone the repository
-git clone https://github.com/corpus-core/colibri-stateless.git
-cd colibri-stateless
+| | Continuous light client | **Colibri Stateless** |
+|---|---|---|
+| **When it works** | Continuously syncs every block | Only when you make a request |
+| **Idle cost** | Ongoing bandwidth / CPU / battery | Zero — nothing runs in the background |
+| **State kept** | Follows the head over time | Just the current sync committee (~27h) |
+| **Historical data (> ~27h)** | Typically fails / not supported | ✅ Verified via `historical_summaries` proofs |
+| **`eth_getLogs` completeness** | Not proven | ✅ Cryptographic completeness proof |
+| **Footprint** | Larger runtime | Tiny C core, embeddable |
 
-# Create build directory
-mkdir build && cd build
+Each Colibri result is a self-contained, cryptographically verifiable proof — so it fits naturally into wallets, dApps, mobile, and embedded devices that can't afford an always-on sync loop.
 
-# Configure with CMake and build
-cmake -DCMAKE_BUILD_TYPE=Release -DTEST=true ..
-make -j4
+## Quickstart (JavaScript / TypeScript)
 
-# Test
-make test
-```
-
-Usage:
-
-```bash
-bin/verify -i https://mainnet1.colibri-proof.tech eth_blockNumber
-```
-
-📖 [**Full CLI Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/cli)
-
-### Bindings
-
-#### JavaScript/TypeScript
+The JS/TS binding is the fastest way to try Colibri — it works in Node.js and the browser.
 
 ```bash
 npm install @corpus-core/colibri-stateless
 ```
 
-**Hello World:**
 ```typescript
 import Colibri from "@corpus-core/colibri-stateless";
 
-const client = new Colibri({prover:['https://mainnet.colibri-proof.tech']});
+const client = new Colibri({ prover: ['https://mainnet.colibri-proof.tech'] });
+
+// RPC call with automatic proof generation + verification
 const block = await client.request('eth_getBlockByNumber', ['latest', false]);
 console.log("Latest block:", block.number);
 ```
 
 📖 [**Full JavaScript/TypeScript Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/javascript-typescript)
 
-#### Kotlin/Java
+## Other Bindings
 
-**Installation via GitHub Packages:**
+Colibri exposes the same core through several language bindings. Pick yours below.
+
+<details>
+<summary><b>Swift</b> (iOS / macOS)</summary>
+
+```swift
+// Add to Package.swift
+dependencies: [
+    .package(url: "https://github.com/corpus-core/colibri-stateless-swift.git", from: "1.0.0")
+]
+```
+
+```swift
+import Colibri
+
+let colibri = Colibri()
+colibri.chainId = 1  // Ethereum Mainnet
+colibri.provers = ["https://mainnet.colibri-proof.tech"]
+
+let result = try await colibri.rpc(method: "eth_getBalance", params: [
+    "0x742d35Cc6434C532532532532532532535C0ddd",
+    "latest"
+])
+print("Account balance:", result as? String ?? "n/a")
+```
+
+📖 [**Full Swift Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/swift)
+
+</details>
+
+<details>
+<summary><b>Kotlin / Java</b> (JVM / Android)</summary>
 
 ```kotlin
-// Add to your build.gradle.kts
+// build.gradle.kts
 repositories {
-    maven {
-        url = uri("https://maven.pkg.github.com/corpus-core/colibri-stateless")
-    }
+    maven { url = uri("https://maven.pkg.github.com/corpus-core/colibri-stateless") }
 }
 
 dependencies {
-    // For JVM/Server (JAR with Linux, macOS, Windows natives)
+    // JVM/Server (JAR with Linux, macOS, Windows natives)
     implementation("com.corpuscore:colibri-jar:1.0.0")
-    
-    // For Android (AAR with all Android ABIs)
+    // Android (AAR with all Android ABIs)
     implementation("com.corpuscore:colibri-aar:1.0.0")
 }
 ```
 
-**Hello World:**
 ```kotlin
 import com.corpuscore.colibri.Colibri
 
@@ -97,46 +124,17 @@ val blockNumber = String(result).removePrefix("0x").toLong(16)
 println("Current block: #$blockNumber")
 ```
 
-📦 [**GitHub Packages**](https://github.com/corpus-core/colibri-stateless/packages) | 📖 [**Full Kotlin/Java Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/kotlin-java)
+📦 [**GitHub Packages**](https://github.com/corpus-core/colibri-stateless/packages) · 📖 [**Full Kotlin/Java Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/kotlin-java)
 
-#### Swift
+</details>
 
-```swift
-// Add to Package.swift
-dependencies: [
-    .package(url: "https://github.com/corpus-core/colibri-stateless-swift.git", from: "1.0.0")
-]
-```
-
-**Hello World:**
-```swift
-// In your iOS app
-import Colibri
-
-let colibri = Colibri()
-colibri.chainId = 1  // Ethereum Mainnet
-colibri.provers = ["https://c4.incubed.net"]
-
-// RPC call with automatic proof verification
-let result = try await colibri.rpc(method: "eth_getBalance", params: [
-    "0x742d35Cc6434C532532532532532532535C0ddd",
-    "latest"
-])
-
-if let balance = result as? String {
-    print("Account balance: \(balance)")
-}
-```
-
-📖 [**Full Swift Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/swift)
-
-#### Python
+<details>
+<summary><b>Python</b></summary>
 
 ```bash
 pip install colibri-stateless
 ```
 
-**Hello World:**
 ```python
 from colibri import Colibri
 
@@ -147,33 +145,12 @@ print(f"Current block: {block_number}")
 
 📖 [**Full Python Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/python)
 
-#### Dart
+</details>
 
-```bash
-cd bindings/dart
-./build.sh
-```
+<details>
+<summary><b>Dart / Flutter</b></summary>
 
-**Hello World:**
-```dart
-import 'package:colibri_stateless/colibri.dart';
-
-final colibri = Colibri(
-  chainId: 1,
-  libraryPath: 'native/libcolibri.dylib', // adjust for your OS
-);
-
-final blockNumber = await colibri.rpc('eth_blockNumber', []);
-print('Current block: $blockNumber');
-
-colibri.close();
-```
-
-📖 [**Dart Binding Documentation**](bindings/dart/README.md)
-
-#### Dart / Flutter
-
-For Flutter apps (Android, iOS, macOS, Linux) with **bundled native binaries**:
+Flutter apps (Android, iOS, macOS, Linux) with **bundled native binaries**:
 
 ```yaml
 dependencies:
@@ -188,46 +165,62 @@ final blockNumber = await colibri.rpc('eth_blockNumber', []);
 colibri.close();
 ```
 
-📖 [**Flutter Plugin Documentation**](bindings/dart/flutter/colibri_flutter/README.md) | 📦 [**pub.dev**](https://pub.dev/packages/colibri_flutter)
+📖 [**Full Dart Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/dart) · 📖 [**Flutter Plugin Documentation**](bindings/dart/flutter/colibri_flutter/README.md) · 📦 [**pub.dev**](https://pub.dev/packages/colibri_flutter)
 
-#### Docker / Prover Server
+</details>
 
-Run your own prover server using Docker:
+> **More languages coming:** **Rust** bindings are currently in progress; **Go** and **C#** are planned.
+
+<details>
+<summary><b>CLI</b></summary>
+
+```bash
+# Clone and build
+git clone https://github.com/corpus-core/colibri-stateless.git
+cd colibri-stateless
+cmake --preset default
+cmake --build build/default
+
+# Verify a request against a prover
+build/default/bin/verify -i https://mainnet1.colibri-proof.tech eth_blockNumber
+```
+
+📖 [**Full CLI Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/cli)
+
+</details>
+
+<details>
+<summary><b>Docker / Prover Server</b> (run your own prover)</summary>
 
 ```bash
 # Pull from GitHub Container Registry
 docker pull ghcr.io/corpus-core/colibri-prover:latest
 
-# Run with Docker
+# Run
 docker run -p 8090:8090 ghcr.io/corpus-core/colibri-prover:latest
 
 # Or use Docker Compose with Memcached (recommended)
 # See bindings/docker/README.md for full configuration
 ```
 
-**Available tags:**
-- `latest` - Latest stable release (linux/amd64, linux/arm64)
-- `main` - Main branch (linux/amd64)
-- `dev` - Development branch (linux/amd64)
-- `vX.Y.Z` - Specific versions
+**Available tags:** `latest` (linux/amd64, linux/arm64), `main`, `dev`, `vX.Y.Z`.
 
 The prover server is lightweight (single-threaded, ~100MB internal cache) and benefits greatly from Memcached for caching external requests (24h TTL).
 
-[**Full Docker Documentation**](bindings/docker/README.md) |  [**GitHub Container Registry**](https://github.com/corpus-core/colibri-stateless/pkgs/container/colibri-prover)
+📖 [**Full Docker Documentation**](bindings/docker/README.md) · 📦 [**GitHub Container Registry**](https://github.com/corpus-core/colibri-stateless/pkgs/container/colibri-prover)
 
-## Documentation
+</details>
 
-Complete documentation with detailed specifications, API references, and examples can be found at:
+## Documentation & Links
 
-**📖 [Colibri Stateless Specification](https://corpus-core.gitbook.io/specification-colibri-stateless)**
+| | |
+|---|---|
+| 🌐 **Product website** | [corpuscore.tech/colibri](https://www.corpuscore.tech/colibri) |
+| 📄 **Whitepaper** | [General whitepaper](https://corpus-core.gitbook.io/whitepaper-colibri-stateless) |
+| 🔒 **Privacy concept (PAP)** | [Privacy whitepaper](https://corpus-core.gitbook.io/pap-colibri-stateless) |
+| 📖 **Specification & developer docs** | [Colibri Stateless Specification](https://corpus-core.gitbook.io/specification-colibri-stateless) |
 
-The documentation includes:
-- Detailed architecture and concepts
-- Complete API reference
-- Supported RPC methods
-- SSZ type definitions
-- Developer guides for all bindings
-- Examples and best practices
+The specification covers architecture and concepts, the complete API reference, supported RPC methods, SSZ type definitions, developer guides for all bindings, and the [threat model](https://corpus-core.gitbook.io/specification-colibri-stateless/specifications/ethereum/threat-model).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Colibri Stateless is a highly efficient prover/verifier for Ethereum (with upcom
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 [![npm](https://img.shields.io/npm/v/@corpus-core/colibri-stateless.svg)](https://www.npmjs.com/package/@corpus-core/colibri-stateless)
 
-🌐 [**Website**](https://www.corpuscore.tech/colibri) · 📖 [**Docs**](https://corpus-core.gitbook.io/specification-colibri-stateless) · 📄 [**Whitepaper**](https://corpus-core.gitbook.io/whitepaper-colibri-stateless) · 🔒 [**Privacy (PAP)**](https://corpus-core.gitbook.io/pap-colibri-stateless)
+[**Website**](https://www.corpuscore.tech/colibri) · [**Docs**](https://corpus-core.gitbook.io/specification-colibri-stateless) · [**Whitepaper**](https://corpus-core.gitbook.io/whitepaper-colibri-stateless) · [**Privacy (PAP)**](https://corpus-core.gitbook.io/pap-colibri-stateless)
 
 ```mermaid
 flowchart LR
@@ -20,16 +20,18 @@ flowchart LR
 
 ## Why Colibri?
 
-- 🪶 **Almost stateless** — the verifier only stores the current sync committee state (rotates every ~27h). No block-by-block header processing, no full node.
-- 🔐 **Cryptographically verified RPC** — the prover creates proofs for the validity of RPC responses; the verifier checks them against BLS signatures.
-- 💤 **On-demand, not always-on** — Colibri only does work when you actually make a request. It does **not** continuously sync in the background, so it never burns bandwidth, CPU, or battery while your app is idle (see [How is Colibri different?](#how-is-colibri-different-from-other-light-clients) below).
-- 🕰️ **Verifies historical data (older than ~27h / 8192 blocks)** — a unique capability: using `historical_summaries` Merkle proofs from the beacon state, Colibri cleanly verifies old transactions and receipts where other light clients simply fail.
-- 📜 **`eth_getLogs` completeness proofs** — cryptographic guarantee that for a requested block range **no matching event was omitted** ([PR #318](https://github.com/corpus-core/colibri-stateless/pull/318)). No other light client offers this today.
-- 🧪 **Fully verified local transaction simulation** — `colibri_simulateTransaction` lets wallets simulate a transaction against verified state *before signing*, so users can be shown exactly what a transaction will do.
-- ⚡ **Tiny & fast** — a portable C core for websites, mobile apps, and embedded systems. Most requests are barely slower than a plain RPC call — see the [benchmarks](https://corpus-core.gitbook.io/specification-colibri-stateless/specifications/ethereum/benchmark).
-- 🔗 **Multi-chain** — Ethereum today, Layer-2s (OP-Stack) and more coming.
-- 🧩 **Bindings everywhere** — JavaScript/TypeScript, Swift, Kotlin/Java, Python, and Dart.
-- 🕵️ **Privacy-aware** — Pragmatic Adaptive Privacy (PAP) mode. See the [Privacy Whitepaper](https://corpus-core.gitbook.io/pap-colibri-stateless).
+- **Stateless** — verification needs nothing but the proof and the sync committee it is checked against. The sync committee is cached locally so it does not have to travel with every request, but it works just as well with an empty cache or none at all. No persistent state, no block-by-block header processing, no full node.
+- **Cryptographically verified RPC** — the prover creates proofs for the validity of RPC responses; the verifier checks them against BLS signatures.
+- **Offline verification** — a proof is fully self-contained and can be verified without any network connection. A phone can hand a complete event proof to an offline device — e.g. a smart lock over Bluetooth — which then verifies it locally. This is made possible by zk-proofs for the sync committee and signed checkpoints.
+- **Flexible trust bootstrap** — initialize either from a checkpoint (the classic light-client bootstrap) or from a zk-proof that recursively proves every sync-committee transition back to the trusted root.
+- **On-demand, not always-on** — Colibri only does work when you actually make a request. It does not continuously sync in the background, so it never burns bandwidth, CPU, or battery while your app is idle (see [How is Colibri different?](#how-is-colibri-different-from-other-light-clients) below).
+- **Verifies historical data (older than ~27h / 8192 blocks)** — a unique capability: using `historical_summaries` Merkle proofs from the beacon state, Colibri cleanly verifies old transactions and receipts where other light clients simply fail.
+- **`eth_getLogs` completeness proofs** — cryptographic guarantee that for a requested block range no matching event was omitted ([PR #318](https://github.com/corpus-core/colibri-stateless/pull/318)). No other light client offers this today.
+- **Fully verified local transaction simulation** — `colibri_simulateTransaction` lets wallets simulate a transaction against verified state *before signing*, so users can be shown exactly what a transaction will do.
+- **Tiny & fast** — a portable C core for websites, mobile apps, and embedded systems. Most requests are barely slower than a plain RPC call — see the [benchmarks](https://corpus-core.gitbook.io/specification-colibri-stateless/specifications/ethereum/benchmark).
+- **Multi-chain** — Ethereum today, Layer-2s (OP-Stack) and more coming.
+- **Bindings everywhere** — JavaScript/TypeScript, Swift, Kotlin/Java, Python, and Dart.
+- **Privacy-aware** — Pragmatic Adaptive Privacy (PAP) mode. See the [Privacy Whitepaper](https://corpus-core.gitbook.io/pap-colibri-stateless).
 
 ## How is Colibri different from other light clients?
 
@@ -39,9 +41,10 @@ Classic light clients (e.g. Helios) keep a **continuous sync** running: they fol
 |---|---|---|
 | **When it works** | Continuously syncs every block | Only when you make a request |
 | **Idle cost** | Ongoing bandwidth / CPU / battery | Zero — nothing runs in the background |
-| **State kept** | Follows the head over time | Just the current sync committee (~27h) |
-| **Historical data (> ~27h)** | Typically fails / not supported | ✅ Verified via `historical_summaries` proofs |
-| **`eth_getLogs` completeness** | Not proven | ✅ Cryptographic completeness proof |
+| **State kept** | Follows the head over time | None required — sync committee is cached or delivered |
+| **Offline verification** | Needs a live connection | Yes — proofs are self-contained |
+| **Historical data (> ~27h)** | Typically fails / not supported | Yes — verified via `historical_summaries` proofs |
+| **`eth_getLogs` completeness** | Not proven | Yes — cryptographic completeness proof |
 | **Footprint** | Larger runtime | Tiny C core, embeddable |
 
 Each Colibri result is a self-contained, cryptographically verifiable proof — so it fits naturally into wallets, dApps, mobile, and embedded devices that can't afford an always-on sync loop.
@@ -64,7 +67,7 @@ const block = await client.request('eth_getBlockByNumber', ['latest', false]);
 console.log("Latest block:", block.number);
 ```
 
-📖 [**Full JavaScript/TypeScript Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/javascript-typescript)
+[**Full JavaScript/TypeScript Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/javascript-typescript)
 
 ## Other Bindings
 
@@ -94,7 +97,7 @@ let result = try await colibri.rpc(method: "eth_getBalance", params: [
 print("Account balance:", result as? String ?? "n/a")
 ```
 
-📖 [**Full Swift Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/swift)
+[**Full Swift Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/swift)
 
 </details>
 
@@ -124,7 +127,7 @@ val blockNumber = String(result).removePrefix("0x").toLong(16)
 println("Current block: #$blockNumber")
 ```
 
-📦 [**GitHub Packages**](https://github.com/corpus-core/colibri-stateless/packages) · 📖 [**Full Kotlin/Java Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/kotlin-java)
+[**GitHub Packages**](https://github.com/corpus-core/colibri-stateless/packages) · [**Full Kotlin/Java Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/kotlin-java)
 
 </details>
 
@@ -143,7 +146,7 @@ block_number = client.request('eth_blockNumber', [])
 print(f"Current block: {block_number}")
 ```
 
-📖 [**Full Python Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/python)
+[**Full Python Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/python)
 
 </details>
 
@@ -165,7 +168,7 @@ final blockNumber = await colibri.rpc('eth_blockNumber', []);
 colibri.close();
 ```
 
-📖 [**Full Dart Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/dart) · 📖 [**Flutter Plugin Documentation**](bindings/dart/flutter/colibri_flutter/README.md) · 📦 [**pub.dev**](https://pub.dev/packages/colibri_flutter)
+[**Full Dart Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/dart) · [**Flutter Plugin Documentation**](bindings/dart/flutter/colibri_flutter/README.md) · [**pub.dev**](https://pub.dev/packages/colibri_flutter)
 
 </details>
 
@@ -185,7 +188,7 @@ cmake --build build/default
 build/default/bin/verify -i https://mainnet1.colibri-proof.tech eth_blockNumber
 ```
 
-📖 [**Full CLI Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/cli)
+[**Full CLI Documentation**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/cli)
 
 </details>
 
@@ -207,7 +210,7 @@ docker run -p 8090:8090 ghcr.io/corpus-core/colibri-prover:latest
 
 The prover server is lightweight (single-threaded, ~100MB internal cache) and benefits greatly from Memcached for caching external requests (24h TTL).
 
-📖 [**Full Docker Documentation**](bindings/docker/README.md) · 📦 [**GitHub Container Registry**](https://github.com/corpus-core/colibri-stateless/pkgs/container/colibri-prover)
+[**Full Docker Documentation**](bindings/docker/README.md) · [**GitHub Container Registry**](https://github.com/corpus-core/colibri-stateless/pkgs/container/colibri-prover)
 
 </details>
 
@@ -215,10 +218,10 @@ The prover server is lightweight (single-threaded, ~100MB internal cache) and be
 
 | | |
 |---|---|
-| 🌐 **Product website** | [corpuscore.tech/colibri](https://www.corpuscore.tech/colibri) |
-| 📄 **Whitepaper** | [General whitepaper](https://corpus-core.gitbook.io/whitepaper-colibri-stateless) |
-| 🔒 **Privacy concept (PAP)** | [Privacy whitepaper](https://corpus-core.gitbook.io/pap-colibri-stateless) |
-| 📖 **Specification & developer docs** | [Colibri Stateless Specification](https://corpus-core.gitbook.io/specification-colibri-stateless) |
+| **Product website** | [corpuscore.tech/colibri](https://www.corpuscore.tech/colibri) |
+| **Whitepaper** | [General whitepaper](https://corpus-core.gitbook.io/whitepaper-colibri-stateless) |
+| **Privacy concept (PAP)** | [Privacy whitepaper](https://corpus-core.gitbook.io/pap-colibri-stateless) |
+| **Specification & developer docs** | [Colibri Stateless Specification](https://corpus-core.gitbook.io/specification-colibri-stateless) |
 
 The specification covers architecture and concepts, the complete API reference, supported RPC methods, SSZ type definitions, developer guides for all bindings, and the [threat model](https://corpus-core.gitbook.io/specification-colibri-stateless/specifications/ethereum/threat-model).
 

--- a/bindings/dart/README.md
+++ b/bindings/dart/README.md
@@ -1,8 +1,27 @@
-<img src="https://github.com/corpus-core/colibri-stateless/raw/dev/c4_logo.png" alt="C4 Logo" width="300"/>
+<img src="https://github.com/corpus-core/colibri-stateless/raw/dev/c4_logo.png" alt="Colibri Logo" width="300"/>
 
-# Colibri Dart Bindings
+# Colibri Stateless — Dart / Flutter
 
-Dart FFI bindings for Colibri Stateless (proof generation + verification).
+**Verify Ethereum RPC data cryptographically — without running a full node.**
+
+![ETH2.0 Spec Version 1.4.0](https://img.shields.io/badge/ETH2.0_Spec_Version-1.4.0-2e86c1.svg)
+![License](https://img.shields.io/badge/license-MIT-green.svg)
+[![pub](https://img.shields.io/pub/v/colibri_flutter.svg)](https://pub.dev/packages/colibri_flutter)
+
+Colibri Stateless is a highly efficient prover/verifier for Ethereum (with upcoming support for Layer-2s such as OP-Stack). These Dart FFI bindings wrap the C core and verify every RPC response against the beacon chain — no full node, no continuous sync. Use them standalone (`colibri_stateless`) or via the Flutter plugin (`colibri_flutter`) with bundled native binaries.
+
+[**Website**](https://www.corpuscore.tech/colibri) · [**Docs**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/dart) · [**Whitepaper**](https://corpus-core.gitbook.io/whitepaper-colibri-stateless) · [**Privacy (PAP)**](https://corpus-core.gitbook.io/pap-colibri-stateless)
+
+## Why Colibri?
+
+- **Stateless** — verification needs nothing but the proof and the sync committee it is checked against. The committee is cached locally so it does not have to travel with every request, but it works just as well with an empty cache or none at all. No persistent state, no full node.
+- **Cryptographically verified RPC** — every RPC response is checked against BLS signatures.
+- **Offline verification** — proofs are fully self-contained and verify without any network connection, thanks to zk-proofs for the sync committee and signed checkpoints.
+- **On-demand, not always-on** — work happens only when you make a request; no background sync burning bandwidth, CPU, or battery.
+- **Verifies historical data (older than ~27h / 8192 blocks)** — via `historical_summaries` proofs, where other light clients simply fail.
+- **`eth_getLogs` completeness proofs** — proves no matching log was omitted in the requested range.
+- **Fully verified local transaction simulation** — simulate a transaction against verified state before signing.
+- **Privacy-aware** — Pragmatic Adaptive Privacy (PAP) mode. *Experimental.*
 
 ## Quick Start
 
@@ -36,12 +55,12 @@ final colibri = Colibri(
 }
 ```
 
-## Features
+## Dart-specific features
 
-- Proof generation + verification through the C core
 - Async request handling with `dart:async`
 - Multi-chain configuration with sensible defaults
-- **Privacy-preserving `eth_call`** – `proverMode: hybrid`, `privacyMode: basic`, `obliviousNodes` (default empty; e.g. `https://rpc.safe-node.com/`, API key for testing). Oblivious auto-enables PAP. TEE/ORAM: [Oblivious Labs](https://www.obliviouslabs.com/).
+- Flutter plugin (`colibri_flutter`) with bundled Android/iOS/desktop binaries
+- **Privacy-preserving `eth_call`** – `proverMode: hybrid`, `privacyMode: basic`, `obliviousNodes` (default empty; e.g. `https://rpc.safe-node.com/`, API key for testing). Setting `obliviousNodes` auto-enables PAP. TEE/ORAM: [Oblivious Labs](https://www.obliviouslabs.com/).
 
 You can also set the library path via `COLIBRI_DART_LIBRARY`.
 

--- a/bindings/dart/doc.md
+++ b/bindings/dart/doc.md
@@ -115,6 +115,7 @@ class Colibri {
     this.trustedCheckpoint,
     this.includeCode = false,
     this.zkProof = false,
+    this.logsCompleteness = false,
     this.proverMode,
     this.checkpointWitnessKeys,
     this.skipWspCheck = false,
@@ -140,6 +141,8 @@ class Colibri {
 - **close** – Releases native resources; call when done.
 
 Constructor: **libraryPath** overrides the default native library (or use env `COLIBRI_DART_LIBRARY`). **storage** registers a custom cache; **zkProof** requests ZK proofs from remote provers when using **rpc** with provers. **onDebug** can contain sensitive data; do not forward to production logging.
+
+**logsCompleteness** (`bool`, default `false`) makes `eth_getLogs` produce (prover) and require (verifier) a **completeness proof** over the requested block range `[fromBlock, toBlock]`. The proof guarantees that no matching log was omitted, not just that the returned logs are valid. It sets the prover flag (`1 << 12`) and the verifier flag (`1 << 9`) and requires a prover that supports it. The range end (`toBlock`) may be a pinned block hash/number or `"latest"`; `"safe"`/`"finalized"` are not supported yet. Tracks issue #128.
 
 ### Storage
 

--- a/bindings/dart/lib/src/client.dart
+++ b/bindings/dart/lib/src/client.dart
@@ -44,6 +44,7 @@ class Colibri {
     this.proverMode,
     this.checkpointWitnessKeys,
     this.skipWspCheck = false,
+    this.logsCompleteness = false,
     this.maxLatestAgeSeconds = 60,
     this.logProverRequests = false,
     this.storage,
@@ -102,6 +103,10 @@ class Colibri {
   /// signed package) is in place. Disabling raises the risk of long-range
   /// attacks across periods older than the WSP. Default: `false`.
   final bool skipWspCheck;
+  /// If true, `eth_getLogs` produces and requires a completeness proof over the
+  /// requested block range (prover flag `1 << 12`, verify flag `1 << 9`),
+  /// guaranteeing that no matching log was omitted. Default: `false`.
+  final bool logsCompleteness;
   /// Maximum age (in seconds) accepted for a proof whose request uses the
   /// `"latest"` block tag. The verifier compares `block.timestamp` from the
   /// proof against `DateTime.now().millisecondsSinceEpoch ~/ 1000 - maxLatestAgeSeconds`;
@@ -172,7 +177,8 @@ class Colibri {
     final pap = privacyMode == PrivacyMode.basic || obliviousNodes.isNotEmpty;
     return (pap ? 2 : 0)
         | (obliviousNodes.isNotEmpty ? (1 << 6) : 0)
-        | (skipWspCheck ? (1 << 7) : 0);
+        | (skipWspCheck ? (1 << 7) : 0)
+        | (logsCompleteness ? (1 << 9) : 0);
   }
 
   /// Computes the lower bound for `block.timestamp` accepted on `"latest"`
@@ -208,7 +214,7 @@ class Colibri {
   /// (ZK proofs are produced by remote provers, not the local prover).
   Future<Uint8List> createProof(String method, List<dynamic> params) async {
     final paramsJson = jsonEncode(params);
-    final flags = (includeCode ? 1 : 0) | (useAccesslist ? (1 << 6) : 0);
+    final flags = (includeCode ? 1 : 0) | (useAccesslist ? (1 << 6) : 0) | (logsCompleteness ? (1 << 12) : 0);
     final ctx = _native.createProverCtx(
       method,
       paramsJson,
@@ -310,7 +316,7 @@ class Colibri {
   /// data requests.
   Future<dynamic> rpc(String method, List<dynamic> params) async {
     final paramsJson = jsonEncode(params);
-    final proverFlags = (includeCode ? 1 : 0) | (useAccesslist ? (1 << 6) : 0) | (zkProof ? (1 << 7) : 0);
+    final proverFlags = (includeCode ? 1 : 0) | (useAccesslist ? (1 << 6) : 0) | (zkProof ? (1 << 7) : 0) | (logsCompleteness ? (1 << 12) : 0);
     final resolvedMode = proverMode ?? (provers.isEmpty ? ProverMode.local : ProverMode.remote);
     final nativeMode = resolvedMode == ProverMode.lightClient ? ProverMode.hybrid.value : resolvedMode.value;
 

--- a/bindings/dart/test/integration_test.dart
+++ b/bindings/dart/test/integration_test.dart
@@ -159,13 +159,27 @@ void main() {
   }
 
   /// Prover fails (500) then fallback to local createProof succeeds via fixture mock.
-  if (testDirs.isNotEmpty) {
-    final dir = testDirs.first;
+  /// `listSync()` order is filesystem-dependent (differs between e.g. APFS and ext4), so
+  /// sort for a deterministic pick and skip fixtures the local createProof fallback cannot
+  /// regenerate: `remote_prover` proofs are only produced by a real remote prover, and
+  /// `requires_chain_store` needs a populated chain store.
+  final fallbackCandidates = [...testDirs]..sort((a, b) => a.path.compareTo(b.path));
+  Directory? fallbackDir;
+  for (final candidate in fallbackCandidates) {
+    final cfg = jsonDecode(
+      File('${candidate.path}${Platform.pathSeparator}test.json').readAsStringSync(),
+    ) as Map<String, dynamic>;
+    if ((cfg['requires_chain_store'] as bool?) ?? false) continue;
+    if ((cfg['remote_prover'] as bool?) ?? false) continue;
+    fallbackDir = candidate;
+    break;
+  }
+  if (fallbackDir != null) {
+    final dir = fallbackDir;
     final name = dir.path.split(Platform.pathSeparator).last;
     test('prover failure falls back to createProof: $name', () async {
       final testJson = File('${dir.path}${Platform.pathSeparator}test.json');
       final content = jsonDecode(testJson.readAsStringSync()) as Map<String, dynamic>;
-      if ((content['requires_chain_store'] as bool?) ?? false) return;
 
       final method = content['method'] as String;
       final params = content['params'] as List<dynamic>;

--- a/bindings/emscripten/README.md
+++ b/bindings/emscripten/README.md
@@ -1,12 +1,30 @@
 
 
-<img src="c4_logo.png" alt="C4 Logo" width="300"/>
+<img src="c4_logo.png" alt="Colibri Logo" width="300"/>
 
-# Colibri-stateless
+# Colibri Stateless — JavaScript / TypeScript
 
-![ETH2.0_Spec_Version 1.4.0](https://img.shields.io/badge/ETH2.0_Spec_Version-1.4.0-2e86c1.svg)
+**Verify Ethereum RPC data cryptographically — without running a full node.**
 
-The colibri client is a stateless and trustless ethereum client, which is optimized for the mobile apps or embedded devices, because it does not hold any state, but verifies on demand.
+![ETH2.0 Spec Version 1.4.0](https://img.shields.io/badge/ETH2.0_Spec_Version-1.4.0-2e86c1.svg)
+![License](https://img.shields.io/badge/license-MIT-green.svg)
+[![npm](https://img.shields.io/npm/v/@corpus-core/colibri-stateless.svg)](https://www.npmjs.com/package/@corpus-core/colibri-stateless)
+
+Colibri Stateless is a highly efficient prover/verifier for Ethereum (with upcoming support for Layer-2s such as OP-Stack). This package runs the C core as WebAssembly in Node.js and the browser, and implements the [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193) provider interface — so it drops straight into ethers, web3.js, or viem while cryptographically verifying every response.
+
+[**Website**](https://www.corpuscore.tech/colibri) · [**Docs**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/javascript-typescript) · [**Whitepaper**](https://corpus-core.gitbook.io/whitepaper-colibri-stateless) · [**Privacy (PAP)**](https://corpus-core.gitbook.io/pap-colibri-stateless)
+
+## Why Colibri?
+
+- **Stateless** — verification needs nothing but the proof and the sync committee it is checked against. The sync committee is cached locally so it does not have to travel with every request, but it works just as well with an empty cache or none at all. No persistent state, no block-by-block header processing, no full node.
+- **Cryptographically verified RPC** — the prover creates proofs for the validity of RPC responses; the verifier checks them against BLS signatures.
+- **Offline verification** — a proof is fully self-contained and can be verified without any network connection, thanks to zk-proofs for the sync committee and signed checkpoints.
+- **On-demand, not always-on** — Colibri only does work when you actually make a request. It does not continuously sync in the background, so it never burns bandwidth, CPU, or battery while your app is idle.
+- **Verifies historical data (older than ~27h / 8192 blocks)** — using `historical_summaries` Merkle proofs from the beacon state, Colibri cleanly verifies old transactions and receipts where other light clients simply fail.
+- **`eth_getLogs` completeness proofs** — cryptographic guarantee that for a requested block range no matching event was omitted (opt-in via `logs_completeness`).
+- **Fully verified local transaction simulation** — simulate a transaction against verified state *before signing*, so users can be shown exactly what a transaction will do.
+- **Tiny & fast** — most requests are barely slower than a plain RPC call — see the [benchmarks](https://corpus-core.gitbook.io/specification-colibri-stateless/specifications/ethereum/benchmark).
+- **Privacy-aware** — Pragmatic Adaptive Privacy (PAP) mode. See the [Privacy Whitepaper](https://corpus-core.gitbook.io/pap-colibri-stateless).
 
 ## Installation
 
@@ -143,7 +161,7 @@ Protect your dApp from NPM supply-chain attacks and transaction manipulation:
 import { BrowserProvider } from "ethers";
 import Colibri from "@corpus-core/colibri-stateless";
 
-// 🛡️ Secure transactions with built-in verification
+// Secure transactions with built-in verification
 const client = new Colibri({
     fallback_provider: window.ethereum, // MetaMask as Signer
     verifyTransactions: true            // Prevents transaction manipulation
@@ -158,7 +176,7 @@ const tx = await provider.getSigner().sendTransaction({
     gasLimit: "0x5208"
 });
 
-console.log("✅ Verified transaction:", tx.hash);
+console.log("Verified transaction:", tx.hash);
 ```
 
 ## Building proofs in you app.
@@ -464,13 +482,12 @@ There is also a VS Code / Cursor launch configuration **"WASM Node Test (inspect
 
 ## Concept
 
-The idea behind C4 is to create a ultra light client or better verifier which can be used in Websites, Mobile applications, but especially in embedded systems. The Prover is a library which can used within you mobile app or in the backend to create Proof that the given data is valid. The Verifier is a library which can be used within the embedded system to verify this Proof.
+The idea behind Colibri is to create an ultra-light client — or rather a verifier — that can be used in websites, mobile applications, and especially embedded systems. The prover is a library used within your app or backend to create a proof that the given data is valid. The verifier is a library used on the client (or embedded system) to verify that proof.
 
-The verifier itself is almost stateless and only needs to store the state of the sync committee, which changes every 27h. But with the latest sync committee the verifier is able to verify any proof with the signatures matching the previously verified public keys of the sync committee.
-This allows independent Verification and security on any devices without the need to process every blockheader (as light clients usually would do).
+The verifier is stateless: it only needs the current sync committee (which rotates every ~27h), and that committee can be cached, fetched on demand, or delivered with the proof. With it, the verifier can validate any proof whose signatures match the verified public keys of the sync committee — enabling independent verification on any device without processing every block header (as classic light clients do).
 
-More Details can be found on [github](https://github.com/corpus-core/c4)
+More details can be found in the [documentation](https://corpus-core.gitbook.io/specification-colibri-stateless) and on [GitHub](https://github.com/corpus-core/colibri-stateless).
 
 ## License
 
-MIT
+MIT — see the main [repository](https://github.com/corpus-core/colibri-stateless) for details.

--- a/bindings/emscripten/README.md
+++ b/bindings/emscripten/README.md
@@ -306,6 +306,10 @@ The constructor of the colibri client accepts a configuration-object, which may 
     ```js
     new Colibri({ include_code:  true})
     ```
+- `logs_completeness` - if true, `eth_getLogs` produces (prover) and requires (verifier) a **completeness proof** over the requested block range `[fromBlock, toBlock]`. It proves that no matching log was omitted, not just that the returned logs are valid. This sets the prover flag (`1 << 12`) and the verifier flag (`1 << 9`) and requires a prover that supports it. The range end (`toBlock`) may be a pinned block hash/number or `"latest"`; `"safe"`/`"finalized"` are not supported yet. (default: false, tracks issue #128)
+    ```js
+    new Colibri({ logs_completeness: true })
+    ```
 - `privacy_mode` - **PAP (Pragmatic Adaptive Privacy)** mode: `"none"` (default) or `"basic"`. With `"basic"`, the verifier may use cached storage for optimistic execution and verify afterwards; method type can depend on params. *This feature is still experimental!*
     ```js
     new Colibri({ privacy_mode: "basic" })

--- a/bindings/emscripten/doc.md
+++ b/bindings/emscripten/doc.md
@@ -318,6 +318,10 @@ The constructor of the colibri client accepts a configuration-object, which may 
     ```js
     new Colibri({ include_code:  true})
     ```
+- `logs_completeness` - if true, `eth_getLogs` produces (prover) and requires (verifier) a **completeness proof** over the requested block range `[fromBlock, toBlock]`. It proves that no matching log was omitted, not just that the returned logs are valid. This sets the prover flag (`1 << 12`) and the verifier flag (`1 << 9`) and requires a prover that supports it. The range end (`toBlock`) may be a pinned block hash/number or `"latest"`; `"safe"`/`"finalized"` are not supported yet. (default: false, tracks issue #128)
+    ```js
+    new Colibri({ logs_completeness: true })
+    ```
 - `privacy_mode` - **PAP (Pragmatic Adaptive Privacy)** mode. Reduces intent leakage towards RPC/prover by using cached data when available and verifying afterwards. Allowed values: `"none"` (default), `"basic"`. With `"basic"`, the verifier sets the PAP flag so that method-type and verification can use cached storage for optimistic execution (e.g. for `eth_call`); method type may depend on params. *This feature is still experimental!*
     ```js
     new Colibri({ privacy_mode: "basic" })

--- a/bindings/emscripten/src/index.ts
+++ b/bindings/emscripten/src/index.ts
@@ -146,6 +146,7 @@ export default class C4Client {
     if (this.config.privacy_mode === 'basic' || this.config.oblivious_nodes?.length) this.verify_flags |= 2;
     if (this.config.oblivious_nodes?.length) this.verify_flags |= (1 << 6);
     if (this.config.skip_wsp_check) this.verify_flags |= (1 << 7);
+    if (this.config.logs_completeness) { this.flags |= (1 << 12); this.verify_flags |= (1 << 9); }
 
     if (!this.config.warningHandler)
       this.config.warningHandler = async (req: RequestArguments, message: string) => console.warn(message)

--- a/bindings/emscripten/src/types.ts
+++ b/bindings/emscripten/src/types.ts
@@ -137,6 +137,12 @@ export interface Config extends ChainConfig {
     /** Pragmatic Adaptive Privacy mode. Default "none". "basic" sets verify flag for PAP. */
     privacy_mode?: PrivacyMode;
     zk_proof?: boolean;
+    /**
+     * If true, `eth_getLogs` requests produce and require a completeness proof over the
+     * requested block range: the proof guarantees that no matching log was omitted.
+     * Sets the prover flag (`1 << 12`) and the verify flag (`1 << 9`). Default: false.
+     */
+    logs_completeness?: boolean;
     /** Proof generation mode. Default: "remote" if prover URLs configured, otherwise "local". */
     prover_mode?: ProverMode;
     /**

--- a/bindings/kotlin/README.md
+++ b/bindings/kotlin/README.md
@@ -1,11 +1,29 @@
 
-<img src="https://github.com/corpus-core/colibri-stateless/raw/dev/c4_logo.png" alt="C4 Logo" width="300"/>
+<img src="https://github.com/corpus-core/colibri-stateless/raw/dev/c4_logo.png" alt="Colibri Logo" width="300"/>
 
-# Kotlin/Java Bindings for Colibri
+# Colibri Stateless — Kotlin / Java
 
-The Colibri bindings for Kotlin/Java are built using CMake and Gradle. It can be used as AAR (Android Archive) or JAR (Java Archive).
+**Verify Ethereum RPC data cryptographically — without running a full node.**
 
-> 💡 **Quick Start**: Check out the [Example Android App](./example) for a complete working implementation!
+![ETH2.0 Spec Version 1.4.0](https://img.shields.io/badge/ETH2.0_Spec_Version-1.4.0-2e86c1.svg)
+![License](https://img.shields.io/badge/license-MIT-green.svg)
+
+Colibri Stateless is a highly efficient prover/verifier for Ethereum (with upcoming support for Layer-2s such as OP-Stack). These Kotlin/Java bindings wrap the C core and verify every RPC response against the beacon chain — no full node, no continuous sync. Distributed as an AAR (Android) or JAR (JVM/server).
+
+[**Website**](https://www.corpuscore.tech/colibri) · [**Docs**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/kotlin-java) · [**Whitepaper**](https://corpus-core.gitbook.io/whitepaper-colibri-stateless) · [**Privacy (PAP)**](https://corpus-core.gitbook.io/pap-colibri-stateless)
+
+> **Quick Start:** check out the [Example Android App](./example) for a complete working implementation.
+
+## Why Colibri?
+
+- **Stateless** — verification needs nothing but the proof and the sync committee it is checked against. The committee is cached locally so it does not have to travel with every request, but it works just as well with an empty cache or none at all. No persistent state, no full node.
+- **Cryptographically verified RPC** — every RPC response is checked against BLS signatures.
+- **Offline verification** — proofs are fully self-contained and verify without any network connection, thanks to zk-proofs for the sync committee and signed checkpoints.
+- **On-demand, not always-on** — work happens only when you make a request; no background sync burning bandwidth, CPU, or battery.
+- **Verifies historical data (older than ~27h / 8192 blocks)** — via `historical_summaries` proofs, where other light clients simply fail.
+- **`eth_getLogs` completeness proofs** — proves no matching log was omitted in the requested range.
+- **Fully verified local transaction simulation** — simulate a transaction against verified state before signing.
+- **Privacy-aware** — Pragmatic Adaptive Privacy (PAP) mode. *Experimental.*
 
 ## Installation
 
@@ -139,10 +157,10 @@ cd example && ./gradlew build && ./gradlew installDebug
 
 ## Resources
 
-- 📦 **[GitHub Packages](https://github.com/corpus-core/colibri-stateless/packages)** - All published versions
-- 📖 **[Complete Documentation](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/kotlin-java)** - Detailed API reference and guides
-- 🔗 **[Supported RPC Methods](https://corpus-core.gitbook.io/specification-colibri-stateless/specifications/ethereum/supported-rpc-methods)** - Full list of available Ethereum RPC calls
-- 🏗️ **[Building Guide](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/building)** - Build from source instructions
+- **[GitHub Packages](https://github.com/corpus-core/colibri-stateless/packages)** - All published versions
+- **[Complete Documentation](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/kotlin-java)** - Detailed API reference and guides
+- **[Supported RPC Methods](https://corpus-core.gitbook.io/specification-colibri-stateless/specifications/ethereum/supported-rpc-methods)** - Full list of available Ethereum RPC calls
+- **[Building Guide](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/building)** - Build from source instructions
 
 ## Building
 Make sure you have the Java SDK, Cmake and Swig installed.

--- a/bindings/kotlin/doc.md
+++ b/bindings/kotlin/doc.md
@@ -236,7 +236,7 @@ The gate covers the following RPC methods:
 - **Block / header:** `eth_getBlockByNumber`, `eth_getBlockHeader`, `eth_blobBaseFee`, `eth_maxPriorityFeePerGas`
 - **Implicit-latest:** `eth_blockNumber`
 
-`eth_getLogs` is **not** covered yet (tracked in issue #128). Account methods rely on a slim `timestamp` leaf inside the state proof which is only emitted by **prover version ≥ 1.1.27**; against older provers the verifier fails closed (`"cannot verify freshness of latest block without block context"`).
+`eth_getLogs` is not part of this per-method freshness gate; instead, enabling `logsCompleteness` (see below) produces a dedicated completeness proof over the whole requested block range (issue #128). Account methods rely on a slim `timestamp` leaf inside the state proof which is only emitted by **prover version ≥ 1.1.27**; against older provers the verifier fails closed (`"cannot verify freshness of latest block without block context"`).
 
 - `maxLatestAgeSeconds` (`Long`, default `60` ≈ 5 Ethereum slots) -- upper bound on the accepted age. Set to `0` to disable the check (e.g. when using legacy proof formats that do not embed a block context).
 
@@ -250,6 +250,19 @@ val colibri = Colibri(
 ```
 
 > **PAP mode:** the freshness check also applies to PAP, where the call proof arrives via `colibri_proofCall` (same proof structure as a direct `eth_call`). This requires a prover that embeds the block context (≥ 1.1.15); against an older PAP proof without a block timestamp the check fails closed (`"cannot verify freshness of latest block without block context"`). Set `maxLatestAgeSeconds = 0L` to opt out.
+
+### Logs completeness proof
+
+By default an `eth_getLogs` proof witnesses the returned log entries but not the completeness of the requested range -- a prover could omit matching logs. Enabling `logsCompleteness` makes the prover produce and the verifier require a **completeness proof** over the requested block range `[fromBlock, toBlock]`, guaranteeing that no matching log was omitted.
+
+- `logsCompleteness` (`Boolean`, default `false`) -- sets the prover flag (`1L shl 12`) and the verifier flag (`1L shl 9`). Requires a prover that supports it. The range end (`toBlock`) may be a pinned block hash/number or `"latest"`; `"safe"`/`"finalized"` are not supported yet. Tracks issue #128.
+
+```kotlin
+val colibri = Colibri(
+    chainId = BigInteger.ONE,
+    logsCompleteness = true,
+)
+```
 
 ### Privacy-preserving `eth_call` (oblivious + PAP + hybrid)
 

--- a/bindings/kotlin/lib/src/main/kotlin/com/corpuscore/colibri/Colibri.kt
+++ b/bindings/kotlin/lib/src/main/kotlin/com/corpuscore/colibri/Colibri.kt
@@ -143,6 +143,12 @@ class Colibri(
      */
     var skipWspCheck: Boolean = false,
     /**
+     * If true, `eth_getLogs` produces and requires a completeness proof over the requested
+     * block range (prover flag `1 shl 12`, verify flag `1 shl 9`), guaranteeing that no
+     * matching log was omitted. Default: false.
+     */
+    var logsCompleteness: Boolean = false,
+    /**
      * Maximum age (in seconds) accepted for a proof whose request uses the
      * `"latest"` block tag. The verifier compares `block.timestamp` from the
      * proof against `System.currentTimeMillis() / 1000 - maxLatestAgeSeconds`;
@@ -283,7 +289,8 @@ class Colibri(
         val pap = privacyMode == PrivacyMode.BASIC || obliviousNodes.isNotEmpty()
         return (if (pap) 2L else 0L) or
                 (if (obliviousNodes.isNotEmpty()) (1L shl 6) else 0L) or
-                (if (skipWspCheck) (1L shl 7) else 0L)
+                (if (skipWspCheck) (1L shl 7) else 0L) or
+                (if (logsCompleteness) (1L shl 9) else 0L)
     }
 
     /**
@@ -474,7 +481,7 @@ class Colibri(
         return withContext(Dispatchers.IO) {
             val jsonArgs = formatArgsArray(args) // Use helper
             // Create the prover context with properly formatted JSON args
-            val proverFlags = (if (includeCode) 1L else 0L) or (if (useAccesslist) (1L shl 6) else 0L)
+            val proverFlags = (if (includeCode) 1L else 0L) or (if (useAccesslist) (1L shl 6) else 0L) or (if (logsCompleteness) (1L shl 12) else 0L)
             val ctx = com.corpuscore.colibri.c4.c4_create_prover_ctx(method, jsonArgs, chainId, proverFlags)
                 ?: throw ColibriException("Failed to create prover context for method $method")
 
@@ -715,7 +722,7 @@ class Colibri(
     suspend fun rpc(method: String, args: Array<Any?>): Any? {
         return withContext(Dispatchers.IO) {
             val jsonArgs = formatArgsArray(args)
-            val proverFlags = (if (includeCode) 1L else 0L) or (if (useAccesslist) (1L shl 6) else 0L) or (if (zkProof) (1L shl 7) else 0L)
+            val proverFlags = (if (includeCode) 1L else 0L) or (if (useAccesslist) (1L shl 6) else 0L) or (if (zkProof) (1L shl 7) else 0L) or (if (logsCompleteness) (1L shl 12) else 0L)
             // Base prover-mode auto-detection on the user-configured `provers` array,
             // NOT on `effectiveProvers()`. Consumers passing `emptyArray()` explicitly
             // signal "no remote prover" -- if we consulted the per-chain fallback here,

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,12 +1,29 @@
-<img src="https://github.com/corpus-core/colibri-stateless/raw/dev/c4_logo.png" alt="C4 Logo" width="300"/>
+<img src="https://github.com/corpus-core/colibri-stateless/raw/dev/c4_logo.png" alt="Colibri Logo" width="300"/>
 
-# Colibri Python Bindings (corpus core colibri client)
+# Colibri Stateless — Python
 
-![ETH2.0_Spec_Version 1.4.0](https://img.shields.io/badge/ETH2.0_Spec_Version-1.4.0-2e86c1.svg)
+**Verify Ethereum RPC data cryptographically — without running a full node.**
 
-The colibri client is a stateless and trustless ethereum client, which is optimized for the mobile apps or embedded devices, because it does not hols the state, but verifies on demand. 
+![ETH2.0 Spec Version 1.4.0](https://img.shields.io/badge/ETH2.0_Spec_Version-1.4.0-2e86c1.svg)
+![License](https://img.shields.io/badge/license-MIT-green.svg)
+[![PyPI](https://img.shields.io/pypi/v/colibri-stateless.svg)](https://pypi.org/project/colibri-stateless/)
 
-## 🚀 Quick Start
+Colibri Stateless is a highly efficient prover/verifier for Ethereum (with upcoming support for Layer-2s such as OP-Stack). These Python bindings wrap the C core and give you an async API that verifies every RPC response against the beacon chain — no full node, no continuous sync.
+
+[**Website**](https://www.corpuscore.tech/colibri) · [**Docs**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/python) · [**Whitepaper**](https://corpus-core.gitbook.io/whitepaper-colibri-stateless) · [**Privacy (PAP)**](https://corpus-core.gitbook.io/pap-colibri-stateless)
+
+## Why Colibri?
+
+- **Stateless** — verification needs nothing but the proof and the sync committee it is checked against. The committee is cached locally so it does not have to travel with every request, but it works just as well with an empty cache or none at all. No persistent state, no full node.
+- **Cryptographically verified RPC** — every RPC response is checked against BLS signatures.
+- **Offline verification** — proofs are fully self-contained and verify without any network connection, thanks to zk-proofs for the sync committee and signed checkpoints.
+- **On-demand, not always-on** — work happens only when you make a request; no background sync burning bandwidth, CPU, or battery.
+- **Verifies historical data (older than ~27h / 8192 blocks)** — via `historical_summaries` proofs, where other light clients simply fail.
+- **`eth_getLogs` completeness proofs** — optional `logs_completeness=True` proves no matching log was omitted in the requested range.
+- **Fully verified local transaction simulation** — simulate a transaction against verified state before signing.
+- **Privacy-aware** — Pragmatic Adaptive Privacy (PAP) mode (`privacy_mode=PrivacyMode.BASIC`). *Experimental.*
+
+## Quick Start
 
 ### Installation
 
@@ -39,29 +56,26 @@ async def main():
 asyncio.run(main())
 ```
 
-## ✨ Key Features
+## Python-specific features
 
-- **🔐 Cryptographic Verification** - All RPC responses verified with Merkle proofs
-- **🚀 Async/Await Support** - Modern Python async support for network operations  
-- **💾 Pluggable Storage** - Customizable storage backends for caching
-- **🧪 Comprehensive Testing** - Mock HTTP requests and storage for testing
-- **🌐 Multi-Chain Support** - Ethereum Mainnet, Sepolia, Gnosis Chain, and more
-- **📦 Easy Integration** - Simple pip install with pre-built native extensions
-- **📜 Log completeness proofs** - Optional `logs_completeness=True` for `eth_getLogs` proves the requested block range is complete (no matching log omitted; issue #128)
-- **🔒 Privacy (PAP)** - Optional Pragmatic Adaptive Privacy mode (`privacy_mode=PrivacyMode.BASIC`) to reduce intent leakage ( *This feature is still experimental!* )
-- **🔐 Privacy-preserving `eth_call`** - `ProverMode.HYBRID` + `PrivacyMode.BASIC` + `oblivious_nodes` (default empty; e.g. `https://rpc.safe-node.com/`, API key for testing). Oblivious auto-enables PAP. TEE/ORAM: [Oblivious Labs](https://www.obliviouslabs.com/).
+- **Async/await** — modern async API for all network operations.
+- **Pluggable storage** — customizable storage backends for caching.
+- **Easy integration** — `pip install` with pre-built native extensions.
+- **Testing utilities** — mock HTTP requests and storage for deterministic tests.
+- **Multi-chain** — Ethereum Mainnet, Sepolia, Gnosis Chain, and more.
+- **Privacy-preserving `eth_call`** — combine `ProverMode.HYBRID` + `PrivacyMode.BASIC` + `oblivious_nodes` (default empty; e.g. `https://rpc.safe-node.com/`, API key for testing). Setting `oblivious_nodes` auto-enables PAP. TEE/ORAM background: [Oblivious Labs](https://www.obliviouslabs.com/).
 
-## 📖 Documentation
+## Documentation
 
-**Full Documentation**: [GitBook Guide](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/python)
+**Full documentation**: [GitBook Guide](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/python)
 
-- **API Reference** - Complete class and method documentation
-- **Storage System** - Custom storage implementations
-- **Testing Framework** - Mock data and integration tests  
-- **Configuration** - Chain setup and advanced options
-- **Building from Source** - Development and contribution guide
+- **API Reference** — complete class and method documentation
+- **Storage System** — custom storage implementations
+- **Testing Framework** — mock data and integration tests
+- **Configuration** — chain setup and advanced options
+- **Building from Source** — development and contribution guide
 
-## 🛠️ Development
+## Development
 
 ### Building from Source
 
@@ -120,23 +134,23 @@ for test_name, test_config in tests.items():
     print(f"Test {test_name}: {'PASSED' if result else 'FAILED'}")
 ```
 
-## 📋 System Requirements
+## System Requirements
 
 - **Python 3.8+**
 - **CMake 3.20+** (for building from source)
 - **C++17 compiler** (for building from source)
 
-## 🔗 Related Projects
+## Related Projects
 
 - **Core Library**: [colibri-stateless](https://github.com/corpus-core/colibri-stateless)
 - **Swift Bindings**: iOS/macOS native integration
 - **Kotlin Bindings**: Android/JVM integration
 - **JavaScript Bindings**: Web/Node.js integration
 
-## 📄 License
+## License
 
 MIT License - see [LICENSE](../../LICENSE) for details.
 
-## 🤝 Contributing
+## Contributing
 
 Contributions welcome! Please read our [Contributing Guide](../../CONTRIBUTING.md) and check the [Development Documentation](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/python).

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -47,6 +47,7 @@ asyncio.run(main())
 - **🧪 Comprehensive Testing** - Mock HTTP requests and storage for testing
 - **🌐 Multi-Chain Support** - Ethereum Mainnet, Sepolia, Gnosis Chain, and more
 - **📦 Easy Integration** - Simple pip install with pre-built native extensions
+- **📜 Log completeness proofs** - Optional `logs_completeness=True` for `eth_getLogs` proves the requested block range is complete (no matching log omitted; issue #128)
 - **🔒 Privacy (PAP)** - Optional Pragmatic Adaptive Privacy mode (`privacy_mode=PrivacyMode.BASIC`) to reduce intent leakage ( *This feature is still experimental!* )
 - **🔐 Privacy-preserving `eth_call`** - `ProverMode.HYBRID` + `PrivacyMode.BASIC` + `oblivious_nodes` (default empty; e.g. `https://rpc.safe-node.com/`, API key for testing). Oblivious auto-enables PAP. TEE/ORAM: [Oblivious Labs](https://www.obliviouslabs.com/).
 

--- a/bindings/python/doc.md
+++ b/bindings/python/doc.md
@@ -181,6 +181,7 @@ class Colibri:
         prover_mode: Optional[ProverMode] = None,
         skip_wsp_check: bool = False,
         max_latest_age_seconds: int = 60,
+        logs_completeness: bool = False,
         storage: Optional[ColibriStorage] = None
     ):
         """
@@ -194,6 +195,7 @@ class Colibri:
             trusted_checkpoint: Optional trusted checkpoint block hash for anchoring
             privacy_mode: PAP mode (PrivacyMode.NONE or PrivacyMode.BASIC). Default NONE.
             prover_mode: Proof generation mode (ProverMode.LOCAL, REMOTE, or HYBRID). Default: REMOTE if provers configured, LOCAL otherwise.
+            logs_completeness: If True, eth_getLogs produces and requires a completeness proof over the requested block range (proves no matching log was omitted). Sets the prover flag (1 << 12) and the verify flag (1 << 9). Default: False.
             request_handler: Custom HTTP request handler
             storage: Custom storage implementation
         """
@@ -539,7 +541,20 @@ client = Colibri(
 
 > **PAP mode:** the freshness check also applies to PAP, where the call proof arrives via `colibri_proofCall` (same proof structure as a direct `eth_call`). This requires a prover that embeds the block context (≥ 1.1.15); against an older PAP proof without a block timestamp the check fails closed (`"cannot verify freshness of latest block without block context"`). Set `max_latest_age_seconds=0` to opt out.
 
-> **`eth_getLogs`:** intentionally **not** covered. The proof witnesses individual log entries; the request range itself (up to `latest`) is not part of the proof yet. Tracked under issue #128 (full log-range proofs).
+> **`eth_getLogs`:** the per-method freshness gate does not apply. Instead, enable `logs_completeness` (see below) to get a dedicated completeness proof over the whole requested block range (issue #128).
+
+### Logs completeness proof
+
+By default an `eth_getLogs` proof witnesses the returned log entries but not the completeness of the requested range -- a prover could omit matching logs. Enabling `logs_completeness` makes the prover produce and the verifier require a **completeness proof** over the requested block range `[fromBlock, toBlock]`, guaranteeing that no matching log was omitted.
+
+- `logs_completeness` (`bool`, default `False`) -- sets the prover flag (`1 << 12`) and the verifier flag (`1 << 9`). Requires a prover that supports it. The range end (`toBlock`) may be a pinned block hash/number or `"latest"`; `"safe"`/`"finalized"` are not supported yet. Tracks issue #128.
+
+```python
+client = Colibri(
+    chain_id=1,
+    logs_completeness=True,
+)
+```
 
 ### Privacy (PAP)
 

--- a/bindings/python/src/colibri/client.py
+++ b/bindings/python/src/colibri/client.py
@@ -61,6 +61,7 @@ class Colibri:
         prover_mode: Optional['ProverMode'] = None,
         checkpoint_witness_keys: Optional[str] = None,
         skip_wsp_check: bool = False,
+        logs_completeness: bool = False,
         max_latest_age_seconds: int = 60,
         storage: Optional[ColibriStorage] = None,
         request_handler: Optional[Any] = None,  # For testing
@@ -86,6 +87,9 @@ class Colibri:
                 anchor (witness signatures, hard-coded checkpoint, signed package); disabling
                 raises the risk of long-range attacks across periods older than the WSP.
                 Default: False.
+            logs_completeness: If True, eth_getLogs produces and requires a completeness proof
+                over the requested block range (prover flag 1<<12, verify flag 1<<9), guaranteeing
+                that no matching log was omitted. Default: False.
             max_latest_age_seconds: Maximum age (in seconds) accepted for a proof whose
                 request uses the ``"latest"`` block tag. The verifier rejects proofs whose
                 ``block.timestamp`` is older than ``time.time() - max_latest_age_seconds``
@@ -111,6 +115,7 @@ class Colibri:
         self.prover_mode = prover_mode
         self.checkpoint_witness_keys = checkpoint_witness_keys
         self.skip_wsp_check = skip_wsp_check
+        self.logs_completeness = logs_completeness
         self.max_latest_age_seconds = max_latest_age_seconds
         self.request_handler = request_handler
         self._light_client_task: Optional[asyncio.Task] = None
@@ -239,6 +244,8 @@ class Colibri:
             flags |= 1 << 6
         if self.skip_wsp_check:
             flags |= 1 << 7
+        if self.logs_completeness:
+            flags |= 1 << 9
         return flags
 
     def _get_min_latest_block_ts(self) -> int:
@@ -315,7 +322,7 @@ class Colibri:
         try:
             # Create prover context
             params_json = json.dumps(params)
-            prover_flags = (1 if self.include_code else 0) | ((1 << 6) if self.use_accesslist else 0)
+            prover_flags = (1 if self.include_code else 0) | ((1 << 6) if self.use_accesslist else 0) | ((1 << 12) if self.logs_completeness else 0)
             ctx = native.create_prover_ctx(
                 method, 
                 params_json, 
@@ -456,7 +463,7 @@ class Colibri:
             raise ColibriError("Native module not available")
 
         params_json = json.dumps(params)
-        prover_flags = (1 if self.include_code else 0) | ((1 << 6) if self.use_accesslist else 0) | ((1 << 7) if self.zk_proof else 0)
+        prover_flags = (1 if self.include_code else 0) | ((1 << 6) if self.use_accesslist else 0) | ((1 << 7) if self.zk_proof else 0) | ((1 << 12) if self.logs_completeness else 0)
         resolved_mode = self.prover_mode if self.prover_mode is not None else (ProverMode.REMOTE if self.provers else ProverMode.LOCAL)
         native_mode = int(ProverMode.HYBRID) if resolved_mode == ProverMode.LIGHT_CLIENT else int(resolved_mode)
 

--- a/bindings/swift/README.md
+++ b/bindings/swift/README.md
@@ -36,6 +36,7 @@ swift build && swift test
 - **📱 iOS + macOS** - Native Swift Package for Apple platforms  
 - **🗄️ Flexible Storage** - Customizable storage implementations
 - **🧪 28 Tests** - Unit + Integration tests with mock data
+- **📜 Log completeness proofs** - Optional `logsCompleteness = true` for `eth_getLogs` proves the requested block range is complete (no matching log omitted; issue #128)
 
 ## 📖 Examples
 

--- a/bindings/swift/README.md
+++ b/bindings/swift/README.md
@@ -1,8 +1,26 @@
-# Colibri Swift Bindings
+# Colibri Stateless — Swift
 
-Native Swift Package for secure, verified blockchain interactions.
+**Verify Ethereum RPC data cryptographically — without running a full node.**
 
-## 🚀 Quick Start
+![ETH2.0 Spec Version 1.4.0](https://img.shields.io/badge/ETH2.0_Spec_Version-1.4.0-2e86c1.svg)
+![License](https://img.shields.io/badge/license-MIT-green.svg)
+
+Colibri Stateless is a highly efficient prover/verifier for Ethereum (with upcoming support for Layer-2s such as OP-Stack). This native Swift Package wraps the C core and verifies every RPC response against the beacon chain — no full node, no continuous sync.
+
+[**Website**](https://www.corpuscore.tech/colibri) · [**Docs**](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/swift) · [**Whitepaper**](https://corpus-core.gitbook.io/whitepaper-colibri-stateless) · [**Privacy (PAP)**](https://corpus-core.gitbook.io/pap-colibri-stateless)
+
+## Why Colibri?
+
+- **Stateless** — verification needs nothing but the proof and the sync committee it is checked against. The committee is cached locally so it does not have to travel with every request, but it works just as well with an empty cache or none at all. No persistent state, no full node.
+- **Cryptographically verified RPC** — every RPC response is checked against BLS signatures.
+- **Offline verification** — proofs are fully self-contained and verify without any network connection, thanks to zk-proofs for the sync committee and signed checkpoints.
+- **On-demand, not always-on** — work happens only when you make a request; no background sync burning bandwidth, CPU, or battery.
+- **Verifies historical data (older than ~27h / 8192 blocks)** — via `historical_summaries` proofs, where other light clients simply fail.
+- **`eth_getLogs` completeness proofs** — optional `logsCompleteness = true` proves no matching log was omitted in the requested range.
+- **Fully verified local transaction simulation** — simulate a transaction against verified state before signing.
+- **Privacy-aware** — Pragmatic Adaptive Privacy (PAP) mode. *Experimental.*
+
+## Quick Start
 
 ### iOS
 
@@ -30,15 +48,13 @@ let balance = try await colibri.rpc(method: "eth_getBalance", params: [
 swift build && swift test
 ```
 
-## ✨ Features
+## Platform notes
 
-- **🔐 Cryptographic Verification** - Merkle proofs for all RPC responses
-- **📱 iOS + macOS** - Native Swift Package for Apple platforms  
-- **🗄️ Flexible Storage** - Customizable storage implementations
-- **🧪 28 Tests** - Unit + Integration tests with mock data
-- **📜 Log completeness proofs** - Optional `logsCompleteness = true` for `eth_getLogs` proves the requested block range is complete (no matching log omitted; issue #128)
+- **iOS + macOS** — native Swift Package for Apple platforms.
+- **Flexible storage** — customizable storage implementations (see below).
+- **Well tested** — unit and integration tests with mock data.
 
-## 📖 Examples
+## Examples
 
 ### Chains
 
@@ -80,7 +96,7 @@ class MyStorage: ColibriStorage {
 StorageBridge.registerStorage(MyStorage())
 ```
 
-## 🏗️ Build
+## Build
 
 ```bash
 # iOS XCFramework
@@ -90,7 +106,7 @@ StorageBridge.registerStorage(MyStorage())
 ./build_macos.sh -dev
 ```
 
-## 🧪 Testing
+## Testing
 
 ```bash
 swift test                                     # All tests
@@ -99,9 +115,9 @@ swift test --filter GeneratedIntegrationTests # Integration tests
 cd test_ios_app && swift test                # iOS example
 ```
 
-## 📚 Documentation
+## Documentation
 
-- **[📖 Complete Guide](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/swift)** - Full API reference and guide
-- **[�� iOS Test App](test_ios_app/)** - Reference implementation & CI example
-- **[📄 Local Documentation](doc.md)** - Source documentation
-- **[�� Core Repository](https://github.com/corpus-core/colibri-stateless)** - Source code
+- **[Complete Guide](https://corpus-core.gitbook.io/specification-colibri-stateless/developer-guide/bindings/swift)** - Full API reference and guide
+- **[iOS Test App](test_ios_app/)** - Reference implementation & CI example
+- **[Local Documentation](doc.md)** - Source documentation
+- **[Core Repository](https://github.com/corpus-core/colibri-stateless)** - Source code

--- a/bindings/swift/Sources/Colibri/Colibri.swift
+++ b/bindings/swift/Sources/Colibri/Colibri.swift
@@ -265,6 +265,11 @@ public class Colibri {
     /// the WSP. Default: false.
     public var skipWspCheck: Bool = false
 
+    /// If true, `eth_getLogs` produces and requires a completeness proof over the requested
+    /// block range (prover flag `1 << 12`, verify flag `1 << 9`), guaranteeing that no
+    /// matching log was omitted. Default: false.
+    public var logsCompleteness: Bool = false
+
     /// Maximum age (in seconds) accepted for a proof whose request uses the
     /// `"latest"` block tag. The verifier compares `block.timestamp` from the
     /// proof against `now - maxLatestAgeSeconds`; older proofs are rejected
@@ -428,6 +433,9 @@ public class Colibri {
         if skipWspCheck {
             flags |= 1 << 7
         }
+        if logsCompleteness {
+            flags |= 1 << 9
+        }
         return flags
     }
 
@@ -479,7 +487,7 @@ public class Colibri {
             free(paramsPtr)
         }
         
-        let proverFlags: UInt32 = (includeCode ? 1 : 0) | (useAccesslist ? (1 << 6) : 0)
+        let proverFlags: UInt32 = (includeCode ? 1 : 0) | (useAccesslist ? (1 << 6) : 0) | (logsCompleteness ? (1 << 12) : 0)
         guard let ctx = c4_create_prover_ctx(methodPtr, paramsPtr, chainId, proverFlags) else {
             throw ColibriError.contextCreationFailed
         }
@@ -615,7 +623,7 @@ public class Colibri {
         }
         defer { free(mPtr); free(pPtr) }
 
-        let proverFlags: UInt32 = (includeCode ? 1 : 0) | (useAccesslist ? (1 << 6) : 0) | (zkProof ? (1 << 7) : 0)
+        let proverFlags: UInt32 = (includeCode ? 1 : 0) | (useAccesslist ? (1 << 6) : 0) | (zkProof ? (1 << 7) : 0) | (logsCompleteness ? (1 << 12) : 0)
         // Base prover-mode auto-detection on the user-configured `provers` array,
         // NOT on the per-chain default fallback. Consumers passing `[]` explicitly
         // signal "no remote prover" -- if we consulted the fallback here, any

--- a/bindings/swift/doc.md
+++ b/bindings/swift/doc.md
@@ -199,6 +199,11 @@ public class Colibri {
     /// `colibri_simulateTransaction`. Default: 60.
     public var maxLatestAgeSeconds: UInt64
 
+    /// If true, `eth_getLogs` produces (prover) and requires (verifier) a completeness
+    /// proof over the requested block range, guaranteeing that no matching log was
+    /// omitted. Sets the prover flag (1 << 12) and the verify flag (1 << 9). Default: false.
+    public var logsCompleteness: Bool
+
     /// Initialization
     public init()
     
@@ -274,7 +279,7 @@ The gate covers the following RPC methods:
 - **Block / header:** `eth_getBlockByNumber`, `eth_getBlockHeader`, `eth_blobBaseFee`, `eth_maxPriorityFeePerGas`
 - **Implicit-latest:** `eth_blockNumber`
 
-`eth_getLogs` is **not** covered yet (tracked in issue #128). Account methods rely on a slim `timestamp` leaf inside the state proof which is only emitted by **prover version ≥ 1.1.27**; against older provers the verifier fails closed (`"cannot verify freshness of latest block without block context"`).
+`eth_getLogs` is not part of this per-method freshness gate; instead, enabling `logsCompleteness` (see below) produces a dedicated completeness proof over the whole requested block range (issue #128). Account methods rely on a slim `timestamp` leaf inside the state proof which is only emitted by **prover version ≥ 1.1.27**; against older provers the verifier fails closed (`"cannot verify freshness of latest block without block context"`).
 
 - `maxLatestAgeSeconds` (`UInt64`, default `60` ≈ 5 Ethereum slots) -- upper bound on the accepted age. Set to `0` to disable the check (e.g. when using legacy proof formats that do not embed a block context).
 
@@ -287,6 +292,18 @@ colibri.maxLatestAgeSeconds = 30 // tighter window for latency-sensitive flows
 ```
 
 > **PAP mode:** the freshness check also applies to PAP, where the call proof arrives via `colibri_proofCall` (same proof structure as a direct `eth_call`). This requires a prover that embeds the block context (≥ 1.1.15); against an older PAP proof without a block timestamp the check fails closed (`"cannot verify freshness of latest block without block context"`). Set `maxLatestAgeSeconds = 0` to opt out.
+
+### Logs completeness proof
+
+By default an `eth_getLogs` proof witnesses the returned log entries but not the completeness of the requested range -- a prover could omit matching logs. Enabling `logsCompleteness` makes the prover produce and the verifier require a **completeness proof** over the requested block range `[fromBlock, toBlock]`, guaranteeing that no matching log was omitted.
+
+- `logsCompleteness` (`Bool`, default `false`) -- sets the prover flag (`1 << 12`) and the verifier flag (`1 << 9`). Requires a prover that supports it. The range end (`toBlock`) may be a pinned block hash/number or `"latest"`; `"safe"`/`"finalized"` are not supported yet. Tracks issue #128.
+
+```swift
+let colibri = Colibri()
+colibri.chainId = 1
+colibri.logsCompleteness = true
+```
 
 ### Privacy-preserving `eth_call` (oblivious + PAP + hybrid)
 

--- a/src/chains/eth/CMakeLists.txt
+++ b/src/chains/eth/CMakeLists.txt
@@ -127,7 +127,7 @@ if(ETH_RECEIPT)
 endif()
 
 if(ETH_LOGS)
-  set(VERIFIER_SOURCES ${VERIFIER_SOURCES} verifier/verify_logs_proof.c verifier/eth_bloom.c)
+  set(VERIFIER_SOURCES ${VERIFIER_SOURCES} verifier/verify_logs_proof.c verifier/verify_logs_completeness.c verifier/eth_bloom.c)
   add_definitions(-DETH_LOGS)
 endif()
 
@@ -187,6 +187,7 @@ add_prover(
     prover/proof_transaction.c
     prover/tx_cache.c
     prover/proof_logs.c
+    prover/proof_logs_completeness.c
     prover/proof_call.c
     prover/beacon.c
     prover/beacon_header.c

--- a/src/chains/eth/prover/eth_tools.h
+++ b/src/chains/eth/prover/eth_tools.h
@@ -32,6 +32,14 @@
 #define JSON_TX_CALL_FIELDS     "{to:address,data:bytes,gas?:hexuint,value?:hexuint,gasPrice?:hexuint,from?:address}"
 #define JSON_ACCESS_LIST_FIELDS "{accessList:[{address:address,storageKeys:[hex32]}],error?:string,gasUsed?:hexuint}"
 
+// Schema for the eth_getLogs filter object (all fields optional):
+//   - fromBlock/toBlock: block tag ("latest"/"safe"/...) or a hex block number
+//   - blockHash: a single 32-byte block hash (mutually exclusive with from/toBlock, not enforced here)
+//   - topics: array where each position is a single topic, an array of alternatives, or null (wildcard)
+//   - bloomFilter: optional pre-computed query blooms used by PAP mode
+//   - address: a single address or an array of addresses
+#define JSON_GET_LOGS_FILTER_FIELDS "{fromBlock?:block,toBlock?:block,blockHash?:bytes32,topics?:[bytes32|[bytes32|null]|null],bloomFilter?:[bytes],address?:address|[address]}"
+
 // Forward declaration (defined in src/chains/eth/verifier/state_overrides.h).
 // Prover code only needs the pointer type.
 typedef struct eth_state_overrides eth_state_overrides_t;

--- a/src/chains/eth/prover/proof_account.c
+++ b/src/chains/eth/prover/proof_account.c
@@ -139,11 +139,11 @@ c4_status_t c4_proof_account(prover_ctx_t* ctx) {
   c4_status_t       status         = C4_SUCCESS;
 
   if (is_storage_at)
-    CHECK_JSON(ctx->params, "[address,bytes32,block]", "Invalid arguments for eth_getStorageAt: ");
+    CHECK_JSON_INPUT(ctx->params, "[address,bytes32,block]", "Invalid arguments for eth_getStorageAt: ");
   else if (is_proof)
-    CHECK_JSON(ctx->params, "[address,[bytes32],block]", "Invalid arguments for eth_getProof: ");
+    CHECK_JSON_INPUT(ctx->params, "[address,[bytes32],block]", "Invalid arguments for eth_getProof: ");
   else
-    CHECK_JSON(ctx->params, "[address,block]", "Invalid arguments for AccountProof: ");
+    CHECK_JSON_INPUT(ctx->params, "[address,block]", "Invalid arguments for AccountProof: ");
 
   TRY_ASYNC(c4_beacon_get_block_for_eth(ctx, block_number, &block));
   TRY_ADD_ASYNC(status, eth_get_proof(ctx, address, storage_keys, &eth_proof, ssz_get_uint64(&block.execution, "blockNumber")));

--- a/src/chains/eth/prover/proof_call.c
+++ b/src/chains/eth/prover/proof_call.c
@@ -306,13 +306,13 @@ c4_status_t c4_proof_call(prover_ctx_t* ctx) {
   TRACE_START(ctx, "get_block_for_eth");
 
   if (strcmp(ctx->method, "eth_call") == 0) {
-    CHECK_JSON(ctx->params, "[" JSON_TX_CALL_FIELDS ",block," JSON_STATE_OVERRIDES_FIELDS "]", "Invalid transaction");
+    CHECK_JSON_INPUT(ctx->params, "[" JSON_TX_CALL_FIELDS ",block," JSON_STATE_OVERRIDES_FIELDS "]", "Invalid transaction");
   }
   else if (is_proof_call) {
-    CHECK_JSON(ctx->params, "[" JSON_ACCESS_LIST_FIELDS ",block]", "Invalid transaction");
+    CHECK_JSON_INPUT(ctx->params, "[" JSON_ACCESS_LIST_FIELDS ",block]", "Invalid transaction");
   }
   else {
-    CHECK_JSON(ctx->params, "[" JSON_TX_CALL_FIELDS ",block," JSON_STATE_OVERRIDES_FIELDS "]", "Invalid transaction");
+    CHECK_JSON_INPUT(ctx->params, "[" JSON_TX_CALL_FIELDS ",block," JSON_STATE_OVERRIDES_FIELDS "]", "Invalid transaction");
   }
   if (has_overrides) TRY_ASYNC(eth_parse_state_overrides_state(&ctx->state, state_overrides, &overrides_parsed));
 

--- a/src/chains/eth/prover/proof_logs.c
+++ b/src/chains/eth/prover/proof_logs.c
@@ -372,6 +372,11 @@ static c4_status_t serialize_log_proof(prover_ctx_t* ctx, proof_logs_block_t* bl
 }
 
 c4_status_t c4_proof_logs(prover_ctx_t* ctx) {
+  // Validate the eth_getLogs filter object up front. eth_proofLogs passes the logs array as params,
+  // so the filter schema only applies to eth_getLogs.
+  if (proof_logs_block_proof_type(ctx) == ETH_GET_LOGS)
+    CHECK_JSON_CACHED(json_at(ctx->params, 0), JSON_GET_LOGS_FILTER_FIELDS, "Invalid eth_getLogs filter: ");
+
   // A completeness proof is only meaningful for eth_getLogs (range queries), not for eth_proofLogs.
   if ((ctx->flags & C4_PROVER_FLAG_LOGS_COMPLETENESS) && proof_logs_block_proof_type(ctx) == ETH_GET_LOGS)
     return c4_proof_logs_completeness(ctx);

--- a/src/chains/eth/prover/proof_logs.c
+++ b/src/chains/eth/prover/proof_logs.c
@@ -33,6 +33,7 @@
 #include "logs_cache.h"
 #endif
 #include "patricia.h"
+#include "proof_logs_completeness.h"
 #include "prover.h"
 #include "rlp.h"
 #include "ssz.h"
@@ -371,6 +372,10 @@ static c4_status_t serialize_log_proof(prover_ctx_t* ctx, proof_logs_block_t* bl
 }
 
 c4_status_t c4_proof_logs(prover_ctx_t* ctx) {
+  // A completeness proof is only meaningful for eth_getLogs (range queries), not for eth_proofLogs.
+  if ((ctx->flags & C4_PROVER_FLAG_LOGS_COMPLETENESS) && proof_logs_block_proof_type(ctx) == ETH_GET_LOGS)
+    return c4_proof_logs_completeness(ctx);
+
   bool                hybrid        = (ctx->flags & C4_PROVER_FLAG_HYBRID) != 0;
   json_t              logs          = {0};
   proof_logs_block_t* blocks        = NULL;

--- a/src/chains/eth/prover/proof_logs.c
+++ b/src/chains/eth/prover/proof_logs.c
@@ -375,7 +375,7 @@ c4_status_t c4_proof_logs(prover_ctx_t* ctx) {
   // Validate the eth_getLogs filter object up front. eth_proofLogs passes the logs array as params,
   // so the filter schema only applies to eth_getLogs.
   if (proof_logs_block_proof_type(ctx) == ETH_GET_LOGS)
-    CHECK_JSON_CACHED(json_at(ctx->params, 0), JSON_GET_LOGS_FILTER_FIELDS, "Invalid eth_getLogs filter: ");
+    CHECK_JSON_INPUT(json_at(ctx->params, 0), JSON_GET_LOGS_FILTER_FIELDS, "Invalid eth_getLogs filter: ");
 
   // A completeness proof is only meaningful for eth_getLogs (range queries), not for eth_proofLogs.
   if ((ctx->flags & C4_PROVER_FLAG_LOGS_COMPLETENESS) && proof_logs_block_proof_type(ctx) == ETH_GET_LOGS)

--- a/src/chains/eth/prover/proof_logs_completeness.c
+++ b/src/chains/eth/prover/proof_logs_completeness.c
@@ -259,7 +259,7 @@ static c4_status_t serialize_completeness_proof(prover_ctx_t* ctx, compl_block_t
 c4_status_t c4_proof_logs_completeness(prover_ctx_t* ctx) {
   if (ctx->flags & C4_PROVER_FLAG_HYBRID) THROW_ERROR("logs completeness proof is not supported in hybrid mode");
   json_t filter = json_at(ctx->params, 0);
-  if (filter.type != JSON_TYPE_OBJECT) THROW_ERROR("eth_getLogs completeness requires a filter object");
+  CHECK_JSON_CACHED(filter, JSON_GET_LOGS_FILTER_FIELDS, "Invalid eth_getLogs filter: ");
 
   // resolve the range endpoints (fromBlock/toBlock, defaulting to "latest")
   uint8_t  tmp_from[16], tmp_to[16];

--- a/src/chains/eth/prover/proof_logs_completeness.c
+++ b/src/chains/eth/prover/proof_logs_completeness.c
@@ -28,6 +28,7 @@
 #include "eth_compute_units.h"
 #include "eth_req.h"
 #include "eth_tools.h"
+#include "historic_proof.h"
 #include "json.h"
 #include "logger.h"
 #include "ssz.h"
@@ -39,6 +40,10 @@
 #define COMPLETENESS_BLOCK_NONE     0
 #define COMPLETENESS_BLOCK_NEGATIVE 1
 #define COMPLETENESS_BLOCK_FULL     2
+
+// Union selectors for ETH_STATE_BLOCK_UNION used as the anchor `tag_proof` (see verify_proof_types.h).
+#define STATE_BLOCK_UNION_NONE      0
+#define STATE_BLOCK_UNION_TIMESTAMP 4
 
 static uint32_t g_max_blocks = C4_LOGS_COMPLETENESS_DEFAULT_MAX_BLOCKS;
 
@@ -164,10 +169,47 @@ static void serialize_full_block(prover_ctx_t* ctx, ssz_builder_t* blist, uint32
   safe_free(vbytes.bytes.data);
 }
 
-static c4_status_t serialize_completeness_proof(prover_ctx_t* ctx, compl_block_t* blocks, uint32_t count, bytes_t query_blooms) {
-  ssz_builder_t    proof      = ssz_builder_for_type(ETH_SSZ_VERIFY_LOGS_COMPLETENESS_PROOF);
-  compl_block_t*   first      = &blocks[0];
-  compl_block_t*   anchor     = &blocks[count - 1];
+// True if the JSON string token `t` equals the C string `s` (token includes the surrounding quotes).
+static bool json_str_eq(json_t t, const char* s) {
+  size_t n = strlen(s);
+  return t.type == JSON_TYPE_STRING && (size_t) t.len == n + 2 && strncmp(t.start + 1, s, n) == 0;
+}
+
+// True if the block tag is a pinned hex quantity/hash (e.g. "0x...").
+static bool tag_is_pinned(json_t tag) {
+  return tag.type == JSON_TYPE_STRING && tag.len > 2 && tag.start[1] == '0' && tag.start[2] == 'x';
+}
+
+// Builds the anchor `tag_proof` union (+ branch). A pinned block tag needs no freshness proof (`none`),
+// `latest` uses the `timestamp` variant proven against the anchor bodyRoot. `safe`/`finalized` would use
+// the `checkpoint_proof` variant (structurally prepared, not yet emitted) and are rejected earlier.
+static void serialize_tag_proof(prover_ctx_t* ctx, ssz_builder_t* proof, compl_block_t* anchor, json_t to_tag) {
+  if (tag_is_pinned(to_tag)) {
+    uint8_t none = STATE_BLOCK_UNION_NONE;
+    ssz_add_bytes(proof, "tag_proof", bytes(&none, 1));
+    ssz_add_bytes(proof, "tag_proof_branch", NULL_BYTES);
+    return;
+  }
+
+  // `latest`: prove the anchor's execution timestamp against its bodyRoot so the verifier can run the
+  // `latest` freshness gate.
+  uint8_t tag[9] = {0};
+  tag[0]         = STATE_BLOCK_UNION_TIMESTAMP;
+  memcpy(tag + 1, ssz_get(&anchor->beacon.execution, "timestamp").bytes.data, 8);
+  ssz_add_bytes(proof, "tag_proof", bytes(tag, sizeof(tag)));
+
+  gindex_t  gindex[1] = {ssz_gindex(anchor->beacon.body.def, 2, "executionPayload", "timestamp")};
+  bytes32_t tmp_root  = {0};
+  bytes_t   branch    = ssz_create_multi_proof_for_gindexes(anchor->beacon.body, tmp_root, gindex, 1);
+  eth_cu_add_multi_proof(ctx, 1);
+  ssz_add_bytes(proof, "tag_proof_branch", branch);
+  safe_free(branch.data);
+}
+
+static c4_status_t serialize_completeness_proof(prover_ctx_t* ctx, compl_block_t* blocks, uint32_t count, bytes_t query_blooms, blockroot_proof_t anchor_proof, json_t to_tag) {
+  ssz_builder_t    proof       = ssz_builder_for_type(ETH_SSZ_VERIFY_LOGS_COMPLETENESS_PROOF);
+  compl_block_t*   first       = &blocks[0];
+  compl_block_t*   anchor      = &blocks[count - 1];
   const ssz_def_t* headers_def = ssz_get_def(proof.def, "headers");
   const ssz_def_t* blocks_def  = ssz_get_def(proof.def, "blocks");
   const ssz_def_t* ph_def      = headers_def->def.vector.type;
@@ -176,12 +218,11 @@ static c4_status_t serialize_completeness_proof(prover_ctx_t* ctx, compl_block_t
   for (uint32_t i = 0; i < count; i++)
     ssz_hash_tree_root(blocks[i].beacon.body, blocks[i].body_root);
 
-  ssz_add_uint64(&proof, first->block_number);
-  ssz_add_uint64(&proof, anchor->block_number);
+  // full header of the oldest block; parentRoot anchors the ascending chain
   ssz_add_builders(&proof, "header", c4_proof_add_header(first->beacon.header, first->body_root));
 
-  // parent_root chain: ProofHeaders for fromBlock+1 .. toBlock
-  ssz_builder_t headers = ssz_builder_for_def(headers_def);
+  // parentRoot chain: ProofHeaders for the oldest+1 .. anchor (newest)
+  ssz_builder_t headers      = ssz_builder_for_def(headers_def);
   uint32_t      header_count = count - 1;
   for (uint32_t i = 1; i < count; i++) {
     ssz_builder_t ph = ssz_builder_for_def(ph_def);
@@ -194,9 +235,12 @@ static c4_status_t serialize_completeness_proof(prover_ctx_t* ctx, compl_block_t
   ssz_add_builders(&proof, "headers", headers);
   eth_cu_add(ctx, header_count * CU_HISTORIC_HEADER_HOP);
 
-  // anchor signature (sync aggregate of the block following the anchor)
-  ssz_add_bytes(&proof, "sync_committee_bits", ssz_get(&anchor->beacon.sync_aggregate, "syncCommitteeBits").bytes);
-  ssz_add_bytes(&proof, "sync_committee_signature", ssz_get(&anchor->beacon.sync_aggregate, "syncCommitteeSignature").bytes);
+  // anchor the newest block via the shared header_proof union (signature / header-chain / historic)
+  ssz_add_header_proof(&proof, &anchor->beacon, anchor_proof);
+
+  // anchor block-tag proof (freshness) for an open-ended toBlock -- must be added in field order
+  // (after header_proof, before blocks)
+  serialize_tag_proof(ctx, &proof, anchor, to_tag);
 
   // per-block payloads
   ssz_builder_t blist = ssz_builder_for_def(blocks_def);
@@ -225,6 +269,11 @@ c4_status_t c4_proof_logs_completeness(prover_ctx_t* ctx) {
   json_t   to_id   = json_get(filter, "toBlock");
   if (from_id.type == JSON_TYPE_NOT_FOUND) from_id = json_parse(bprintf(&bf, "\"latest\""));
   if (to_id.type == JSON_TYPE_NOT_FOUND) to_id = json_parse(bprintf(&bt, "\"latest\""));
+
+  // `safe`/`finalized` require binding the anchor to the beacon checkpoint (checkpoint_proof variant),
+  // which is not implemented yet. Reject up front instead of emitting a proof the verifier would reject.
+  if (!tag_is_pinned(to_id) && !json_str_eq(to_id, "latest"))
+    THROW_ERROR("eth_getLogs completeness currently supports only a pinned toBlock or 'latest'");
 
   beacon_block_t from_block = {0};
   beacon_block_t to_block   = {0};
@@ -268,7 +317,19 @@ c4_status_t c4_proof_logs_completeness(prover_ctx_t* ctx) {
     return status;
   }
 
-  status = serialize_completeness_proof(ctx, blocks, (uint32_t) count, query_blooms);
+  // single header proof for the whole range: anchor the newest block via the shared header_proof
+  // union (direct signature, header-chain or historic summaries, depending on how recent it is).
+  blockroot_proof_t anchor_proof = {0};
+  status                         = c4_check_blockroot_proof(ctx, &anchor_proof, &blocks[count - 1].beacon);
+  if (status != C4_SUCCESS) {
+    c4_free_block_proof(&anchor_proof);
+    safe_free(blocks);
+    safe_free(query_blooms.data);
+    return status;
+  }
+
+  status = serialize_completeness_proof(ctx, blocks, (uint32_t) count, query_blooms, anchor_proof, to_id);
+  c4_free_block_proof(&anchor_proof);
   safe_free(blocks);
   safe_free(query_blooms.data);
   return status;

--- a/src/chains/eth/prover/proof_logs_completeness.c
+++ b/src/chains/eth/prover/proof_logs_completeness.c
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2025 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "proof_logs_completeness.h"
+#include "beacon.h"
+#include "beacon_types.h"
+#include "eth_bloom.h"
+#include "eth_compute_units.h"
+#include "eth_req.h"
+#include "eth_tools.h"
+#include "json.h"
+#include "logger.h"
+#include "ssz.h"
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Union selectors for ETH_COMPLETENESS_BLOCK_UNION (see verify_proof_types.h).
+#define COMPLETENESS_BLOCK_NONE     0
+#define COMPLETENESS_BLOCK_NEGATIVE 1
+#define COMPLETENESS_BLOCK_FULL     2
+
+static uint32_t g_max_blocks = C4_LOGS_COMPLETENESS_DEFAULT_MAX_BLOCKS;
+
+void c4_eth_set_logs_completeness_max_blocks(uint32_t max_blocks) {
+  g_max_blocks = max_blocks ? max_blocks : C4_LOGS_COMPLETENESS_DEFAULT_MAX_BLOCKS;
+}
+
+uint32_t c4_eth_get_logs_completeness_max_blocks(void) {
+  return g_max_blocks;
+}
+
+typedef struct {
+  uint64_t       block_number;
+  beacon_block_t beacon;    // header + execution + body + sync_aggregate
+  bytes32_t      body_root; // hash_tree_root of the beacon block body
+  bool           is_full;   // true: deliver all receipts, false: bloom-negative
+  json_t         receipts;  // block receipts (only for full blocks)
+} compl_block_t;
+
+// Builds a JSON block identifier ("0x..") for the given block number into buf.
+static json_t block_id_json(uint64_t block_number, buffer_t* buf) {
+  buffer_reset(buf);
+  return json_parse(bprintf(buf, "\"0x%" PRIx64 "\"", block_number));
+}
+
+// Serializes one bloom-negative block (blockNumber + logsBloom proven to bodyRoot).
+static void serialize_negative_block(prover_ctx_t* ctx, ssz_builder_t* blist, uint32_t count, compl_block_t* block, const ssz_def_t* union_def) {
+  ssz_ob_t exec   = block->beacon.execution;
+  bytes_t  bloom  = ssz_get(&exec, "logsBloom").bytes;
+  gindex_t gindex[2];
+  gindex[0] = ssz_gindex(block->beacon.body.def, 2, "executionPayload", "blockNumber");
+  gindex[1] = ssz_gindex(block->beacon.body.def, 2, "executionPayload", "logsBloom");
+
+  bytes32_t tmp_root = {0};
+  bytes_t   proof    = ssz_create_multi_proof_for_gindexes(block->beacon.body, tmp_root, gindex, 2);
+  eth_cu_add_multi_proof(ctx, 2);
+
+  ssz_builder_t v = ssz_builder_for_def(union_def->def.container.elements + COMPLETENESS_BLOCK_NEGATIVE);
+  ssz_add_uint64(&v, block->block_number);
+  ssz_add_bytes(&v, "logsBloom", bloom);
+  ssz_add_bytes(&v, "proof", proof);
+  safe_free(proof.data);
+
+  ssz_ob_t vbytes = ssz_builder_to_bytes(&v);
+  buffer_t elem   = {0};
+  uint8_t  sel    = COMPLETENESS_BLOCK_NEGATIVE;
+  buffer_append(&elem, bytes(&sel, 1));
+  buffer_append(&elem, vbytes.bytes);
+  ssz_add_dynamic_list_bytes(blist, count, elem.data);
+  buffer_free(&elem);
+  safe_free(vbytes.bytes.data);
+}
+
+// Serializes one full-receipts block (all receipts + matched txs + multi proof).
+static void serialize_full_block(prover_ctx_t* ctx, ssz_builder_t* blist, uint32_t count, compl_block_t* block, const ssz_def_t* union_def, bytes_t query_blooms) {
+  ssz_ob_t exec         = block->beacon.execution;
+  ssz_ob_t transactions = ssz_get(&exec, "transactions");
+  uint32_t receipt_len  = (uint32_t) json_len(block->receipts);
+
+  // Collect the transaction indices whose receipt could contain a matching log
+  // (bloom-positive). These provide the transaction hashes for matched logs.
+  uint32_t* match_idx   = safe_calloc(receipt_len ? receipt_len : 1, sizeof(uint32_t));
+  uint32_t  match_count = 0;
+  uint8_t   bloom_tmp[256];
+  buffer_t  bloom_buf = stack_buffer(bloom_tmp);
+  json_for_each_value(block->receipts, r) {
+    bytes_t rbloom = json_get_bytes(r, "logsBloom", &bloom_buf);
+    if (!c4_eth_bloom_negative(query_blooms, rbloom))
+      match_idx[match_count++] = json_get_uint32(r, "transactionIndex");
+  }
+
+  // multi proof: blockNumber, blockHash, receiptsRoot, matched transactions
+  uint32_t  gcount = 3 + match_count;
+  gindex_t* gindex = safe_calloc(gcount, sizeof(gindex_t));
+  gindex[0]        = ssz_gindex(block->beacon.body.def, 2, "executionPayload", "blockNumber");
+  gindex[1]        = ssz_gindex(block->beacon.body.def, 2, "executionPayload", "blockHash");
+  gindex[2]        = ssz_gindex(block->beacon.body.def, 2, "executionPayload", "receiptsRoot");
+  for (uint32_t i = 0; i < match_count; i++)
+    gindex[3 + i] = ssz_gindex(block->beacon.body.def, 3, "executionPayload", "transactions", match_idx[i]);
+
+  bytes32_t tmp_root = {0};
+  bytes_t   proof    = ssz_create_multi_proof_for_gindexes(block->beacon.body, tmp_root, gindex, gcount);
+  safe_free(gindex);
+  eth_cu_add_multi_proof(ctx, gcount);
+  eth_cu_add(ctx, receipt_len * CU_PATRICIA_INSERT);
+
+  ssz_builder_t v = ssz_builder_for_def(union_def->def.container.elements + COMPLETENESS_BLOCK_FULL);
+  ssz_add_uint64(&v, block->block_number);
+  ssz_add_bytes(&v, "blockHash", ssz_get(&exec, "blockHash").bytes);
+
+  // all RLP-serialized receipts
+  const ssz_def_t* receipts_def = ssz_get_def(union_def->def.container.elements + COMPLETENESS_BLOCK_FULL, "receipts");
+  ssz_builder_t    rlist        = ssz_builder_for_def(receipts_def);
+  buffer_t         rbuf         = {0};
+  json_for_each_value(block->receipts, r) {
+    buffer_reset(&rbuf);
+    ssz_add_dynamic_list_bytes(&rlist, receipt_len, c4_serialize_receipt(r, &rbuf));
+  }
+  buffer_free(&rbuf);
+  ssz_add_builders(&v, "receipts", rlist);
+
+  // raw transactions of the matched receipts
+  const ssz_def_t* txs_def = ssz_get_def(union_def->def.container.elements + COMPLETENESS_BLOCK_FULL, "txs");
+  ssz_builder_t    tx_list = ssz_builder_for_def(txs_def);
+  for (uint32_t i = 0; i < match_count; i++) {
+    ssz_builder_t tx_ssz = ssz_builder_for_def(txs_def->def.vector.type);
+    ssz_add_bytes(&tx_ssz, "transaction", ssz_at(transactions, match_idx[i]).bytes);
+    ssz_add_uint32(&tx_ssz, match_idx[i]);
+    ssz_add_dynamic_list_builders(&tx_list, match_count, tx_ssz);
+  }
+  ssz_add_builders(&v, "txs", tx_list);
+  ssz_add_bytes(&v, "proof", proof);
+  safe_free(proof.data);
+  safe_free(match_idx);
+
+  ssz_ob_t vbytes = ssz_builder_to_bytes(&v);
+  buffer_t elem   = {0};
+  uint8_t  sel    = COMPLETENESS_BLOCK_FULL;
+  buffer_append(&elem, bytes(&sel, 1));
+  buffer_append(&elem, vbytes.bytes);
+  ssz_add_dynamic_list_bytes(blist, count, elem.data);
+  buffer_free(&elem);
+  safe_free(vbytes.bytes.data);
+}
+
+static c4_status_t serialize_completeness_proof(prover_ctx_t* ctx, compl_block_t* blocks, uint32_t count, bytes_t query_blooms) {
+  ssz_builder_t    proof      = ssz_builder_for_type(ETH_SSZ_VERIFY_LOGS_COMPLETENESS_PROOF);
+  compl_block_t*   first      = &blocks[0];
+  compl_block_t*   anchor     = &blocks[count - 1];
+  const ssz_def_t* headers_def = ssz_get_def(proof.def, "headers");
+  const ssz_def_t* blocks_def  = ssz_get_def(proof.def, "blocks");
+  const ssz_def_t* ph_def      = headers_def->def.vector.type;
+
+  // compute the body roots for the whole range
+  for (uint32_t i = 0; i < count; i++)
+    ssz_hash_tree_root(blocks[i].beacon.body, blocks[i].body_root);
+
+  ssz_add_uint64(&proof, first->block_number);
+  ssz_add_uint64(&proof, anchor->block_number);
+  ssz_add_builders(&proof, "header", c4_proof_add_header(first->beacon.header, first->body_root));
+
+  // parent_root chain: ProofHeaders for fromBlock+1 .. toBlock
+  ssz_builder_t headers = ssz_builder_for_def(headers_def);
+  uint32_t      header_count = count - 1;
+  for (uint32_t i = 1; i < count; i++) {
+    ssz_builder_t ph = ssz_builder_for_def(ph_def);
+    ssz_add_bytes(&ph, "slot", ssz_get(&blocks[i].beacon.header, "slot").bytes);
+    ssz_add_bytes(&ph, "proposerIndex", ssz_get(&blocks[i].beacon.header, "proposerIndex").bytes);
+    ssz_add_bytes(&ph, "stateRoot", ssz_get(&blocks[i].beacon.header, "stateRoot").bytes);
+    ssz_add_bytes(&ph, "bodyRoot", bytes(blocks[i].body_root, 32));
+    ssz_add_dynamic_list_builders(&headers, header_count, ph);
+  }
+  ssz_add_builders(&proof, "headers", headers);
+  eth_cu_add(ctx, header_count * CU_HISTORIC_HEADER_HOP);
+
+  // anchor signature (sync aggregate of the block following the anchor)
+  ssz_add_bytes(&proof, "sync_committee_bits", ssz_get(&anchor->beacon.sync_aggregate, "syncCommitteeBits").bytes);
+  ssz_add_bytes(&proof, "sync_committee_signature", ssz_get(&anchor->beacon.sync_aggregate, "syncCommitteeSignature").bytes);
+
+  // per-block payloads
+  ssz_builder_t blist = ssz_builder_for_def(blocks_def);
+  for (uint32_t i = 0; i < count; i++) {
+    if (blocks[i].is_full)
+      serialize_full_block(ctx, &blist, count, &blocks[i], blocks_def->def.vector.type, query_blooms);
+    else
+      serialize_negative_block(ctx, &blist, count, &blocks[i], blocks_def->def.vector.type);
+  }
+  ssz_add_builders(&proof, "blocks", blist);
+
+  ctx->proof = eth_create_proof_request(ctx->chain_id, NULL_SSZ_BUILDER, proof, NULL_SSZ_BUILDER);
+  return C4_SUCCESS;
+}
+
+c4_status_t c4_proof_logs_completeness(prover_ctx_t* ctx) {
+  if (ctx->flags & C4_PROVER_FLAG_HYBRID) THROW_ERROR("logs completeness proof is not supported in hybrid mode");
+  json_t filter = json_at(ctx->params, 0);
+  if (filter.type != JSON_TYPE_OBJECT) THROW_ERROR("eth_getLogs completeness requires a filter object");
+
+  // resolve the range endpoints (fromBlock/toBlock, defaulting to "latest")
+  uint8_t  tmp_from[16], tmp_to[16];
+  buffer_t bf      = stack_buffer(tmp_from);
+  buffer_t bt      = stack_buffer(tmp_to);
+  json_t   from_id = json_get(filter, "fromBlock");
+  json_t   to_id   = json_get(filter, "toBlock");
+  if (from_id.type == JSON_TYPE_NOT_FOUND) from_id = json_parse(bprintf(&bf, "\"latest\""));
+  if (to_id.type == JSON_TYPE_NOT_FOUND) to_id = json_parse(bprintf(&bt, "\"latest\""));
+
+  beacon_block_t from_block = {0};
+  beacon_block_t to_block   = {0};
+  c4_status_t    status     = C4_SUCCESS;
+  TRY_ADD_ASYNC(status, c4_beacon_get_block_for_eth(ctx, to_id, &to_block));
+  TRY_ADD_ASYNC(status, c4_beacon_get_block_for_eth(ctx, from_id, &from_block));
+  TRY_ASYNC(status);
+
+  uint64_t from_num = ssz_get_uint64(&from_block.execution, "blockNumber");
+  uint64_t to_num   = ssz_get_uint64(&to_block.execution, "blockNumber");
+  if (from_num > to_num) THROW_ERROR("fromBlock is greater than toBlock");
+  uint64_t count = to_num - from_num + 1;
+  if (count > g_max_blocks) THROW_ERROR("completeness range exceeds the configured maximum number of blocks");
+
+  // fetch the beacon blocks for the whole range
+  compl_block_t* blocks = safe_calloc((size_t) count, sizeof(compl_block_t));
+  uint8_t        idbuf[16];
+  buffer_t       ib = stack_buffer(idbuf);
+  status            = C4_SUCCESS;
+  for (uint64_t i = 0; i < count; i++) {
+    blocks[i].block_number = from_num + i;
+    TRY_ADD_ASYNC(status, c4_beacon_get_block_for_eth(ctx, block_id_json(from_num + i, &ib), &blocks[i].beacon));
+  }
+  if (status != C4_SUCCESS) {
+    safe_free(blocks);
+    return status;
+  }
+
+  // decide the per-block scenario and fetch receipts for full blocks
+  bytes_t query_blooms = c4_eth_filter_query_blooms(filter);
+  status               = C4_SUCCESS;
+  for (uint64_t i = 0; i < count; i++) {
+    bytes_t bloom      = ssz_get(&blocks[i].beacon.execution, "logsBloom").bytes;
+    blocks[i].is_full  = !c4_eth_bloom_negative(query_blooms, bloom);
+    if (blocks[i].is_full)
+      TRY_ADD_ASYNC(status, eth_getBlockReceipts(ctx, block_id_json(blocks[i].block_number, &ib), &blocks[i].receipts));
+  }
+  if (status != C4_SUCCESS) {
+    safe_free(blocks);
+    safe_free(query_blooms.data);
+    return status;
+  }
+
+  status = serialize_completeness_proof(ctx, blocks, (uint32_t) count, query_blooms);
+  safe_free(blocks);
+  safe_free(query_blooms.data);
+  return status;
+}

--- a/src/chains/eth/prover/proof_logs_completeness.c
+++ b/src/chains/eth/prover/proof_logs_completeness.c
@@ -261,14 +261,13 @@ c4_status_t c4_proof_logs_completeness(prover_ctx_t* ctx) {
   json_t filter = json_at(ctx->params, 0);
   CHECK_JSON_INPUT(filter, JSON_GET_LOGS_FILTER_FIELDS, "Invalid eth_getLogs filter: ");
 
-  // resolve the range endpoints (fromBlock/toBlock, defaulting to "latest")
-  uint8_t  tmp_from[16], tmp_to[16];
-  buffer_t bf      = stack_buffer(tmp_from);
-  buffer_t bt      = stack_buffer(tmp_to);
-  json_t   from_id = json_get(filter, "fromBlock");
-  json_t   to_id   = json_get(filter, "toBlock");
-  if (from_id.type == JSON_TYPE_NOT_FOUND) from_id = json_parse(bprintf(&bf, "\"latest\""));
-  if (to_id.type == JSON_TYPE_NOT_FOUND) to_id = json_parse(bprintf(&bt, "\"latest\""));
+  // resolve the range endpoints (fromBlock/toBlock, defaulting to "latest").
+  // json_parse keeps a pointer into the source string, so the string literal
+  // (static storage duration) is safe here and no temporary buffer is needed.
+  json_t from_id = json_get(filter, "fromBlock");
+  json_t to_id   = json_get(filter, "toBlock");
+  if (from_id.type == JSON_TYPE_NOT_FOUND) from_id = json_parse("\"latest\"");
+  if (to_id.type == JSON_TYPE_NOT_FOUND) to_id = json_parse("\"latest\"");
 
   // `safe`/`finalized` require binding the anchor to the beacon checkpoint (checkpoint_proof variant),
   // which is not implemented yet. Reject up front instead of emitting a proof the verifier would reject.

--- a/src/chains/eth/prover/proof_logs_completeness.c
+++ b/src/chains/eth/prover/proof_logs_completeness.c
@@ -259,7 +259,7 @@ static c4_status_t serialize_completeness_proof(prover_ctx_t* ctx, compl_block_t
 c4_status_t c4_proof_logs_completeness(prover_ctx_t* ctx) {
   if (ctx->flags & C4_PROVER_FLAG_HYBRID) THROW_ERROR("logs completeness proof is not supported in hybrid mode");
   json_t filter = json_at(ctx->params, 0);
-  CHECK_JSON_CACHED(filter, JSON_GET_LOGS_FILTER_FIELDS, "Invalid eth_getLogs filter: ");
+  CHECK_JSON_INPUT(filter, JSON_GET_LOGS_FILTER_FIELDS, "Invalid eth_getLogs filter: ");
 
   // resolve the range endpoints (fromBlock/toBlock, defaulting to "latest")
   uint8_t  tmp_from[16], tmp_to[16];

--- a/src/chains/eth/prover/proof_logs_completeness.h
+++ b/src/chains/eth/prover/proof_logs_completeness.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef C4_PROOF_LOGS_COMPLETENESS_H
+#define C4_PROOF_LOGS_COMPLETENESS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "prover.h"
+#include <stdint.h>
+
+/** Default maximum number of blocks a single completeness proof may cover. */
+#define C4_LOGS_COMPLETENESS_DEFAULT_MAX_BLOCKS 1000
+
+/**
+ * Sets the maximum number of blocks a single `eth_getLogs` completeness proof may cover.
+ *
+ * The prover rejects requests whose `[fromBlock, toBlock]` range exceeds this limit.
+ * A value of `0` restores the built-in default (`C4_LOGS_COMPLETENESS_DEFAULT_MAX_BLOCKS`).
+ *
+ * @param max_blocks the new limit, or `0` to reset to the default.
+ */
+void c4_eth_set_logs_completeness_max_blocks(uint32_t max_blocks);
+
+/**
+ * Returns the currently configured maximum number of blocks for a completeness proof.
+ *
+ * @return the current limit (always non-zero).
+ */
+uint32_t c4_eth_get_logs_completeness_max_blocks(void);
+
+/**
+ * Generates an `eth_getLogs` completeness proof over the requested block range.
+ *
+ * Resolves `[fromBlock, toBlock]`, builds a parent_root header chain anchored to a
+ * single signed beacon header, and serializes for every block either a bloom-negative
+ * proof or the full set of receipts. The result is stored in `ctx->proof`.
+ *
+ * @param ctx the prover context (method must be `eth_getLogs`).
+ * @return `C4_SUCCESS` when the proof is ready, `C4_PENDING` while fetching data, `C4_ERROR` on failure.
+ */
+c4_status_t c4_proof_logs_completeness(prover_ctx_t* ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/chains/eth/prover/proof_receipt.c
+++ b/src/chains/eth/prover/proof_receipt.c
@@ -165,7 +165,7 @@ c4_status_t c4_proof_receipt(prover_ctx_t* ctx) {
   uint32_t          tx_index       = 0;
   json_t            block_number   = {0};
 
-  CHECK_JSON(txhash, "bytes32", "Invalid arguments for Tx: ");
+  CHECK_JSON_INPUT(txhash, "bytes32", "Invalid arguments for Tx: ");
 
   TRACE_START(ctx, "get_tx_data");
 

--- a/src/chains/eth/server/eth_conf.c
+++ b/src/chains/eth/server/eth_conf.c
@@ -4,6 +4,9 @@
 #ifdef PROVER_CACHE
 #include "../prover/logs_cache.h"
 #endif
+#ifdef ETH_LOGS
+#include "../prover/proof_logs_completeness.h"
+#endif
 
 eth_config_t eth_config = {
     .stream_beacon_events        = 0,
@@ -12,6 +15,7 @@ eth_config_t eth_config = {
     .period_backfill_max_periods = 2,   // default backfill up to 2 periods,
     .period_full_sync            = 0,
     .eth_logs_cache_blocks       = 0,
+    .logs_completeness_max_blocks = 0,
 
 };
 
@@ -21,6 +25,7 @@ void eth_configure() {
   conf_int(&eth_config.period_backfill_delay_ms, "C4_PERIOD_BACKFILL_DELAY_MS", "period_backfill_delay_ms", 0, "delay between backfill requests (ms)", 0, 60000);
   conf_int(&eth_config.period_backfill_max_periods, "C4_PERIOD_BACKFILL_MAX_PERIODS", "period_backfill_max_periods", 0, "max number of periods to backfill at startup", 0, 10000);
   conf_int(&eth_config.eth_logs_cache_blocks, "ETH_LOGS_CACHE_BLOCKS", "eth_logs_cache_blocks", 0, "max number of contiguous blocks to cache logs for eth_getLogs", 0, 131072);
+  conf_int(&eth_config.logs_completeness_max_blocks, "ETH_LOGS_COMPLETENESS_MAX_BLOCKS", "logs_completeness_max_blocks", 0, "max block range for an eth_getLogs completeness proof (0 = default)", 0, 131072);
   conf_string(&eth_config.period_store, "DATA", "data", 'd', "path to the data-directory holding blockroots and light client updates");
   conf_string(&eth_config.period_master_url, "PERIOD_MASTER_URL", "period_master_url", 0, "URL of the master node to use. if set, the server will not write to the period-store but fetch it when needed.");
   conf_int(&eth_config.period_full_sync, "C4_PERIOD_FULL_SYNC", "period_full_sync", 0, "if enabled and period_master_url is set, periodically sync full period_store from master", 0, 1);
@@ -35,6 +40,11 @@ void eth_configure() {
     c4_eth_logs_cache_disable();
     log_info("eth_logs_cache disabled (beacon_events=%d, capacity=%d)", (uint32_t) eth_config.stream_beacon_events, (uint32_t) eth_config.eth_logs_cache_blocks);
   }
+#endif
+
+#ifdef ETH_LOGS
+  if (eth_config.logs_completeness_max_blocks > 0)
+    c4_eth_set_logs_completeness_max_blocks((uint32_t) eth_config.logs_completeness_max_blocks);
 #endif
 
   http_server.prover_flags |= (eth_config.period_store ? C4_PROVER_FLAG_CHAIN_STORE : 0) | C4_PROVER_FLAG_USE_ACCESSLIST;

--- a/src/chains/eth/server/eth_conf.h
+++ b/src/chains/eth/server/eth_conf.h
@@ -12,6 +12,7 @@ typedef struct {
   int   period_full_sync;            // if set and period_master_url is configured, periodically sync full period_store from master
   char* period_prover_key_file;      // Path to file containing SP1/Network private key
   int   eth_logs_cache_blocks;
+  int   logs_completeness_max_blocks; // max block range for an eth_getLogs completeness proof (0 = keep default)
 
 } eth_config_t;
 

--- a/src/chains/eth/ssz/beacon_types.h
+++ b/src/chains/eth/ssz/beacon_types.h
@@ -107,7 +107,9 @@ typedef enum {
   // on the union array at the call sites).
   ETH_SSZ_VERIFY_LC_SYNCDATA    = 45, // `LCSyncData`   (union index 1): LightClient sync data
   ETH_SSZ_VERIFY_ZK_SYNCDATA    = 46, // `ZKSyncData`   (union index 2): legacy SP1 v5 ZK sync data, 260-byte proof
-  ETH_SSZ_VERIFY_ZK_SYNCDATA_V6 = 47  // `ZKSyncDataV6` (union index 3): SP1 v6 ZK sync data, 356-byte proof
+  ETH_SSZ_VERIFY_ZK_SYNCDATA_V6 = 47, // `ZKSyncDataV6` (union index 3): SP1 v6 ZK sync data, 356-byte proof
+
+  ETH_SSZ_VERIFY_LOGS_COMPLETENESS_PROOF = 48 // `LogsCompletenessProof` (proof union index 20): completeness proof for eth_getLogs
 
 } eth_ssz_type_t;
 

--- a/src/chains/eth/ssz/verify_proof_types.h
+++ b/src/chains/eth/ssz/verify_proof_types.h
@@ -96,7 +96,7 @@ static const ssz_def_t ETH_HISTORIC_BLOCK_PROOF[] = {
 };
 
 static const ssz_def_t PROOF_HEADER[4];
-
+static const ssz_def_t ETH_STATE_BLOCK_UNION[6];
 static const ssz_def_t PROOF_HEADER_CONTAINER = SSZ_CONTAINER("ProofHeader", PROOF_HEADER);
 
 // If the header we want to prove is slightly older than the sync period for which the user has the keys, the easiest way to prove it
@@ -239,6 +239,87 @@ static const ssz_def_t ETH_LOGS_BLOCK[] = {
     SSZ_LIST("txs", ETH_LOGS_TX_CONTAINER, 256)};       // the transactions of the block
 
 static const ssz_def_t ETH_LOGS_BLOCK_CONTAINER = SSZ_CONTAINER("LogsBlock", ETH_LOGS_BLOCK);
+
+
+
+// A **Logs Completeness Proof** proves for a contiguous range of execution blocks
+// `[fromBlock, toBlock]` that **no** matching log for the `eth_getLogs` filter was
+// omitted. The normal Logs Proof only proves inclusion of the returned logs; this
+// proof additionally guarantees completeness.
+//
+// **Continuity.** A single signed anchor header (the beacon block of `toBlock`) plus a
+// parent_root chain of `ProofHeader`s down to `fromBlock`. Because the execution-layer
+// `blockNumber` increments by exactly 1 per non-empty beacon block, an unbroken
+// parent_root chain together with a gap-free `blockNumber` sequence `fromBlock..toBlock`
+// guarantees that no block was skipped. Only one sync-committee BLS signature (over the
+// anchor) is required.
+//
+// **Per block** one of two variants (covers the three scenarios of issue #128):
+//   - `BloomNegative`: `blockNumber` + `logsBloom` are proven via a multi-merkle proof
+//     against the block's `bodyRoot`. The verifier computes the query bloom(s) from the
+//     filter and asserts that none is a bit-subset of the block's `logsBloom`, hence no
+//     matching log can exist in this block.
+//   - `FullReceipts`: `blockNumber` + `blockHash` + `receiptsRoot` (and the matching
+//     transactions) are proven; all RLP receipts are delivered so the verifier rebuilds
+//     the receipts trie, compares it to the proven `receiptsRoot`, and filters the logs
+//     locally. An empty match set corresponds to scenario 2, a non-empty one to
+//     scenario 3 (the raw transactions provide the transaction hashes).
+// A slim transaction entry (raw payload + index) used to reconstruct transaction hashes
+// for matched logs; the transaction is bound to the block via the block's multi proof.
+static const ssz_def_t ETH_COMPLETENESS_TX[] = {
+    SSZ_BYTES("transaction", 1073741824), // the raw transaction payload
+    SSZ_UINT32("transactionIndex"),       // the index of the transaction in the block
+};
+static const ssz_def_t ETH_COMPLETENESS_TX_CONTAINER = SSZ_CONTAINER("CompletenessTx", ETH_COMPLETENESS_TX);
+
+// Bloom-negative block: proves that the query bloom is not a subset of the block's logsBloom.
+static const ssz_def_t ETH_COMPLETENESS_BLOOM_NEGATIVE[] = {
+    SSZ_UINT64("blockNumber"),           // the execution block number
+    SSZ_BYTE_VECTOR("logsBloom", 256),   // the block's logsBloom (execution payload)
+    SSZ_LIST("proof", ssz_bytes32, 256), // multi proof of blockNumber + logsBloom to bodyRoot
+};
+
+// Full-receipts block: all receipts are delivered so the verifier rebuilds the receipts trie.
+static const ssz_def_t ETH_COMPLETENESS_FULL_RECEIPTS[] = {
+    SSZ_UINT64("blockNumber"),                            // the execution block number
+    SSZ_BYTES32("blockHash"),                             // the execution block hash (for reconstructed log entries)
+    SSZ_LIST("receipts", ssz_bytes_list, 65536),         // all RLP-serialized receipts of the block
+    SSZ_LIST("txs", ETH_COMPLETENESS_TX_CONTAINER, 256), // raw transactions of the matching logs (for transactionHash)
+    SSZ_LIST("proof", ssz_bytes32, 1024),                // multi proof of blockNumber + blockHash + receiptsRoot + matched txs to bodyRoot
+};
+
+// Per-block union: a block is either proven bloom-negative or delivered with all receipts.
+static const ssz_def_t ETH_COMPLETENESS_BLOCK_UNION[] = {
+    SSZ_NONE,
+    SSZ_CONTAINER("BloomNegative", ETH_COMPLETENESS_BLOOM_NEGATIVE), // 1: no matching log possible (bloom check)
+    SSZ_CONTAINER("FullReceipts", ETH_COMPLETENESS_FULL_RECEIPTS),   // 2: all receipts delivered, filtered locally
+};
+static const ssz_def_t ETH_COMPLETENESS_BLOCK = SSZ_UNION("block", ETH_COMPLETENESS_BLOCK_UNION);
+
+// The main proof data for a logs completeness proof over a contiguous block range.
+//
+// The claim (the requested block range) comes from the RPC request, so the range endpoints are NOT
+// carried in the proof; the verifier derives fromBlock/toBlock from the (proven) per-block payloads
+// and binds them to the request. `header` is the full beacon header of the oldest block; `headers`
+// is the ascending parentRoot chain up to the anchor (the newest block). The anchor's canonicity is
+// established via the shared `header_proof` union (signature / header-chain / historic summaries),
+// exactly like every other proof type -- the verifier reconstructs the anchor header from the chain
+// and passes it to `c4_verify_header`.
+//
+// `tag_proof` proves the anchor's block tag for an open-ended `toBlock` (the same union that account
+// proofs use): the `timestamp` variant (proven via `tag_proof_branch` against the anchor's bodyRoot)
+// gates the `latest` freshness, while the `checkpoint_proof` variant is reserved for `safe`/`finalized`
+// (structurally prepared; verification pending). For a pinned `toBlock` the `none` variant is used.
+static const ssz_def_t ETH_LOGS_COMPLETENESS_PROOF[] = {
+    SSZ_CONTAINER("header", BEACON_BLOCK_HEADER),       // full beacon header of the oldest block (parentRoot anchors the chain)
+    SSZ_LIST("headers", PROOF_HEADER_CONTAINER, 4096),  // ProofHeaders ascending, one per block after the first (last == anchor)
+    SSZ_UNION("header_proof", ETH_HEADER_PROOFS_UNION), // proof for the correctness of the reconstructed anchor header
+    SSZ_UNION("tag_proof", ETH_STATE_BLOCK_UNION),      // anchor block-tag proof (timestamp for `latest`, checkpoint_proof for `safe`/`finalized`, none for pinned)
+    SSZ_LIST("tag_proof_branch", ssz_bytes32, 256),     // multi proof of the tag_proof leaf (timestamp) to the anchor's bodyRoot
+    SSZ_LIST("blocks", ETH_COMPLETENESS_BLOCK, 4096),   // per-block payload ascending fromBlock..toBlock
+};
+static const ssz_def_t ETH_LOGS_COMPLETENESS_PROOF_CONTAINER = SSZ_CONTAINER("LogsCompletenessProof", ETH_LOGS_COMPLETENESS_PROOF);
+
 
 // :: Transaction Proof
 //
@@ -811,84 +892,3 @@ static const ssz_def_t ETH_HYBRID_BLOCK_PROOF[] = {
 static const ssz_def_t ETH_HYBRID_BLOCK_HEADER_PROOF[] = {
     SSZ_CONTAINER("header_data", ETH_BLOCK_HEADER_DATA),
 };
-
-// :: Logs Completeness Proof
-//
-// A **Logs Completeness Proof** proves for a contiguous range of execution blocks
-// `[fromBlock, toBlock]` that **no** matching log for the `eth_getLogs` filter was
-// omitted. The normal Logs Proof only proves inclusion of the returned logs; this
-// proof additionally guarantees completeness.
-//
-// **Continuity.** A single signed anchor header (the beacon block of `toBlock`) plus a
-// parent_root chain of `ProofHeader`s down to `fromBlock`. Because the execution-layer
-// `blockNumber` increments by exactly 1 per non-empty beacon block, an unbroken
-// parent_root chain together with a gap-free `blockNumber` sequence `fromBlock..toBlock`
-// guarantees that no block was skipped. Only one sync-committee BLS signature (over the
-// anchor) is required.
-//
-// **Per block** one of two variants (covers the three scenarios of issue #128):
-//   - `BloomNegative`: `blockNumber` + `logsBloom` are proven via a multi-merkle proof
-//     against the block's `bodyRoot`. The verifier computes the query bloom(s) from the
-//     filter and asserts that none is a bit-subset of the block's `logsBloom`, hence no
-//     matching log can exist in this block.
-//   - `FullReceipts`: `blockNumber` + `blockHash` + `receiptsRoot` (and the matching
-//     transactions) are proven; all RLP receipts are delivered so the verifier rebuilds
-//     the receipts trie, compares it to the proven `receiptsRoot`, and filters the logs
-//     locally. An empty match set corresponds to scenario 2, a non-empty one to
-//     scenario 3 (the raw transactions provide the transaction hashes).
-
-// A slim transaction entry (raw payload + index) used to reconstruct transaction hashes
-// for matched logs; the transaction is bound to the block via the block's multi proof.
-static const ssz_def_t ETH_COMPLETENESS_TX[] = {
-    SSZ_BYTES("transaction", 1073741824), // the raw transaction payload
-    SSZ_UINT32("transactionIndex"),       // the index of the transaction in the block
-};
-static const ssz_def_t ETH_COMPLETENESS_TX_CONTAINER = SSZ_CONTAINER("CompletenessTx", ETH_COMPLETENESS_TX);
-
-// Bloom-negative block: proves that the query bloom is not a subset of the block's logsBloom.
-static const ssz_def_t ETH_COMPLETENESS_BLOOM_NEGATIVE[] = {
-    SSZ_UINT64("blockNumber"),           // the execution block number
-    SSZ_BYTE_VECTOR("logsBloom", 256),   // the block's logsBloom (execution payload)
-    SSZ_LIST("proof", ssz_bytes32, 256), // multi proof of blockNumber + logsBloom to bodyRoot
-};
-
-// Full-receipts block: all receipts are delivered so the verifier rebuilds the receipts trie.
-static const ssz_def_t ETH_COMPLETENESS_FULL_RECEIPTS[] = {
-    SSZ_UINT64("blockNumber"),                            // the execution block number
-    SSZ_BYTES32("blockHash"),                             // the execution block hash (for reconstructed log entries)
-    SSZ_LIST("receipts", ssz_bytes_list, 65536),         // all RLP-serialized receipts of the block
-    SSZ_LIST("txs", ETH_COMPLETENESS_TX_CONTAINER, 256), // raw transactions of the matching logs (for transactionHash)
-    SSZ_LIST("proof", ssz_bytes32, 1024),                // multi proof of blockNumber + blockHash + receiptsRoot + matched txs to bodyRoot
-};
-
-// Per-block union: a block is either proven bloom-negative or delivered with all receipts.
-static const ssz_def_t ETH_COMPLETENESS_BLOCK_UNION[] = {
-    SSZ_NONE,
-    SSZ_CONTAINER("BloomNegative", ETH_COMPLETENESS_BLOOM_NEGATIVE), // 1: no matching log possible (bloom check)
-    SSZ_CONTAINER("FullReceipts", ETH_COMPLETENESS_FULL_RECEIPTS),   // 2: all receipts delivered, filtered locally
-};
-static const ssz_def_t ETH_COMPLETENESS_BLOCK = SSZ_UNION("block", ETH_COMPLETENESS_BLOCK_UNION);
-
-// The main proof data for a logs completeness proof over a contiguous block range.
-//
-// The claim (the requested block range) comes from the RPC request, so the range endpoints are NOT
-// carried in the proof; the verifier derives fromBlock/toBlock from the (proven) per-block payloads
-// and binds them to the request. `header` is the full beacon header of the oldest block; `headers`
-// is the ascending parentRoot chain up to the anchor (the newest block). The anchor's canonicity is
-// established via the shared `header_proof` union (signature / header-chain / historic summaries),
-// exactly like every other proof type -- the verifier reconstructs the anchor header from the chain
-// and passes it to `c4_verify_header`.
-//
-// `tag_proof` proves the anchor's block tag for an open-ended `toBlock` (the same union that account
-// proofs use): the `timestamp` variant (proven via `tag_proof_branch` against the anchor's bodyRoot)
-// gates the `latest` freshness, while the `checkpoint_proof` variant is reserved for `safe`/`finalized`
-// (structurally prepared; verification pending). For a pinned `toBlock` the `none` variant is used.
-static const ssz_def_t ETH_LOGS_COMPLETENESS_PROOF[] = {
-    SSZ_CONTAINER("header", BEACON_BLOCK_HEADER),       // full beacon header of the oldest block (parentRoot anchors the chain)
-    SSZ_LIST("headers", PROOF_HEADER_CONTAINER, 4096),  // ProofHeaders ascending, one per block after the first (last == anchor)
-    SSZ_UNION("header_proof", ETH_HEADER_PROOFS_UNION), // proof for the correctness of the reconstructed anchor header
-    SSZ_UNION("tag_proof", ETH_STATE_BLOCK_UNION),      // anchor block-tag proof (timestamp for `latest`, checkpoint_proof for `safe`/`finalized`, none for pinned)
-    SSZ_LIST("tag_proof_branch", ssz_bytes32, 256),     // multi proof of the tag_proof leaf (timestamp) to the anchor's bodyRoot
-    SSZ_LIST("blocks", ETH_COMPLETENESS_BLOCK, 4096),   // per-block payload ascending fromBlock..toBlock
-};
-static const ssz_def_t ETH_LOGS_COMPLETENESS_PROOF_CONTAINER = SSZ_CONTAINER("LogsCompletenessProof", ETH_LOGS_COMPLETENESS_PROOF);

--- a/src/chains/eth/ssz/verify_proof_types.h
+++ b/src/chains/eth/ssz/verify_proof_types.h
@@ -847,8 +847,8 @@ static const ssz_def_t ETH_COMPLETENESS_TX_CONTAINER = SSZ_CONTAINER("Completene
 
 // Bloom-negative block: proves that the query bloom is not a subset of the block's logsBloom.
 static const ssz_def_t ETH_COMPLETENESS_BLOOM_NEGATIVE[] = {
-    SSZ_UINT64("blockNumber"),         // the execution block number
-    SSZ_BYTE_VECTOR("logsBloom", 256), // the block's logsBloom (execution payload)
+    SSZ_UINT64("blockNumber"),           // the execution block number
+    SSZ_BYTE_VECTOR("logsBloom", 256),   // the block's logsBloom (execution payload)
     SSZ_LIST("proof", ssz_bytes32, 256), // multi proof of blockNumber + logsBloom to bodyRoot
 };
 
@@ -858,7 +858,7 @@ static const ssz_def_t ETH_COMPLETENESS_FULL_RECEIPTS[] = {
     SSZ_BYTES32("blockHash"),                             // the execution block hash (for reconstructed log entries)
     SSZ_LIST("receipts", ssz_bytes_list, 65536),         // all RLP-serialized receipts of the block
     SSZ_LIST("txs", ETH_COMPLETENESS_TX_CONTAINER, 256), // raw transactions of the matching logs (for transactionHash)
-    SSZ_LIST("proof", ssz_bytes32, 1024),                // multi proof of blockNumber + blockHash + receiptsRoot + matched transactions to bodyRoot
+    SSZ_LIST("proof", ssz_bytes32, 1024),                // multi proof of blockNumber + blockHash + receiptsRoot + matched txs to bodyRoot
 };
 
 // Per-block union: a block is either proven bloom-negative or delivered with all receipts.
@@ -870,13 +870,25 @@ static const ssz_def_t ETH_COMPLETENESS_BLOCK_UNION[] = {
 static const ssz_def_t ETH_COMPLETENESS_BLOCK = SSZ_UNION("block", ETH_COMPLETENESS_BLOCK_UNION);
 
 // The main proof data for a logs completeness proof over a contiguous block range.
+//
+// The claim (the requested block range) comes from the RPC request, so the range endpoints are NOT
+// carried in the proof; the verifier derives fromBlock/toBlock from the (proven) per-block payloads
+// and binds them to the request. `header` is the full beacon header of the oldest block; `headers`
+// is the ascending parentRoot chain up to the anchor (the newest block). The anchor's canonicity is
+// established via the shared `header_proof` union (signature / header-chain / historic summaries),
+// exactly like every other proof type -- the verifier reconstructs the anchor header from the chain
+// and passes it to `c4_verify_header`.
+//
+// `tag_proof` proves the anchor's block tag for an open-ended `toBlock` (the same union that account
+// proofs use): the `timestamp` variant (proven via `tag_proof_branch` against the anchor's bodyRoot)
+// gates the `latest` freshness, while the `checkpoint_proof` variant is reserved for `safe`/`finalized`
+// (structurally prepared; verification pending). For a pinned `toBlock` the `none` variant is used.
 static const ssz_def_t ETH_LOGS_COMPLETENESS_PROOF[] = {
-    SSZ_UINT64("fromBlock"),                            // first execution block of the range (inclusive)
-    SSZ_UINT64("toBlock"),                              // last execution block of the range (inclusive), == anchor block
-    SSZ_CONTAINER("header", BEACON_BLOCK_HEADER),       // full beacon header of fromBlock (oldest; parentRoot anchors the chain)
-    SSZ_LIST("headers", PROOF_HEADER_CONTAINER, 4096),  // ProofHeaders ascending fromBlock+1..toBlock (last == signed anchor)
-    SSZ_BIT_VECTOR("sync_committee_bits", 512),         // the bits of the validators that signed the anchor
-    SSZ_BYTE_VECTOR("sync_committee_signature", 96),    // the sync committee signature over the anchor root
+    SSZ_CONTAINER("header", BEACON_BLOCK_HEADER),       // full beacon header of the oldest block (parentRoot anchors the chain)
+    SSZ_LIST("headers", PROOF_HEADER_CONTAINER, 4096),  // ProofHeaders ascending, one per block after the first (last == anchor)
+    SSZ_UNION("header_proof", ETH_HEADER_PROOFS_UNION), // proof for the correctness of the reconstructed anchor header
+    SSZ_UNION("tag_proof", ETH_STATE_BLOCK_UNION),      // anchor block-tag proof (timestamp for `latest`, checkpoint_proof for `safe`/`finalized`, none for pinned)
+    SSZ_LIST("tag_proof_branch", ssz_bytes32, 256),     // multi proof of the tag_proof leaf (timestamp) to the anchor's bodyRoot
     SSZ_LIST("blocks", ETH_COMPLETENESS_BLOCK, 4096),   // per-block payload ascending fromBlock..toBlock
 };
 static const ssz_def_t ETH_LOGS_COMPLETENESS_PROOF_CONTAINER = SSZ_CONTAINER("LogsCompletenessProof", ETH_LOGS_COMPLETENESS_PROOF);

--- a/src/chains/eth/ssz/verify_proof_types.h
+++ b/src/chains/eth/ssz/verify_proof_types.h
@@ -811,3 +811,72 @@ static const ssz_def_t ETH_HYBRID_BLOCK_PROOF[] = {
 static const ssz_def_t ETH_HYBRID_BLOCK_HEADER_PROOF[] = {
     SSZ_CONTAINER("header_data", ETH_BLOCK_HEADER_DATA),
 };
+
+// :: Logs Completeness Proof
+//
+// A **Logs Completeness Proof** proves for a contiguous range of execution blocks
+// `[fromBlock, toBlock]` that **no** matching log for the `eth_getLogs` filter was
+// omitted. The normal Logs Proof only proves inclusion of the returned logs; this
+// proof additionally guarantees completeness.
+//
+// **Continuity.** A single signed anchor header (the beacon block of `toBlock`) plus a
+// parent_root chain of `ProofHeader`s down to `fromBlock`. Because the execution-layer
+// `blockNumber` increments by exactly 1 per non-empty beacon block, an unbroken
+// parent_root chain together with a gap-free `blockNumber` sequence `fromBlock..toBlock`
+// guarantees that no block was skipped. Only one sync-committee BLS signature (over the
+// anchor) is required.
+//
+// **Per block** one of two variants (covers the three scenarios of issue #128):
+//   - `BloomNegative`: `blockNumber` + `logsBloom` are proven via a multi-merkle proof
+//     against the block's `bodyRoot`. The verifier computes the query bloom(s) from the
+//     filter and asserts that none is a bit-subset of the block's `logsBloom`, hence no
+//     matching log can exist in this block.
+//   - `FullReceipts`: `blockNumber` + `blockHash` + `receiptsRoot` (and the matching
+//     transactions) are proven; all RLP receipts are delivered so the verifier rebuilds
+//     the receipts trie, compares it to the proven `receiptsRoot`, and filters the logs
+//     locally. An empty match set corresponds to scenario 2, a non-empty one to
+//     scenario 3 (the raw transactions provide the transaction hashes).
+
+// A slim transaction entry (raw payload + index) used to reconstruct transaction hashes
+// for matched logs; the transaction is bound to the block via the block's multi proof.
+static const ssz_def_t ETH_COMPLETENESS_TX[] = {
+    SSZ_BYTES("transaction", 1073741824), // the raw transaction payload
+    SSZ_UINT32("transactionIndex"),       // the index of the transaction in the block
+};
+static const ssz_def_t ETH_COMPLETENESS_TX_CONTAINER = SSZ_CONTAINER("CompletenessTx", ETH_COMPLETENESS_TX);
+
+// Bloom-negative block: proves that the query bloom is not a subset of the block's logsBloom.
+static const ssz_def_t ETH_COMPLETENESS_BLOOM_NEGATIVE[] = {
+    SSZ_UINT64("blockNumber"),         // the execution block number
+    SSZ_BYTE_VECTOR("logsBloom", 256), // the block's logsBloom (execution payload)
+    SSZ_LIST("proof", ssz_bytes32, 256), // multi proof of blockNumber + logsBloom to bodyRoot
+};
+
+// Full-receipts block: all receipts are delivered so the verifier rebuilds the receipts trie.
+static const ssz_def_t ETH_COMPLETENESS_FULL_RECEIPTS[] = {
+    SSZ_UINT64("blockNumber"),                            // the execution block number
+    SSZ_BYTES32("blockHash"),                             // the execution block hash (for reconstructed log entries)
+    SSZ_LIST("receipts", ssz_bytes_list, 65536),         // all RLP-serialized receipts of the block
+    SSZ_LIST("txs", ETH_COMPLETENESS_TX_CONTAINER, 256), // raw transactions of the matching logs (for transactionHash)
+    SSZ_LIST("proof", ssz_bytes32, 1024),                // multi proof of blockNumber + blockHash + receiptsRoot + matched transactions to bodyRoot
+};
+
+// Per-block union: a block is either proven bloom-negative or delivered with all receipts.
+static const ssz_def_t ETH_COMPLETENESS_BLOCK_UNION[] = {
+    SSZ_NONE,
+    SSZ_CONTAINER("BloomNegative", ETH_COMPLETENESS_BLOOM_NEGATIVE), // 1: no matching log possible (bloom check)
+    SSZ_CONTAINER("FullReceipts", ETH_COMPLETENESS_FULL_RECEIPTS),   // 2: all receipts delivered, filtered locally
+};
+static const ssz_def_t ETH_COMPLETENESS_BLOCK = SSZ_UNION("block", ETH_COMPLETENESS_BLOCK_UNION);
+
+// The main proof data for a logs completeness proof over a contiguous block range.
+static const ssz_def_t ETH_LOGS_COMPLETENESS_PROOF[] = {
+    SSZ_UINT64("fromBlock"),                            // first execution block of the range (inclusive)
+    SSZ_UINT64("toBlock"),                              // last execution block of the range (inclusive), == anchor block
+    SSZ_CONTAINER("header", BEACON_BLOCK_HEADER),       // full beacon header of fromBlock (oldest; parentRoot anchors the chain)
+    SSZ_LIST("headers", PROOF_HEADER_CONTAINER, 4096),  // ProofHeaders ascending fromBlock+1..toBlock (last == signed anchor)
+    SSZ_BIT_VECTOR("sync_committee_bits", 512),         // the bits of the validators that signed the anchor
+    SSZ_BYTE_VECTOR("sync_committee_signature", 96),    // the sync committee signature over the anchor root
+    SSZ_LIST("blocks", ETH_COMPLETENESS_BLOCK, 4096),   // per-block payload ascending fromBlock..toBlock
+};
+static const ssz_def_t ETH_LOGS_COMPLETENESS_PROOF_CONTAINER = SSZ_CONTAINER("LogsCompletenessProof", ETH_LOGS_COMPLETENESS_PROOF);

--- a/src/chains/eth/ssz/verify_types.c
+++ b/src/chains/eth/ssz/verify_types.c
@@ -99,6 +99,7 @@ static const ssz_def_t C4_REQUEST_PROOFS_UNION[] = {
     SSZ_CONTAINER("HybridBlockProof", ETH_HYBRID_BLOCK_PROOF),             // 17: Hybrid block proof (EP only)
     SSZ_CONTAINER("HybridBlockHeaderProof", ETH_HYBRID_BLOCK_HEADER_PROOF), // 18: Hybrid block header/number proof (header_data only)
     SSZ_CONTAINER("HybridBlockReceiptsProof", ETH_HYBRID_BLOCK_RECEIPTS_PROOF), // 19: Hybrid block receipts proof (header_data only)
+    SSZ_CONTAINER("LogsCompletenessProof", ETH_LOGS_COMPLETENESS_PROOF), // 20: Completeness proof for eth_getLogs over a contiguous block range
 };
 
 // A List of possible types of sync data used to update the sync state by verifying the transition from the last period to the required.
@@ -298,6 +299,8 @@ const ssz_def_t* eth_ssz_verification_type(eth_ssz_type_t type) {
       return ARRAY_TYPE(C4_REQUEST_PROOFS_UNION, ETH_HYBRID_BLOCK_HEADER_PROOF);
     case ETH_SSZ_VERIFY_HYBRID_BLOCK_RECEIPTS_PROOF:
       return ARRAY_TYPE(C4_REQUEST_PROOFS_UNION, ETH_HYBRID_BLOCK_RECEIPTS_PROOF);
+    case ETH_SSZ_VERIFY_LOGS_COMPLETENESS_PROOF:
+      return ARRAY_TYPE(C4_REQUEST_PROOFS_UNION, ETH_LOGS_COMPLETENESS_PROOF);
     case ETH_SSZ_VERIFY_CHECKPOINT_PROOF:
       return ARRAY_TYPE(ETH_HEADER_PROOFS_UNION, ETH_CHECKPOINT_PROOF);
     case ETH_SSZ_VERIFY_LC_SYNCDATA:

--- a/src/chains/eth/verifier/eth_bloom.c
+++ b/src/chains/eth/verifier/eth_bloom.c
@@ -124,6 +124,44 @@ static int build_bloom_variants(bytes_t addresses, bytes_t topics[C4_ETH_LOG_MAX
   return total;
 }
 
+bytes_t c4_eth_filter_query_blooms(json_t filter) {
+  json_t bloom_filter = json_get(filter, "bloomFilter");
+  if (bloom_filter.type == JSON_TYPE_ARRAY) {
+    buffer_t out = {0};
+    uint8_t  tmp[256];
+    buffer_t b = stack_buffer(tmp);
+    json_for_each_value(bloom_filter, entry) {
+      bytes_t v = json_as_bytes(entry, &b);
+      if (v.len != BLOOM_BYTE_LENGTH) {
+        buffer_free(&out);
+        return NULL_BYTES; // malformed PAP bloom -> cannot decide negativity
+      }
+      buffer_append(&out, v);
+    }
+    return out.data;
+  }
+  return c4_eth_create_bloomfilter(filter);
+}
+
+bool c4_eth_bloom_negative(bytes_t query_blooms, bytes_t block_bloom) {
+  if (block_bloom.len != BLOOM_BYTE_LENGTH) return false;
+  uint32_t variant_count = query_blooms.len / BLOOM_BYTE_LENGTH;
+  if (variant_count == 0) return false; // no variants -> cannot prove absence
+
+  for (uint32_t v = 0; v < variant_count; v++) {
+    const uint8_t* q         = query_blooms.data + (size_t) v * BLOOM_BYTE_LENGTH;
+    bool           is_subset = true;
+    for (uint32_t i = 0; i < BLOOM_BYTE_LENGTH; i++) {
+      if (q[i] & (uint8_t) ~block_bloom.data[i]) {
+        is_subset = false; // a required bit is missing in the block bloom
+        break;
+      }
+    }
+    if (is_subset) return false; // this variant might match -> not bloom-negative
+  }
+  return true; // no variant can match -> provably no matching log
+}
+
 bytes_t c4_eth_create_bloomfilter(json_t filter) {
   bytes_t result                                  = {0};
   bytes_t addresses                               = {0};
@@ -140,8 +178,6 @@ bytes_t c4_eth_create_bloomfilter(json_t filter) {
   for (int i = 0; i < C4_ETH_LOG_MAX_TOPICS; i++) safe_free(topics[i].data);
   return result;
 }
-
-#ifdef PAP
 
 static bool log_address_matches(bytes_t filter_addresses, bytes_t log_address) {
   if (filter_addresses.len == 0) return true;
@@ -198,5 +234,3 @@ ssz_ob_t c4_eth_filter_logs(ssz_ob_t logs, json_t filter) {
 
   return ssz_builder_to_bytes(&builder);
 }
-
-#endif // PAP

--- a/src/chains/eth/verifier/eth_bloom.c
+++ b/src/chains/eth/verifier/eth_bloom.c
@@ -150,9 +150,18 @@ bool c4_eth_bloom_negative(bytes_t query_blooms, bytes_t block_bloom) {
 
   for (uint32_t v = 0; v < variant_count; v++) {
     const uint8_t* q         = query_blooms.data + (size_t) v * BLOOM_BYTE_LENGTH;
+    const uint8_t* b         = block_bloom.data;
     bool           is_subset = true;
-    for (uint32_t i = 0; i < BLOOM_BYTE_LENGTH; i++) {
-      if (q[i] & (uint8_t) ~block_bloom.data[i]) {
+    // Compare 8 bytes per step (BLOOM_BYTE_LENGTH is a multiple of 8): the variant
+    // is a subset iff no required bit is missing in the block bloom, i.e. (q & ~b) == 0
+    // for every word. Endianness is irrelevant since we only test whether any word has
+    // a bit set in q but not in b. memcpy avoids unaligned reads and is lowered to a
+    // single load by the compiler.
+    for (uint32_t i = 0; i < BLOOM_BYTE_LENGTH; i += 8) {
+      uint64_t qi, bi;
+      memcpy(&qi, q + i, sizeof(qi));
+      memcpy(&bi, b + i, sizeof(bi));
+      if (qi & ~bi) {
         is_subset = false; // a required bit is missing in the block bloom
         break;
       }

--- a/src/chains/eth/verifier/eth_bloom.h
+++ b/src/chains/eth/verifier/eth_bloom.h
@@ -29,6 +29,35 @@ extern "C" {
 bytes_t c4_eth_create_bloomfilter(json_t filter);
 
 /**
+ * Computes the query bloom variants for an `eth_getLogs` filter, transparently
+ * supporting both plain and PAP (Pragmatic Adaptive Privacy) filters.
+ *
+ * If the filter contains a `bloomFilter` array (PAP mode), its hex-encoded
+ * 256-byte entries are concatenated directly. Otherwise the variants are derived
+ * from `address` and `topics` via `c4_eth_create_bloomfilter`.
+ *
+ * @param filter JSON filter object (`address`/`topics` or `bloomFilter`).
+ * @return Concatenated 256-byte blooms (`n * 256` bytes). Caller must free.
+ *         Returns `NULL_BYTES` if no variants can be derived.
+ */
+bytes_t c4_eth_filter_query_blooms(json_t filter);
+
+/**
+ * Decides whether a block can be proven to contain no matching log by bloom alone.
+ *
+ * A block is bloom-negative when none of the query bloom variants is a bit-subset
+ * of the block's `logsBloom`: if any required bit is missing from the block bloom,
+ * no matching log can exist. If there are no variants or the block bloom has an
+ * unexpected length, the function conservatively returns `false` (a full receipts
+ * check is required).
+ *
+ * @param query_blooms Concatenated 256-byte query bloom variants (`n * 256` bytes).
+ * @param block_bloom The block's `logsBloom` (must be 256 bytes).
+ * @return `true` if the block provably contains no matching log, `false` otherwise.
+ */
+bool c4_eth_bloom_negative(bytes_t query_blooms, bytes_t block_bloom);
+
+/**
  * Parses address filter(s) from JSON into a flat byte buffer.
  *
  * Handles a single hex address string or an array of hex address strings.
@@ -50,7 +79,6 @@ void c4_eth_parse_filter_addresses(json_t address_json, bytes_t* out_addresses);
  */
 void c4_eth_parse_filter_topics(json_t topics_json, bytes_t out_topics[C4_ETH_LOG_MAX_TOPICS]);
 
-#ifdef PAP
 /**
  * Filters an SSZ log list, keeping only entries matching address and topic criteria.
  *
@@ -63,7 +91,6 @@ void c4_eth_parse_filter_topics(json_t topics_json, bytes_t out_topics[C4_ETH_LO
  * @return New SSZ list with matching logs. Caller must free `bytes.data`.
  */
 ssz_ob_t c4_eth_filter_logs(ssz_ob_t logs, json_t filter);
-#endif
 
 #ifdef __cplusplus
 }

--- a/src/chains/eth/verifier/eth_tx.h
+++ b/src/chains/eth/verifier/eth_tx.h
@@ -37,6 +37,7 @@ extern "C" {
 // power-of-two boundary; if a future fork changes the layout, all the
 // constants below must be revisited together.
 #define GINDEX_RECEIPT_ROOT 803
+#define GINDEX_LOGS_BLOOM   804
 #define GINDEX_BLOCKUMBER   806
 #define GINDEX_TIMESTAMP    809
 #define GINDEX_BLOCHASH     812

--- a/src/chains/eth/verifier/eth_verify.c
+++ b/src/chains/eth/verifier/eth_verify.c
@@ -329,9 +329,18 @@ bool c4_eth_verify(verify_ctx_t* ctx) {
   else
 #endif
 #ifdef ETH_LOGS
-      if (ssz_is_type(&ctx->proof, eth_ssz_verification_type(ETH_SSZ_VERIFY_LOGS_PROOF)) ||
-          ssz_is_type(&ctx->proof, eth_ssz_verification_type(ETH_SSZ_VERIFY_HYBRID_LOGS_PROOF)))
-    verify_logs_proof(ctx);
+      if (ssz_is_type(&ctx->proof, eth_ssz_verification_type(ETH_SSZ_VERIFY_LOGS_COMPLETENESS_PROOF)))
+    verify_logs_completeness(ctx);
+  else if (ssz_is_type(&ctx->proof, eth_ssz_verification_type(ETH_SSZ_VERIFY_LOGS_PROOF)) ||
+           ssz_is_type(&ctx->proof, eth_ssz_verification_type(ETH_SSZ_VERIFY_HYBRID_LOGS_PROOF))) {
+    // When completeness is required, a plain (per-log) logs proof is not sufficient.
+    if (ctx->flags & VERIFY_FLAG_LOGS_COMPLETENESS) {
+      ctx->state.error = strdup("logs completeness required, but the proof is a plain logs proof");
+      ctx->success     = false;
+    }
+    else
+      verify_logs_proof(ctx);
+  }
   else
 #endif
 #ifdef ETH_ACCOUNT

--- a/src/chains/eth/verifier/eth_verify.h
+++ b/src/chains/eth/verifier/eth_verify.h
@@ -33,6 +33,7 @@ bool verify_hybrid_account_proof(verify_ctx_t* ctx);
 bool verify_tx_proof(verify_ctx_t* ctx);
 bool verify_receipt_proof(verify_ctx_t* ctx);
 bool verify_logs_proof(verify_ctx_t* ctx);
+bool verify_logs_completeness(verify_ctx_t* ctx);
 bool verify_call_proof(verify_ctx_t* ctx);
 bool verify_block_proof(verify_ctx_t* ctx);
 bool verify_block_number_proof(verify_ctx_t* ctx);

--- a/src/chains/eth/verifier/verify_logs_completeness.c
+++ b/src/chains/eth/verifier/verify_logs_completeness.c
@@ -42,33 +42,36 @@
 // SSZ list capacity (4096) and caps allocation before the (untrusted) range is otherwise validated.
 #define VERIFY_LOGS_COMPLETENESS_MAX_BLOCKS 4096
 
-// Verifies the parent_root header chain and the anchor's sync committee signature.
-// Fills body_roots[0..count-1] with the bodyRoot of each in-range block (ascending).
-static c4_status_t verify_chain(verify_ctx_t* ctx, ssz_ob_t header, ssz_ob_t headers, ssz_ob_t bits, ssz_ob_t sig, bytes32_t* body_roots, uint32_t count) {
-  uint32_t  header_count      = ssz_len(headers);
-  uint8_t   header_bytes[112] = {0};
-  bytes32_t last_block_root   = {0};
-  ssz_ob_t  header_ob         = {.bytes = bytes(header_bytes, sizeof(header_bytes)), .def = eth_ssz_type_for_denep(ETH_SSZ_BEACON_BLOCK_HEADER, C4_CHAIN_MAINNET)};
+// Reconstructs the ascending parentRoot header chain (oldest `header` -> anchor) without verifying
+// the anchor's canonicity (that is done separately via the shared `header_proof` union).
+// Fills body_roots[0..count-1] with the bodyRoot of each in-range block (ascending) and writes the
+// reconstructed anchor (the newest header) into `anchor_bytes`/`*anchor_out`.
+static c4_status_t reconstruct_chain(verify_ctx_t* ctx, ssz_ob_t header, ssz_ob_t headers,
+                                     bytes32_t* body_roots, uint32_t count,
+                                     uint8_t anchor_bytes[112], ssz_ob_t* anchor_out) {
+  uint32_t  header_count    = ssz_len(headers);
+  bytes32_t last_block_root = {0};
+  ssz_ob_t  header_ob       = {.bytes = bytes(anchor_bytes, 112), .def = eth_ssz_type_for_denep(ETH_SSZ_BEACON_BLOCK_HEADER, C4_CHAIN_MAINNET)};
 
   if (header_count != count - 1) THROW_ERROR("completeness proof header chain length mismatch!");
 
-  // bodyRoot of fromBlock comes from the full header
+  // bodyRoot of the oldest block comes from the full header
   memcpy(body_roots[0], ssz_get(&header, "bodyRoot").bytes.data, 32);
   ssz_hash_tree_root(header, last_block_root);
 
-  // walk the parent_root chain from fromBlock+1 up to the anchor (toBlock)
+  // walk the parent_root chain from the oldest+1 up to the anchor (newest)
   for (uint32_t i = 0; i < header_count; i++) {
     ssz_ob_t h = ssz_at(headers, i);
-    memcpy(header_bytes, h.bytes.data, 16);           // slot and proposerIndex
-    memcpy(header_bytes + 16, last_block_root, 32);   // parentRoot = previous block root
-    memcpy(header_bytes + 48, h.bytes.data + 16, 64); // stateRoot and bodyRoot
+    memcpy(anchor_bytes, h.bytes.data, 16);           // slot and proposerIndex
+    memcpy(anchor_bytes + 16, last_block_root, 32);   // parentRoot = previous block root
+    memcpy(anchor_bytes + 48, h.bytes.data + 16, 64); // stateRoot and bodyRoot
     ssz_hash_tree_root(header_ob, last_block_root);
     memcpy(body_roots[i + 1], h.bytes.data + 48, 32); // bodyRoot of this block
   }
 
-  // verify the sync committee signature over the anchor (last header, or the full header for a single-block range)
-  ssz_ob_t anchor = header_count ? header_ob : header;
-  return c4_verify_blockroot_signature(ctx, &anchor, &bits, &sig, 0, NULL);
+  // the anchor is the last reconstructed header, or the full header for a single-block range
+  *anchor_out = header_count ? header_ob : header;
+  return C4_SUCCESS;
 }
 
 static bool verify_negative_block(verify_ctx_t* ctx, ssz_ob_t block, bytes32_t body_root, bytes_t query_blooms) {
@@ -245,53 +248,108 @@ static bool bind_range_endpoint(verify_ctx_t* ctx, json_t tag, uint64_t proof_va
   return proof_value == anchor_value; // "latest"/"safe"/"finalized"
 }
 
+// Verifies the anchor `tag_proof` (ETH_STATE_BLOCK_UNION) and runs the `latest` freshness gate.
+//   - `timestamp` variant: the anchor's execution timestamp is proven against its bodyRoot via
+//     `tag_proof_branch`; the proven value feeds `eth_check_latest_freshness`.
+//   - `checkpoint_proof` variant (`safe`/`finalized`): structurally prepared but not verified yet.
+//   - `none` variant (pinned block): no timestamp -> the gate fails closed if the host demanded
+//     freshness for an open-ended tag.
+//
+// `safe`/`finalized` bind the range endpoint to the beacon checkpoint, which requires the (not yet
+// implemented) `checkpoint_proof` variant. Until then these tags are rejected fail-closed: accepting
+// the `timestamp` variant for them would let a prover anchor at an arbitrary older canonical block
+// (no freshness enforced for non-`latest` tags) and silently omit newer logs.
+static bool verify_tag_proof_freshness(verify_ctx_t* ctx, ssz_ob_t proof, json_t filter, bytes32_t anchor_body_root) {
+  json_t   to_tag    = json_get(filter, "toBlock");
+  bool     is_latest = to_tag.type == JSON_TYPE_NOT_FOUND || eth_json_is_latest(to_tag);
+  bool     is_pinned = to_tag.type == JSON_TYPE_STRING && to_tag.len > 2 && to_tag.start[1] == '0' && to_tag.start[2] == 'x';
+  if (!is_latest && !is_pinned)
+    RETURN_VERIFY_ERROR(ctx, "toBlock tag not yet supported for completeness (only a pinned block or 'latest')");
+
+  ssz_ob_t tag       = ssz_get(&proof, "tag_proof");
+  bool     is_ts     = tag.def == eth_ssz_verification_type(ETH_SSZ_DATA_STATE_BLOCK_TIMESTAMP);
+  uint64_t anchor_ts = 0;
+
+  if (is_ts) {
+    ssz_ob_t  branch    = ssz_get(&proof, "tag_proof_branch");
+    gindex_t  gindex[1] = {GINDEX_TIMESTAMP};
+    uint8_t   leaf[32]  = {0};
+    bytes32_t root      = {0};
+    if (tag.bytes.len >= 8) memcpy(leaf, tag.bytes.data, 8); // uint64 leaf: 8 bytes LE, zero-padded to 32
+    if (!ssz_verify_multi_merkle_proof(branch.bytes, bytes(leaf, 32), gindex, root))
+      RETURN_VERIFY_ERROR(ctx, "invalid tag_proof, missing nodes!");
+    if (memcmp(root, anchor_body_root, 32) != 0)
+      RETURN_VERIFY_ERROR(ctx, "invalid tag_proof, anchor body root mismatch!");
+    anchor_ts = ssz_uint64(tag);
+  }
+  else if (tag.def && tag.def->name && strcmp(tag.def->name, "checkpoint_proof") == 0)
+    RETURN_VERIFY_ERROR(ctx, "checkpoint tag_proof not yet supported for completeness");
+  else if (tag.def && tag.def->type != SSZ_TYPE_NONE)
+    RETURN_VERIFY_ERROR(ctx, "unexpected tag_proof variant in completeness proof!");
+
+  return eth_check_latest_freshness(ctx, is_latest, is_ts, anchor_ts);
+}
+
 bool verify_logs_completeness(verify_ctx_t* ctx) {
   ssz_ob_t proof   = ctx->proof;
-  uint64_t from    = ssz_get_uint64(&proof, "fromBlock");
-  uint64_t to      = ssz_get_uint64(&proof, "toBlock");
   ssz_ob_t header  = ssz_get(&proof, "header");
   ssz_ob_t headers = ssz_get(&proof, "headers");
-  ssz_ob_t bits    = ssz_get(&proof, "sync_committee_bits");
-  ssz_ob_t sig     = ssz_get(&proof, "sync_committee_signature");
   ssz_ob_t blocks  = ssz_get(&proof, "blocks");
 
-  if (to < from) RETURN_VERIFY_ERROR(ctx, "invalid completeness range (toBlock < fromBlock)!");
-  uint64_t count = to - from + 1;
+  // The claim is the requested range (from the RPC request); the proof carries no range endpoints.
+  // The block count is derived from the (proven) parentRoot chain length.
+  uint64_t count = (uint64_t) ssz_len(headers) + 1;
   // Hard upper bound before any allocation: the SSZ list caps at 4096, but lists of dynamic (union)
   // elements are not length-checked by ssz_is_valid, so reject oversized ranges up front (DoS guard).
   if (count > VERIFY_LOGS_COMPLETENESS_MAX_BLOCKS) RETURN_VERIFY_ERROR(ctx, "completeness range too large!");
 
-  // Bind the proven range to the range the client actually asked for (see bind_range_endpoint).
-  // Without this a malicious prover could shrink the range and still produce a valid-looking proof.
   json_t filter = json_at(ctx->args, 0);
   if (filter.type != JSON_TYPE_OBJECT) RETURN_VERIFY_ERROR(ctx, "eth_getLogs completeness requires a filter object!");
-  if (!bind_range_endpoint(ctx, json_get(filter, "fromBlock"), from, to)) return false;
-  if (!bind_range_endpoint(ctx, json_get(filter, "toBlock"), to, to)) return false;
 
   if ((uint64_t) ssz_len(blocks) != count) RETURN_VERIFY_ERROR(ctx, "completeness proof block count mismatch!");
 
-  bytes32_t*  body_roots = safe_calloc((size_t) count, sizeof(bytes32_t));
-  c4_status_t chain      = verify_chain(ctx, header, headers, bits, sig, body_roots, (uint32_t) count);
-  if (chain != C4_SUCCESS) {
-    // C4_PENDING (need sync committee) and C4_ERROR both propagate via ctx->state.
+  // reconstruct the parentRoot chain -> per-block bodyRoots + the reconstructed anchor (newest) header
+  bytes32_t* body_roots       = safe_calloc((size_t) count, sizeof(bytes32_t));
+  uint8_t    anchor_bytes[112] = {0};
+  ssz_ob_t   anchor           = {0};
+  if (reconstruct_chain(ctx, header, headers, body_roots, (uint32_t) count, anchor_bytes, &anchor) != C4_SUCCESS) {
+    safe_free(body_roots);
+    return false;
+  }
+
+  // Anchor the chain via the shared header_proof union (signature / header-chain / historic summaries),
+  // exactly like every other proof type. May return C4_PENDING (need sync committee) or C4_ERROR;
+  // both propagate to the caller via ctx->state.
+  if (c4_verify_header(ctx, anchor, proof) != C4_SUCCESS) {
     safe_free(body_roots);
     return false;
   }
 
   bytes_t query_blooms = c4_eth_filter_query_blooms(filter);
 
-  const ssz_def_t* logs_def     = eth_ssz_verification_type(ETH_SSZ_DATA_LOGS);
-  ssz_builder_t    data_builder = ssz_builder_for_def(logs_def);
-  uint32_t         log_count    = 0;
-  bool             success      = true;
+  const ssz_def_t* logs_def         = eth_ssz_verification_type(ETH_SSZ_DATA_LOGS);
+  ssz_builder_t    data_builder     = ssz_builder_for_def(logs_def);
+  uint32_t         log_count        = 0;
+  uint64_t         from_num         = 0;
+  uint64_t         to_num           = 0;
+  bytes32_t        anchor_body_root = {0};
+  bool             success          = true;
 
   for (uint64_t i = 0; i < count; i++) {
     ssz_ob_t union_ob = ssz_at(blocks, (uint32_t) i);
     ssz_ob_t block    = ssz_union(union_ob);
     if (!block.def) { success = false; break; }
 
-    // the gap-free blockNumber sequence together with the parent_root chain rules out skipped blocks
-    if (ssz_get_uint64(&block, "blockNumber") != from + i) { success = false; break; }
+    // blockNumber is bound to this block's bodyRoot by the per-block multi proof, so from_num/to_num
+    // become cryptographically trusted once the block is verified.
+    uint64_t bn = ssz_get_uint64(&block, "blockNumber");
+    if (i == 0) from_num = bn;
+    // the gap-free blockNumber sequence together with the parentRoot chain rules out skipped blocks
+    if (bn != from_num + i) { success = false; break; }
+    if (i + 1 == count) {
+      to_num = bn;
+      memcpy(anchor_body_root, body_roots[i], 32); // keep the anchor bodyRoot for the tag_proof below
+    }
 
     if (strcmp(block.def->name, "FullReceipts") == 0) {
       if (!verify_full_block(ctx, block, body_roots[i], &data_builder, query_blooms, &log_count)) { success = false; break; }
@@ -307,6 +365,19 @@ bool verify_logs_completeness(verify_ctx_t* ctx) {
 
   safe_free(body_roots);
   safe_free(query_blooms.data);
+
+  // Bind the proven range (now cryptographically established via the bodyRoots) to the range the
+  // client actually requested (see bind_range_endpoint). Without this a malicious prover could
+  // shrink the range and still produce a valid-looking proof.
+  if (success &&
+      (!bind_range_endpoint(ctx, json_get(filter, "fromBlock"), from_num, to_num) ||
+       !bind_range_endpoint(ctx, json_get(filter, "toBlock"), to_num, to_num)))
+    success = false;
+
+  // Freshness gate for an open-ended `toBlock` (absent -> defaults to "latest"): the anchor is only
+  // proven canonical, not recent, so a stale-but-signed anchor could otherwise omit recent logs. The
+  // anchor's block-tag is proven via the shared ETH_STATE_BLOCK_UNION (`tag_proof`).
+  if (success && !verify_tag_proof_freshness(ctx, proof, filter, anchor_body_root)) success = false;
 
   if (!success) {
     safe_free(data_builder.fixed.data.data);

--- a/src/chains/eth/verifier/verify_logs_completeness.c
+++ b/src/chains/eth/verifier/verify_logs_completeness.c
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) 2025 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "beacon_types.h"
+#include "bytes.h"
+#include "crypto.h"
+#include "eth_account.h"
+#include "eth_bloom.h"
+#include "eth_tx.h"
+#include "eth_verify.h"
+#include "json.h"
+#include "patricia.h"
+#include "rlp.h"
+#include "ssz.h"
+#include "sync_committee.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Hard upper bound on the number of blocks a single completeness proof may span. This matches the
+// SSZ list capacity (4096) and caps allocation before the (untrusted) range is otherwise validated.
+#define VERIFY_LOGS_COMPLETENESS_MAX_BLOCKS 4096
+
+// Verifies the parent_root header chain and the anchor's sync committee signature.
+// Fills body_roots[0..count-1] with the bodyRoot of each in-range block (ascending).
+static c4_status_t verify_chain(verify_ctx_t* ctx, ssz_ob_t header, ssz_ob_t headers, ssz_ob_t bits, ssz_ob_t sig, bytes32_t* body_roots, uint32_t count) {
+  uint32_t  header_count      = ssz_len(headers);
+  uint8_t   header_bytes[112] = {0};
+  bytes32_t last_block_root   = {0};
+  ssz_ob_t  header_ob         = {.bytes = bytes(header_bytes, sizeof(header_bytes)), .def = eth_ssz_type_for_denep(ETH_SSZ_BEACON_BLOCK_HEADER, C4_CHAIN_MAINNET)};
+
+  if (header_count != count - 1) THROW_ERROR("completeness proof header chain length mismatch!");
+
+  // bodyRoot of fromBlock comes from the full header
+  memcpy(body_roots[0], ssz_get(&header, "bodyRoot").bytes.data, 32);
+  ssz_hash_tree_root(header, last_block_root);
+
+  // walk the parent_root chain from fromBlock+1 up to the anchor (toBlock)
+  for (uint32_t i = 0; i < header_count; i++) {
+    ssz_ob_t h = ssz_at(headers, i);
+    memcpy(header_bytes, h.bytes.data, 16);           // slot and proposerIndex
+    memcpy(header_bytes + 16, last_block_root, 32);   // parentRoot = previous block root
+    memcpy(header_bytes + 48, h.bytes.data + 16, 64); // stateRoot and bodyRoot
+    ssz_hash_tree_root(header_ob, last_block_root);
+    memcpy(body_roots[i + 1], h.bytes.data + 48, 32); // bodyRoot of this block
+  }
+
+  // verify the sync committee signature over the anchor (last header, or the full header for a single-block range)
+  ssz_ob_t anchor = header_count ? header_ob : header;
+  return c4_verify_blockroot_signature(ctx, &anchor, &bits, &sig, 0, NULL);
+}
+
+static bool verify_negative_block(verify_ctx_t* ctx, ssz_ob_t block, bytes32_t body_root, bytes_t query_blooms) {
+  bytes_t   block_number = ssz_get(&block, "blockNumber").bytes;
+  bytes_t   logs_bloom   = ssz_get(&block, "logsBloom").bytes;
+  ssz_ob_t  proof        = ssz_get(&block, "proof");
+  uint8_t   leafes[64]   = {0};
+  gindex_t  gindexes[2]  = {GINDEX_BLOCKUMBER, GINDEX_LOGS_BLOOM};
+  bytes32_t root_hash    = {0};
+
+  if (logs_bloom.len != 256) RETURN_VERIFY_ERROR(ctx, "invalid logsBloom in completeness proof!");
+  memcpy(leafes, block_number.data, block_number.len);
+  // logsBloom is a 256-byte vector -> its leaf is the hash_tree_root of the vector, not the raw bytes.
+  ssz_hash_tree_root(ssz_get(&block, "logsBloom"), leafes + 32);
+
+  if (!ssz_verify_multi_merkle_proof(proof.bytes, bytes(leafes, sizeof(leafes)), gindexes, root_hash))
+    RETURN_VERIFY_ERROR(ctx, "invalid bloom-negative proof, missing nodes!");
+  if (memcmp(root_hash, body_root, 32) != 0)
+    RETURN_VERIFY_ERROR(ctx, "invalid bloom-negative proof, body root mismatch!");
+
+  // Independently re-check the negativity claim against the proven logsBloom.
+  if (!c4_eth_bloom_negative(query_blooms, logs_bloom))
+    RETURN_VERIFY_ERROR(ctx, "block claimed bloom-negative but query bloom is a subset of logsBloom!");
+  return true;
+}
+
+// Finds the raw transaction for the given index in the block's matched-tx list.
+static bytes_t find_tx_raw(ssz_ob_t txs, uint32_t tx_index) {
+  uint32_t n = ssz_len(txs);
+  for (uint32_t i = 0; i < n; i++) {
+    ssz_ob_t tx = ssz_at(txs, i);
+    if (ssz_get_uint64(&tx, "transactionIndex") == tx_index)
+      return ssz_get(&tx, "transaction").bytes;
+  }
+  return NULL_BYTES;
+}
+
+// Rebuilds the receipts trie, verifies the multi proof and appends the logs of every
+// bloom-positive receipt to `data_builder`. The final exact filtering is done once for the
+// whole range in `verify_logs_completeness`. `out_count` is incremented per appended log.
+static bool verify_full_block(verify_ctx_t* ctx, ssz_ob_t block, bytes32_t body_root,
+                              ssz_builder_t* data_builder, bytes_t query_blooms, uint32_t* out_count) {
+  bytes_t  block_number = ssz_get(&block, "blockNumber").bytes;
+  bytes_t  block_hash   = ssz_get(&block, "blockHash").bytes;
+  ssz_ob_t receipts     = ssz_get(&block, "receipts");
+  ssz_ob_t txs          = ssz_get(&block, "txs");
+  ssz_ob_t proof        = ssz_get(&block, "proof");
+  uint32_t num_receipts = ssz_len(receipts);
+  uint32_t num_txs      = ssz_len(txs);
+  uint64_t blk_num      = ssz_get_uint64(&block, "blockNumber");
+
+  // rebuild the receipts Patricia trie and compute the receiptsRoot
+  node_t*   trie_root    = NULL;
+  bytes32_t tmp          = {0};
+  buffer_t  path_buf     = stack_buffer(tmp);
+  bytes32_t receipt_root = {0};
+  for (uint32_t i = 0; i < num_receipts; i++)
+    patricia_set_value(&trie_root, c4_eth_create_tx_path(i, &path_buf), ssz_at(receipts, i).bytes);
+  if (trie_root) {
+    memcpy(receipt_root, patricia_get_root(trie_root).data, 32);
+    patricia_node_free(trie_root);
+  }
+  else
+    memcpy(receipt_root, EMPTY_ROOT_HASH, 32);
+
+  // verify multi proof: blockNumber, blockHash, receiptsRoot, matched transactions -> bodyRoot
+  uint8_t*  leafes    = safe_calloc(3 + num_txs, 32);
+  gindex_t* gindexes  = safe_calloc(3 + num_txs, sizeof(gindex_t));
+  bytes32_t root_hash = {0};
+  memcpy(leafes, block_number.data, block_number.len);
+  memcpy(leafes + 32, block_hash.data, block_hash.len);
+  memcpy(leafes + 64, receipt_root, 32);
+  gindexes[0] = GINDEX_BLOCKUMBER;
+  gindexes[1] = GINDEX_BLOCHASH;
+  gindexes[2] = GINDEX_RECEIPT_ROOT;
+  for (uint32_t i = 0; i < num_txs; i++) {
+    ssz_ob_t tx = ssz_at(txs, i);
+    ssz_hash_tree_root(ssz_ob(ssz_transactions_bytes, ssz_get(&tx, "transaction").bytes), leafes + 96 + 32 * i);
+    gindexes[3 + i] = GINDEX_TXINDEX_G + ssz_get_uint64(&tx, "transactionIndex");
+  }
+  bool ok = ssz_verify_multi_merkle_proof(proof.bytes, bytes(leafes, (3 + num_txs) * 32), gindexes, root_hash);
+  safe_free(leafes);
+  safe_free(gindexes);
+  if (!ok) RETURN_VERIFY_ERROR(ctx, "invalid full-receipts proof, missing nodes!");
+  if (memcmp(root_hash, body_root, 32) != 0) RETURN_VERIFY_ERROR(ctx, "invalid full-receipts proof, body root mismatch!");
+
+  const ssz_def_t* log_def         = data_builder->def->def.vector.type;
+  uint32_t         block_log_index = 0; // block-wide log index across all receipts
+
+  // walk every receipt in tx order; a matching log can only exist in a bloom-positive receipt,
+  // so the prover legitimately omits transactions of bloom-negative receipts. Independently
+  // re-checking each receipt's (authenticated) logsBloom is what makes the proof complete.
+  for (uint32_t r = 0; r < num_receipts; r++) {
+    bytes_t receipt  = ssz_at(receipts, r).bytes;
+    bytes_t logs_rlp = {0};
+    bytes_t bloom    = {0};
+
+    if (receipt.len && receipt.data[0] < 0x80) { // strip the (optional) EIP-2718 type byte
+      receipt.data++;
+      receipt.len--;
+    }
+    if (rlp_decode(&receipt, 0, &receipt) != RLP_LIST) RETURN_VERIFY_ERROR(ctx, "invalid receipt encoding in completeness proof!");
+    if (rlp_decode(&receipt, 2, &bloom) != RLP_ITEM || bloom.len != 256) RETURN_VERIFY_ERROR(ctx, "invalid receipt logsBloom!");
+    if (rlp_decode(&receipt, 3, &logs_rlp) != RLP_LIST) RETURN_VERIFY_ERROR(ctx, "invalid receipt logs!");
+    int num_logs = rlp_decode(&logs_rlp, -1, &logs_rlp);
+    if (num_logs < 0) num_logs = 0;
+
+    // bloom-negative receipts cannot contain a matching log -> skip, but keep the log index in sync
+    if (c4_eth_bloom_negative(query_blooms, bloom)) {
+      block_log_index += (uint32_t) num_logs;
+      continue;
+    }
+
+    bytes_t raw_tx = find_tx_raw(txs, r);
+    if (!raw_tx.data) RETURN_VERIFY_ERROR(ctx, "bloom-positive receipt without provided transaction (incomplete proof)!");
+    bytes32_t tx_hash = {0};
+    keccak(raw_tx, tx_hash);
+
+    for (int l = 0; l < num_logs; l++, block_log_index++) {
+      bytes_t log_rlp = {0}, addr = {0}, topics_rlp = {0}, data = {0};
+      if (rlp_decode(&logs_rlp, l, &log_rlp) != RLP_LIST) RETURN_VERIFY_ERROR(ctx, "invalid log encoding!");
+      if (rlp_decode(&log_rlp, 0, &addr) != RLP_ITEM) RETURN_VERIFY_ERROR(ctx, "invalid log address!");
+      if (rlp_decode(&log_rlp, 1, &topics_rlp) != RLP_LIST) RETURN_VERIFY_ERROR(ctx, "invalid log topics!");
+      if (rlp_decode(&log_rlp, 2, &data) != RLP_ITEM) RETURN_VERIFY_ERROR(ctx, "invalid log data!");
+      int num_topics = rlp_decode(&topics_rlp, -1, &topics_rlp);
+
+      ssz_builder_t log_builder = ssz_builder_for_def(log_def);
+      ssz_add_bytes(&log_builder, "blockHash", block_hash);
+      ssz_add_uint64(&log_builder, blk_num);
+      ssz_add_bytes(&log_builder, "transactionHash", bytes(tx_hash, 32));
+      ssz_add_uint32(&log_builder, r);
+      uint8_t addr20[20] = {0};
+      if (addr.len <= 20) memcpy(addr20 + (20 - addr.len), addr.data, addr.len);
+      ssz_add_bytes(&log_builder, "address", bytes(addr20, 20));
+      ssz_add_uint32(&log_builder, block_log_index);
+      ssz_add_uint8(&log_builder, 0);
+      ssz_builder_t topics_builder = ssz_builder_for_def(ssz_get_def(log_def, "topics"));
+      for (int t = 0; t < num_topics; t++) {
+        bytes_t topic       = {0};
+        uint8_t topic32[32] = {0};
+        if (rlp_decode(&topics_rlp, t, &topic) != RLP_ITEM) {
+          ssz_builder_free(&topics_builder);
+          ssz_builder_free(&log_builder);
+          RETURN_VERIFY_ERROR(ctx, "invalid topic!");
+        }
+        if (topic.len <= 32) memcpy(topic32 + (32 - topic.len), topic.data, topic.len);
+        ssz_add_dynamic_list_bytes(&topics_builder, num_topics, bytes(topic32, 32));
+      }
+      ssz_add_builders(&log_builder, "topics", topics_builder);
+      ssz_add_bytes(&log_builder, "data", data);
+      ssz_add_dynamic_list_builders(data_builder, 0, log_builder);
+      (*out_count)++;
+    }
+  }
+  return true;
+}
+
+// Binds one endpoint of the proven range to the value requested in the client filter. Without this
+// binding a malicious prover could shrink the range and omit matching logs while still producing a
+// structurally valid proof, defeating the completeness guarantee.
+//
+// - explicit block numbers ("0x..") must match `proof_value` exactly.
+// - "latest"/"safe"/"finalized" (and an absent endpoint, which for `eth_getLogs` defaults to
+//   "latest") accept the signature-anchored `anchor_value`.
+// - "pending"/"earliest" are not provable.
+static bool bind_range_endpoint(verify_ctx_t* ctx, json_t tag, uint64_t proof_value, uint64_t anchor_value) {
+  if (tag.type == JSON_TYPE_NOT_FOUND) return proof_value == anchor_value; // default: "latest"
+  if (tag.type != JSON_TYPE_STRING) RETURN_VERIFY_ERROR(ctx, "invalid block tag in eth_getLogs filter");
+  if (eth_json_is_unproofable_tag(tag)) RETURN_VERIFY_ERROR(ctx, "block tag not provable for completeness");
+  if (tag.len > 2 && tag.start[1] == '0' && tag.start[2] == 'x') { // explicit hex quantity
+    if (json_as_uint64(tag) != proof_value) RETURN_VERIFY_ERROR(ctx, "completeness range does not match requested block range");
+    return true;
+  }
+  return proof_value == anchor_value; // "latest"/"safe"/"finalized"
+}
+
+bool verify_logs_completeness(verify_ctx_t* ctx) {
+  ssz_ob_t proof   = ctx->proof;
+  uint64_t from    = ssz_get_uint64(&proof, "fromBlock");
+  uint64_t to      = ssz_get_uint64(&proof, "toBlock");
+  ssz_ob_t header  = ssz_get(&proof, "header");
+  ssz_ob_t headers = ssz_get(&proof, "headers");
+  ssz_ob_t bits    = ssz_get(&proof, "sync_committee_bits");
+  ssz_ob_t sig     = ssz_get(&proof, "sync_committee_signature");
+  ssz_ob_t blocks  = ssz_get(&proof, "blocks");
+
+  if (to < from) RETURN_VERIFY_ERROR(ctx, "invalid completeness range (toBlock < fromBlock)!");
+  uint64_t count = to - from + 1;
+  // Hard upper bound before any allocation: the SSZ list caps at 4096, but lists of dynamic (union)
+  // elements are not length-checked by ssz_is_valid, so reject oversized ranges up front (DoS guard).
+  if (count > VERIFY_LOGS_COMPLETENESS_MAX_BLOCKS) RETURN_VERIFY_ERROR(ctx, "completeness range too large!");
+
+  // Bind the proven range to the range the client actually asked for (see bind_range_endpoint).
+  // Without this a malicious prover could shrink the range and still produce a valid-looking proof.
+  json_t filter = json_at(ctx->args, 0);
+  if (filter.type != JSON_TYPE_OBJECT) RETURN_VERIFY_ERROR(ctx, "eth_getLogs completeness requires a filter object!");
+  if (!bind_range_endpoint(ctx, json_get(filter, "fromBlock"), from, to)) return false;
+  if (!bind_range_endpoint(ctx, json_get(filter, "toBlock"), to, to)) return false;
+
+  if ((uint64_t) ssz_len(blocks) != count) RETURN_VERIFY_ERROR(ctx, "completeness proof block count mismatch!");
+
+  bytes32_t*  body_roots = safe_calloc((size_t) count, sizeof(bytes32_t));
+  c4_status_t chain      = verify_chain(ctx, header, headers, bits, sig, body_roots, (uint32_t) count);
+  if (chain != C4_SUCCESS) {
+    // C4_PENDING (need sync committee) and C4_ERROR both propagate via ctx->state.
+    safe_free(body_roots);
+    return false;
+  }
+
+  bytes_t query_blooms = c4_eth_filter_query_blooms(filter);
+
+  const ssz_def_t* logs_def     = eth_ssz_verification_type(ETH_SSZ_DATA_LOGS);
+  ssz_builder_t    data_builder = ssz_builder_for_def(logs_def);
+  uint32_t         log_count    = 0;
+  bool             success      = true;
+
+  for (uint64_t i = 0; i < count; i++) {
+    ssz_ob_t union_ob = ssz_at(blocks, (uint32_t) i);
+    ssz_ob_t block    = ssz_union(union_ob);
+    if (!block.def) { success = false; break; }
+
+    // the gap-free blockNumber sequence together with the parent_root chain rules out skipped blocks
+    if (ssz_get_uint64(&block, "blockNumber") != from + i) { success = false; break; }
+
+    if (strcmp(block.def->name, "FullReceipts") == 0) {
+      if (!verify_full_block(ctx, block, body_roots[i], &data_builder, query_blooms, &log_count)) { success = false; break; }
+    }
+    else if (strcmp(block.def->name, "BloomNegative") == 0) {
+      if (!verify_negative_block(ctx, block, body_roots[i], query_blooms)) { success = false; break; }
+    }
+    else {
+      success = false;
+      break;
+    }
+  }
+
+  safe_free(body_roots);
+  safe_free(query_blooms.data);
+
+  if (!success) {
+    safe_free(data_builder.fixed.data.data);
+    safe_free(data_builder.dynamic.data.data);
+    if (!ctx->state.error) ctx->state.error = strdup("invalid logs completeness proof!");
+    return false;
+  }
+
+  ssz_builder_fix_list_offsets(&data_builder, log_count);
+  ssz_ob_t all_logs = ssz_builder_to_bytes(&data_builder);
+
+  // Exact final filtering: plain filters drop bloom false-positives; PAP filters (bloomFilter
+  // only, no address/topics) keep the bloom-matching superset for the client to filter.
+  ctx->data = c4_eth_filter_logs(all_logs, filter);
+  safe_free(all_logs.bytes.data);
+  ctx->flags |= VERIFY_FLAG_FREE_DATA;
+  ctx->success = true;
+  return true;
+}

--- a/src/chains/op/prover/op_proof_account.c
+++ b/src/chains/op/prover/op_proof_account.c
@@ -113,11 +113,11 @@ c4_status_t c4_op_proof_account(prover_ctx_t* ctx) {
   uint64_t      block_number_uint64 = 0;
 
   if (is_storage_at)
-    CHECK_JSON(ctx->params, "[address,bytes32,block]", "Invalid arguments for eth_getStorageAt: ");
+    CHECK_JSON_INPUT(ctx->params, "[address,bytes32,block]", "Invalid arguments for eth_getStorageAt: ");
   else if (is_proof)
-    CHECK_JSON(ctx->params, "[address,[bytes32],block]", "Invalid arguments for eth_getProof: ");
+    CHECK_JSON_INPUT(ctx->params, "[address,[bytes32],block]", "Invalid arguments for eth_getProof: ");
   else
-    CHECK_JSON(ctx->params, "[address,block]", "Invalid arguments for AccountProof: ");
+    CHECK_JSON_INPUT(ctx->params, "[address,block]", "Invalid arguments for AccountProof: ");
   TRY_ASYNC(c4_op_create_block_proof(ctx, block_number, &block_proof));
   ssz_ob_t* execution_payload = op_get_execution_payload(&block_proof);
   block_number_uint64         = ssz_get_uint64(execution_payload, "blockNumber");

--- a/src/chains/op/prover/op_proof_receipt.c
+++ b/src/chains/op/prover/op_proof_receipt.c
@@ -66,7 +66,7 @@ c4_status_t c4_op_proof_receipt(prover_ctx_t* ctx) {
   buffer_t    buf            = stack_buffer(block_hash);
   c4_status_t status         = C4_SUCCESS;
 
-  CHECK_JSON(txhash, "bytes32", "Invalid arguments for Tx: ");
+  CHECK_JSON_INPUT(txhash, "bytes32", "Invalid arguments for Tx: ");
 
   TRY_ASYNC(get_eth_tx(ctx, txhash, &tx_data)); // TODO get thos from tx cache if available
 

--- a/src/cli/prover.c
+++ b/src/cli/prover.c
@@ -80,6 +80,7 @@
 // | `-o`           | `<outputfile>`  | SSZ file with the proof                                                     | `stdout`     |
 // | `-d`           | `<chain_store>` | Use `chain_data` from the `chain_store` found within the path               |              |
 // | `-i`           |                 | Include code in the proof                                                   |              |
+// | `-G`           |                 | Generate an `eth_getLogs` completeness proof over the requested block range (proves no matching log was omitted; sets `C4_PROVER_FLAG_LOGS_COMPLETENESS`) |              |
 // | `<method>`     |                 | The method to execute                                                       |              |
 // | `<params>`     |                 | Parameters for the method                                                   |              |
 
@@ -115,6 +116,7 @@ int main(int argc, char* argv[]) {
                     "  -o <outputfile>  : ssz file with the proof ( default to stdout )\n"
                     "  -d <chain_store> : use chain_data from the chain_store found within the path\n"
                     "  -i               : include code in the proof\n"
+                    "  -G               : generate an eth_getLogs completeness proof over the requested block range (proves no matching log was omitted)\n"
                     "  --version, -v    : display version information\n"
                     "\n",
             argv[0]);
@@ -159,6 +161,10 @@ int main(int argc, char* argv[]) {
           case 'i':
             // Include contract code in the proof (for call proofs)
             flags |= C4_PROVER_FLAG_INCLUDE_CODE;
+            break;
+          case 'G':
+            // Generate an eth_getLogs completeness proof over the requested block range
+            flags |= C4_PROVER_FLAG_LOGS_COMPLETENESS;
             break;
 #ifdef TEST
 #ifdef USE_CURL

--- a/src/cli/verifier.c
+++ b/src/cli/verifier.c
@@ -74,6 +74,7 @@
 // | `-P`           |                 | Enable PAP (Pragmatic Adaptive Privacy) mode       |         |
 // | `-W`           |                 | Skip the Weak Subjectivity Period check (sets `VERIFY_FLAG_SKIP_WSP_CHECK`). **SECURITY:** only safe when another trust anchor (witness signatures, hard-coded checkpoint, signed package) is in place; raises the risk of long-range attacks across periods older than the WSP. |         |
 // | `-A`           | `<seconds>`     | Maximum age (in seconds) accepted for proofs whose request uses the `"latest"` block tag. Currently active for `eth_call`, `eth_estimateGas`, and `colibri_simulateTransaction`. `0` disables the check. | `60` |
+// | `-G`           |                 | Generate and require an `eth_getLogs` completeness proof over the requested block range (proves no matching log was omitted). Sets `C4_PROVER_FLAG_LOGS_COMPLETENESS` and `VERIFY_FLAG_LOGS_COMPLETENESS`. | |
 // | `-h`           |                 | Display this help message  |         |
 // | `<method>`     |                 | Method to verify           |         |
 // | `<args>`       |                 | Arguments for the method   |         |
@@ -121,6 +122,7 @@ int main(int argc, char* argv[]) {
     fprintf(stderr, "  -P enable PAP (Pragmatic Adaptive Privacy) mode\n");
     fprintf(stderr, "  -W skip the Weak Subjectivity Period check (VERIFY_FLAG_SKIP_WSP_CHECK). SECURITY: only safe with an alternative trust anchor (witness signatures, hard-coded checkpoint, signed package).\n");
     fprintf(stderr, "  -A <seconds> max age accepted for proofs targeting the \"latest\" block tag (eth_call/eth_estimateGas/colibri_simulateTransaction; default 60, 0 = disabled)\n");
+    fprintf(stderr, "  -G generate and require an eth_getLogs completeness proof over the requested block range (proves no matching log was omitted)\n");
     fprintf(stderr, "  -O no verifier, just return the proof\n");
     fprintf(stderr, "  --version, -v display version information\n");
     fprintf(stderr, "  -h help\n");
@@ -150,7 +152,8 @@ int main(int argc, char* argv[]) {
   char*            trace_id               = NULL;
   c4_prover_mode_t prover_mode            = C4_PROVER_MODE_REMOTE;
   bool             prover_mode_set        = false;
-  uint64_t         max_latest_age_seconds = 60; // 0 disables the freshness check for "latest" proofs
+  bool             logs_completeness      = false; // enable eth_getLogs completeness proof (prover + verifier flag)
+  uint64_t         max_latest_age_seconds = 60;    // 0 disables the freshness check for "latest" proofs
   c4_set_log_level(LOG_ERROR);
   buffer_add_chars(&args, "[");
 
@@ -232,6 +235,9 @@ int main(int argc, char* argv[]) {
             break;
           case 'W':
             verify_flags |= VERIFY_FLAG_SKIP_WSP_CHECK;
+            break;
+          case 'G':
+            logs_completeness = true;
             break;
           case 'A': {
             if (i + 1 >= argc) {
@@ -335,6 +341,10 @@ int main(int argc, char* argv[]) {
 
   prover_flags_t prover_flags = C4_PROVER_FLAG_USE_ACCESSLIST;
   if (use_zk_proof) prover_flags |= C4_PROVER_FLAG_ZK_PROOF;
+  if (logs_completeness) {
+    prover_flags |= C4_PROVER_FLAG_LOGS_COMPLETENESS;
+    verify_flags |= VERIFY_FLAG_LOGS_COMPLETENESS;
+  }
   if (!prover_mode_set) {
     if (input != NULL)
       prover_mode = C4_PROVER_MODE_LOCAL;

--- a/src/prover/prover.h
+++ b/src/prover/prover.h
@@ -79,6 +79,7 @@ typedef enum {
   C4_PROVER_FLAG_HYBRID             = 1 << 9, // hybrid mode: header proof from remote server, execution data from RPC provider
   C4_PROVER_FLAG_PROXY              = 1 << 10, // server: request used client-supplied RPC/Beacon URLs (proxy mode)
   C4_PROVER_FLAG_LIGHT_CLIENT       = 1 << 11, // light client mode: extended header cache TTL for "latest" (full block_time instead of half)
+  C4_PROVER_FLAG_LOGS_COMPLETENESS  = 1 << 12, // if true, eth_getLogs generates a completeness proof over the requested block range (proves no matching log was omitted)
 } prover_flag_types_t;
 
 /**

--- a/src/prover/prover.h
+++ b/src/prover/prover.h
@@ -80,12 +80,37 @@ typedef enum {
   C4_PROVER_FLAG_PROXY              = 1 << 10, // server: request used client-supplied RPC/Beacon URLs (proxy mode)
   C4_PROVER_FLAG_LIGHT_CLIENT       = 1 << 11, // light client mode: extended header cache TTL for "latest" (full block_time instead of half)
   C4_PROVER_FLAG_LOGS_COMPLETENESS  = 1 << 12, // if true, eth_getLogs generates a completeness proof over the requested block range (proves no matching log was omitted)
+  C4_PROVER_FLAG_INPUT_VALIDATED    = 1 << 13, // internal/transient: set once the request input params have been validated (see CHECK_JSON_INPUT). Prevents re-validation on async re-entries and nested dispatch. Not a request option and never serialized.
 } prover_flag_types_t;
 
 /**
  * a bitmask holding flags used during the prover context.
  */
 typedef uint32_t prover_flags_t;
+
+/**
+ * **CHECK_JSON_INPUT(val, def, error_prefix)** - Validate request input params once per context.
+ *
+ * Validates `val` against the schema `def`, but only if the input parameters have not been
+ * validated yet for this prover context. On success it sets `C4_PROVER_FLAG_INPUT_VALIDATED`
+ * so async re-entries (repeated `C4_PENDING` executions) and nested dispatch skip re-validation.
+ *
+ * Prefer this over `CHECK_JSON_CACHED` for request parameters: it avoids hashing the payload on
+ * every call and instead relies on a single per-context flag. `CHECK_JSON_CACHED` remains the
+ * right choice for large *results* (e.g. `eth_getBlockReceipts`) which are validated once but are
+ * not the request input. Assumes a `prover_ctx_t* ctx` is in scope.
+ *
+ * ```c
+ * CHECK_JSON_INPUT(json_at(ctx->params, 0), JSON_GET_LOGS_FILTER_FIELDS, "Invalid eth_getLogs filter: ");
+ * ```
+ */
+#define CHECK_JSON_INPUT(val, def, error_prefix)          \
+  do {                                                    \
+    if (!(ctx->flags & C4_PROVER_FLAG_INPUT_VALIDATED)) { \
+      CHECK_JSON(val, def, error_prefix);                 \
+      ctx->flags |= C4_PROVER_FLAG_INPUT_VALIDATED;       \
+    }                                                     \
+  } while (0)
 
 #ifdef PROVER_CACHE
 typedef union {

--- a/src/server/handle_proof.c
+++ b/src/server/handle_proof.c
@@ -541,6 +541,7 @@ bool c4_handle_proof_request(client_t* client) {
   json_t client_state = json_get(rpc_req, "c4");
   json_t include_code = json_get(rpc_req, "include_code");
   json_t zk_proof     = json_get(rpc_req, "zk_proof");
+  json_t logs_compl   = json_get(rpc_req, "logs_completeness");
   json_t signers      = json_get(rpc_req, "signers");
   if (method.type != JSON_TYPE_STRING || params.type != JSON_TYPE_ARRAY) {
     c4_write_error_response(client, 400, "Invalid request");
@@ -596,6 +597,7 @@ bool c4_handle_proof_request(client_t* client) {
   prover_flags_t extra_flags = 0;
   if (include_code.type == JSON_TYPE_BOOLEAN && include_code.start[0] == 't') extra_flags |= C4_PROVER_FLAG_INCLUDE_CODE;
   if (zk_proof.type == JSON_TYPE_BOOLEAN && zk_proof.start[0] == 't') extra_flags |= C4_PROVER_FLAG_ZK_PROOF;
+  if (logs_compl.type == JSON_TYPE_BOOLEAN && logs_compl.start[0] == 't') extra_flags |= C4_PROVER_FLAG_LOGS_COMPLETENESS;
 
   buffer_t client_state_buf = {0};
   bytes_t  cs               = NULL_BYTES;

--- a/src/util/json.h
+++ b/src/util/json.h
@@ -228,6 +228,7 @@ json_t json_dup(json_t json);
  *    - "uint"      : JSON number (integer)
  *    - "suint"     : JSON string (integer) like "1234567890"
  *    - "bool"      : JSON boolean (true/false)
+ *    - "null"      : JSON null (useful in alternations, e.g. topics wildcards)
  *    - "block"     : block identifier (hex uint or "latest", "safe", "finalized")
  *
  * 2. ARRAYS:

--- a/src/util/json.h
+++ b/src/util/json.h
@@ -249,7 +249,12 @@ json_t json_dup(json_t json);
  *    Example: "{*:bytes32}" - object with arbitrary keys, all values must be bytes32
  *    Use case: For objects with unknown/dynamic property names
  *
- * 5. NESTED STRUCTURES:
+ * 5. OR OPERATOR:
+ *    Syntax: type1|type2
+ *    Example: "uint|suint" - value must be either a uint or a suint
+ *    Use case: For values that can be either a uint or a suint
+ *
+ * 6. NESTED STRUCTURES:
  *    Types can be nested arbitrarily:
  *    Example: "{logs:[{address:address,topics:[bytes32],data:bytes}]}"
  *

--- a/src/util/json_validate.c
+++ b/src/util/json_validate.c
@@ -50,24 +50,50 @@ static const char* next_name(const char* pos, const char** next, int* len) {
   return start;
 }
 
-static const char* next_type(const char* pos, const char** next, int* len) {
+// Consume exactly one type token (a name, a `[...]` array or a `{...}` object) and
+// advance `*next` past it. Returns the start of the token or NULL on an unbalanced bracket.
+static const char* next_single_type(const char* pos, const char** next) {
   while (*pos && isspace((unsigned char)*pos)) pos++;
   const char* start = pos;
   if (*pos == '[') {
     const char* end = find_end(pos + 1, '[', ']');
     if (!end) return NULL;
     *next = end + 1;
-    *len  = end - start;
     return start;
   }
   if (*pos == '{') {
     const char* end = find_end(pos + 1, '{', '}');
     if (!end) return NULL;
     *next = end + 1;
-    *len  = end - start;
     return start;
   }
-  return next_name(pos, next, len);
+  int len = 0;
+  return next_name(pos, next, &len);
+}
+
+// Consume a full type expression including top-level alternations (`type|type|...`) and
+// advance `*next` past the whole chain. This keeps `|` usable at any position inside an
+// object definition, not just as the last field. The actual alternation is evaluated later
+// by json_validate(); here we only need to skip over the complete expression.
+static const char* next_type(const char* pos, const char** next, int* len) {
+  while (*pos && isspace((unsigned char)*pos)) pos++;
+  const char* start = pos;
+  const char* end   = NULL;
+  if (!next_single_type(pos, &end)) return NULL;
+
+  for (const char* p = end; *p;) {
+    while (*p && isspace((unsigned char)*p)) p++;
+    if (*p != '|') {
+      end = p;
+      break;
+    }
+    if (!next_single_type(p + 1, &end)) return NULL;
+    p = end;
+  }
+
+  *next = end;
+  *len  = end - start;
+  return start;
 }
 
 static bool starts_with_dot(const char* str) {
@@ -200,6 +226,7 @@ static const char* json_validate_def(json_t val, const char* def, const char* er
   if (strncmp(def, "uint", 4) == 0) return val.type == JSON_TYPE_NUMBER ? NULL : strdup("Expected uint");
   if (strncmp(def, "suint", 5) == 0) return val.type == JSON_TYPE_STRING ? NULL : strdup("Expected suint");
   if (strncmp(def, "bool", 4) == 0) return val.type == JSON_TYPE_BOOLEAN ? NULL : strdup("Expected boolean");
+  if (strncmp(def, "null", 4) == 0) return val.type == JSON_TYPE_NULL ? NULL : strdup("Expected null");
   if (strncmp(def, "block", 5) == 0) return check_block(val, error_prefix);
   if (strncmp(def, "string", 6) == 0) return val.type == JSON_TYPE_STRING ? NULL : strdup("Expected string");
   ERROR("%sUnknown type %s", error_prefix ? error_prefix : "", def);

--- a/src/util/json_validate.c
+++ b/src/util/json_validate.c
@@ -186,7 +186,9 @@ static const char* check_suint(json_t val, const char* error_prefix) {
   return NULL;
 }
 
-const char* json_validate(json_t val, const char* def, const char* error_prefix) {
+
+
+static const char* json_validate_def(json_t val, const char* def, const char* error_prefix) {
   if (val.type == JSON_TYPE_INVALID) return strdup("Invalid JSON");
   if (*def == '[') return check_array(val, def, error_prefix ? error_prefix : "");
   if (*def == '{') return check_object(val, def, error_prefix ? error_prefix : "");
@@ -201,6 +203,52 @@ const char* json_validate(json_t val, const char* def, const char* error_prefix)
   if (strncmp(def, "block", 5) == 0) return check_block(val, error_prefix);
   if (strncmp(def, "string", 6) == 0) return val.type == JSON_TYPE_STRING ? NULL : strdup("Expected string");
   ERROR("%sUnknown type %s", error_prefix ? error_prefix : "", def);
+}
+
+const char* json_validate(json_t val, const char* def, const char* error_prefix) {
+  // parse the definition
+
+  const char* current = def;
+  int level=0;
+  char start=0,end=0;
+  for (const char* p = def; *p; p++) {
+    if (start) {
+      if (*p == start) 
+        level++;
+      else if (*p == end) {
+        level--;
+        if (level == 0) {
+          start = 0;
+          end = 0;
+        }
+      }
+      continue;
+    }
+    
+
+    if (*p == '[') {
+      level=1;
+      start = *p;
+      end = ']';
+    } else if (*p == '{') {
+      level=1;
+      start = *p;
+      end = '}';
+    }
+    else if (*p == '|') { // we run the first expression and if it fails, we simply continue with the second expression
+      const char* err = json_validate_def(val, current, error_prefix);
+      if (!err) return NULL;
+      safe_free((char*) err);
+      current = p + 1;
+      continue;
+    }
+    else if (*p == '}' || *p == ']' || *p == ')' || *p == ',' || *p == ':') break;
+
+  }
+
+
+  if (current && *current) return json_validate_def(val, current, error_prefix);
+  ERROR("%sinvalid json def: %s", error_prefix,  def);
 }
 
 // Lightweight cache for json validation results (non-security critical).

--- a/src/util/state.c
+++ b/src/util/state.c
@@ -47,6 +47,8 @@ void c4_append_prover_request_props(buffer_t* payload, bytes_t client_state, cha
     bprintf(payload, ",\"zk_proof\":true");
   if (flags & C4_PROVER_REQ_FLAG_INCLUDE_CODE)
     bprintf(payload, ",\"include_code\":true");
+  if (flags & C4_PROVER_REQ_FLAG_LOGS_COMPLETENESS)
+    bprintf(payload, ",\"logs_completeness\":true");
   if (witness_key.data && witness_key.len)
     bprintf(payload, ",\"signers\":\"0x%x\"", witness_key);
 }

--- a/src/util/state.h
+++ b/src/util/state.h
@@ -289,8 +289,9 @@ void c4_request_free(data_request_t* req);
  * Bit positions for `flags` passed to `c4_append_prover_request_props`.
  * Must stay in sync with `prover_flag_types_t` in `prover.h`.
  */
-#define C4_PROVER_REQ_FLAG_INCLUDE_CODE (1u << 0)
-#define C4_PROVER_REQ_FLAG_ZK_PROOF     (1u << 7)
+#define C4_PROVER_REQ_FLAG_INCLUDE_CODE      (1u << 0)
+#define C4_PROVER_REQ_FLAG_ZK_PROOF          (1u << 7)
+#define C4_PROVER_REQ_FLAG_LOGS_COMPLETENESS (1u << 12)
 
 /**
  * Appends common remote-prover JSON fields to an open object (after `method` / `params`).

--- a/src/verifier/verify.h
+++ b/src/verifier/verify.h
@@ -88,6 +88,7 @@ typedef enum {
   VERIFY_FLAG_OBLIVIOUS      = 1 << 6, // if set, the verifier will use the oblivious_node
   VERIFY_FLAG_SKIP_WSP_CHECK = 1 << 7, // if set, skip the Weak Subjectivity Period check for prover-provided or fetched sync committee data. SECURITY: Only use when an alternative trust anchor (witness signatures, hard-coded checkpoint, signed package) is available. Disabling increases the risk of long-range attacks when syncing across periods older than the WSP.
   VERIFY_FLAG_SYNC_REINIT_TRIED = 1 << 8, // internal transient flag: set by the verifier once it has attempted a full sync-state reinitialization (clear + re-bootstrap from a trusted checkpoint) during this verification. Prevents an infinite reinit loop when the requested period is genuinely older than any obtainable committee. Not intended to be set by hosts.
+  VERIFY_FLAG_LOGS_COMPLETENESS = 1 << 9, // if set, eth_getLogs requires a completeness proof: a plain logs proof is rejected because completeness was requested by the caller.
 } verify_flag_t;
 
 /**

--- a/test/unittests/test_core.c
+++ b/test/unittests/test_core.c
@@ -260,6 +260,80 @@ void test_json_validate_or() {
   safe_free((char*) err);
 
 }
+
+void test_json_validate_or_in_object() {
+  // An alternation (`|`) field is no longer required to be the last object field:
+  // json_validate must keep validating fields that follow it.
+  const char* schema = "{a?:address|[address],b?:bytes32,c?:block}";
+
+  const char* ok[] = {
+      "{}",
+      "{\"a\":\"0x1111111111111111111111111111111111111111\",\"b\":\"0x3333333333333333333333333333333333333333333333333333333333333333\",\"c\":\"latest\"}",
+      "{\"a\":[\"0x1111111111111111111111111111111111111111\"],\"c\":\"0x5\"}",
+  };
+  for (size_t i = 0; i < sizeof(ok) / sizeof(ok[0]); i++) {
+    const char* err = json_validate(json_parse(ok[i]), schema, "");
+    TEST_ASSERT_NULL_MESSAGE(err, ok[i]);
+  }
+
+  // Regression: a bad field AFTER the alternation field must still be rejected
+  // (previously object parsing terminated right after the `|` field).
+  const char* bad[] = {
+      "{\"a\":\"0x1111111111111111111111111111111111111111\",\"b\":\"0xzz\"}", // bad bytes32 after OR field
+      "{\"a\":\"0x1111111111111111111111111111111111111111\",\"c\":\"head\"}", // bad block after OR field
+      "{\"a\":\"0xzz\",\"b\":\"0x3333333333333333333333333333333333333333333333333333333333333333\"}", // bad OR field itself
+  };
+  for (size_t i = 0; i < sizeof(bad) / sizeof(bad[0]); i++) {
+    const char* err = json_validate(json_parse(bad[i]), schema, "");
+    TEST_ASSERT_NOT_NULL_MESSAGE(err, bad[i]);
+    safe_free((char*) err);
+  }
+}
+
+void test_json_validate_null() {
+  // The standalone `null` type only accepts JSON null (needed for topics wildcards).
+  const char* err = json_validate(json_parse("null"), "null", "");
+  TEST_ASSERT_NULL_MESSAGE(err, err);
+
+  err = json_validate(json_parse("\"0x1\""), "null", "");
+  TEST_ASSERT_NOT_NULL_MESSAGE(err, "string is not null");
+  safe_free((char*) err);
+}
+
+void test_json_validate_getlogs_filter() {
+  // Mirrors JSON_GET_LOGS_FILTER_FIELDS: `address` (top-level '|') must be last, `topics` uses
+  // '|' only inside brackets and may contain null wildcard positions.
+  const char* schema =
+      "{fromBlock?:block,toBlock?:block,blockHash?:bytes32,topics?:[bytes32|[bytes32|null]|null],bloomFilter?:[bytes],address?:address|[address]}";
+
+  const char* ok[] = {
+      "{}",
+      "{\"fromBlock\":\"0x1\",\"toBlock\":\"latest\"}",
+      "{\"address\":\"0x1111111111111111111111111111111111111111\"}",
+      "{\"address\":[\"0x1111111111111111111111111111111111111111\",\"0x2222222222222222222222222222222222222222\"]}",
+      "{\"topics\":[\"0x1111111111111111111111111111111111111111111111111111111111111111\",null,[\"0x2222222222222222222222222222222222222222222222222222222222222222\",null]]}",
+      "{\"blockHash\":\"0x3333333333333333333333333333333333333333333333333333333333333333\"}",
+  };
+  for (size_t i = 0; i < sizeof(ok) / sizeof(ok[0]); i++) {
+    const char* err = json_validate(json_parse(ok[i]), schema, "");
+    TEST_ASSERT_NULL_MESSAGE(err, ok[i]);
+  }
+
+  const char* bad[] = {
+      "5",                                                          // not an object
+      "{\"address\":\"0xzz\"}",                                     // invalid hex
+      "{\"address\":\"0x11\"}",                                     // wrong length
+      "{\"address\":[\"0x11\"]}",                                   // wrong length inside array
+      "{\"fromBlock\":\"head\"}",                                   // invalid block tag
+      "{\"topics\":[5]}",                                           // topic neither hex, array nor null
+  };
+  for (size_t i = 0; i < sizeof(bad) / sizeof(bad[0]); i++) {
+    const char* err = json_validate(json_parse(bad[i]), schema, "");
+    TEST_ASSERT_NOT_NULL_MESSAGE(err, bad[i]);
+    safe_free((char*) err);
+  }
+}
+
 void test_json_validate_block() {
   // All standard block tags must be accepted by the "block" type.
   const char* tags[] = {"\"latest\"", "\"safe\"", "\"finalized\"", "\"earliest\"", "\"pending\"", "\"0x1b4\"", "\"0x0\""};
@@ -979,6 +1053,9 @@ int main(void) {
   RUN_TEST(test_json);
   RUN_TEST(test_json_validate_block);
   RUN_TEST(test_json_validate_or);
+  RUN_TEST(test_json_validate_or_in_object);
+  RUN_TEST(test_json_validate_null);
+  RUN_TEST(test_json_validate_getlogs_filter);
   RUN_TEST(test_bprintf);
   RUN_TEST(test_bprintf_extended);
   RUN_TEST(test_bprintf_json_ssz);

--- a/test/unittests/test_core.c
+++ b/test/unittests/test_core.c
@@ -251,6 +251,15 @@ void test_json() {
   buffer_free(&buffer);
 }
 
+void test_json_validate_or() {
+  const char* err = json_validate(json_parse("\"0x1\""), "address|hexuint", "");
+  TEST_ASSERT_NULL_MESSAGE(err, err);
+
+  err = json_validate(json_parse("true"), "address|hexuint", "");
+  TEST_ASSERT_NOT_NULL_MESSAGE(err, "true");
+  safe_free((char*) err);
+
+}
 void test_json_validate_block() {
   // All standard block tags must be accepted by the "block" type.
   const char* tags[] = {"\"latest\"", "\"safe\"", "\"finalized\"", "\"earliest\"", "\"pending\"", "\"0x1b4\"", "\"0x0\""};
@@ -969,6 +978,7 @@ int main(void) {
   UNITY_BEGIN();
   RUN_TEST(test_json);
   RUN_TEST(test_json_validate_block);
+  RUN_TEST(test_json_validate_or);
   RUN_TEST(test_bprintf);
   RUN_TEST(test_bprintf_extended);
   RUN_TEST(test_bprintf_json_ssz);

--- a/test/unittests/test_eth_logs_completeness.c
+++ b/test/unittests/test_eth_logs_completeness.c
@@ -89,23 +89,47 @@ static void test_query_blooms_pap_malformed(void) {
   TEST_ASSERT_EQUAL_INT(0, pap.len);
 }
 
-// Builds a structurally well-shaped LogsCompletenessProof blob with the given range and empty
-// header/blocks lists. The sync-committee fields are dummies -- this is only used to exercise the
-// structural guards that run *before* any signature or trie work.
-static ssz_ob_t build_completeness_proof(uint64_t from, uint64_t to) {
+// Builds a structurally well-shaped LogsCompletenessProof with `header_count` ProofHeaders (i.e. a
+// range of header_count+1 blocks), a zeroed signature_proof header_proof and an empty blocks list.
+// The claim (range) now comes from the request, so the proof carries no range endpoints; this helper
+// only exercises the structural guards that run *before* chain/anchor verification.
+static ssz_ob_t build_completeness_proof(uint32_t header_count) {
   const ssz_def_t* def = eth_ssz_verification_type(ETH_SSZ_VERIFY_LOGS_COMPLETENESS_PROOF);
   TEST_ASSERT_NOT_NULL(def);
 
   uint8_t       header[112] = {0}; // slot(8)+proposerIndex(8)+parentRoot(32)+stateRoot(32)+bodyRoot(32)
-  uint8_t       bits[64]    = {0}; // sync_committee_bits (512 bits)
-  uint8_t       sig[96]     = {0}; // sync_committee_signature
   ssz_builder_t b           = ssz_builder_for_def(def);
-  ssz_add_uint64(&b, from);
-  ssz_add_uint64(&b, to);
   ssz_add_bytes(&b, "header", bytes(header, sizeof(header)));
-  ssz_add_bytes(&b, "headers", NULL_BYTES); // empty list
-  ssz_add_bytes(&b, "sync_committee_bits", bytes(bits, sizeof(bits)));
-  ssz_add_bytes(&b, "sync_committee_signature", bytes(sig, sizeof(sig)));
+
+  // headers list: header_count ProofHeaders (each slot8+proposerIndex8+stateRoot32+bodyRoot32)
+  const ssz_def_t* headers_def = ssz_get_def(def, "headers");
+  const ssz_def_t* ph_def      = headers_def->def.vector.type;
+  ssz_builder_t    hlist       = ssz_builder_for_def(headers_def);
+  for (uint32_t i = 0; i < header_count; i++) {
+    uint8_t       z8[8] = {0}, z32a[32] = {0}, z32b[32] = {0}, z8b[8] = {0};
+    ssz_builder_t ph = ssz_builder_for_def(ph_def);
+    ssz_add_bytes(&ph, "slot", bytes(z8, 8));
+    ssz_add_bytes(&ph, "proposerIndex", bytes(z8b, 8));
+    ssz_add_bytes(&ph, "stateRoot", bytes(z32a, 32));
+    ssz_add_bytes(&ph, "bodyRoot", bytes(z32b, 32));
+    ssz_add_dynamic_list_builders(&hlist, header_count, ph);
+  }
+  ssz_add_builders(&b, "headers", hlist);
+
+  // header_proof: zeroed signature_proof variant (index 0 of ETH_HEADER_PROOFS_UNION)
+  const ssz_def_t* hp_field = ssz_get_def(def, "header_proof");
+  ssz_builder_t    sp       = ssz_builder_for_def(hp_field->def.container.elements + 0);
+  uint8_t          bits[64] = {0}, sig[96] = {0};
+  ssz_add_bytes(&sp, "sync_committee_bits", bytes(bits, sizeof(bits)));
+  ssz_add_bytes(&sp, "sync_committee_signature", bytes(sig, sizeof(sig)));
+  ssz_add_builders(&b, "header_proof", sp);
+
+  // tag_proof: `none` variant (index 0 of ETH_STATE_BLOCK_UNION) + empty branch. The structural
+  // guards under test run before tag_proof verification, so its content is irrelevant here.
+  uint8_t none = 0;
+  ssz_add_bytes(&b, "tag_proof", bytes(&none, 1));
+  ssz_add_bytes(&b, "tag_proof_branch", NULL_BYTES);
+
   ssz_add_bytes(&b, "blocks", NULL_BYTES); // empty list
   return ssz_builder_to_bytes(&b);
 }
@@ -120,20 +144,10 @@ static bool run_verify(ssz_ob_t proof, json_t args, c4_state_t* state_out) {
   return ok;
 }
 
-// A reversed range (toBlock < fromBlock) must be rejected before any allocation.
-static void test_completeness_rejects_reversed_range(void) {
-  ssz_ob_t   proof = build_completeness_proof(0x200, 0x100);
-  json_t     args  = json_parse("[{\"fromBlock\":\"0x200\",\"toBlock\":\"0x100\"}]");
-  c4_state_t st    = {0};
-  TEST_ASSERT_FALSE(run_verify(proof, args, &st));
-  TEST_ASSERT_NOT_NULL(st.error);
-  c4_state_free(&st);
-  safe_free(proof.bytes.data);
-}
-
-// A range wider than the SSZ list capacity must be rejected up front (DoS guard).
+// A range wider than the SSZ list capacity must be rejected up front (DoS guard), before the chain
+// is reconstructed or the anchor signature is checked.
 static void test_completeness_rejects_oversized_range(void) {
-  ssz_ob_t   proof = build_completeness_proof(0, 5000); // count 5001 > 4096
+  ssz_ob_t   proof = build_completeness_proof(4096); // count 4097 > 4096
   json_t     args  = json_parse("[{\"fromBlock\":\"0x0\",\"toBlock\":\"0x1388\"}]");
   c4_state_t st    = {0};
   TEST_ASSERT_FALSE(run_verify(proof, args, &st));
@@ -142,32 +156,9 @@ static void test_completeness_rejects_oversized_range(void) {
   safe_free(proof.bytes.data);
 }
 
-// CRITICAL regression: a prover must not be able to shrink the proven range below the requested
-// range. Here the client asks for 0x100..0x200 but the proof only covers 0x100..0x100.
-static void test_completeness_rejects_range_shrink(void) {
-  ssz_ob_t   proof = build_completeness_proof(0x100, 0x100);
-  json_t     args  = json_parse("[{\"fromBlock\":\"0x100\",\"toBlock\":\"0x200\"}]");
-  c4_state_t st    = {0};
-  TEST_ASSERT_FALSE(run_verify(proof, args, &st));
-  TEST_ASSERT_NOT_NULL(st.error);
-  c4_state_free(&st);
-  safe_free(proof.bytes.data);
-}
-
-// An explicit fromBlock that does not match the proof's fromBlock must be rejected.
-static void test_completeness_rejects_from_mismatch(void) {
-  ssz_ob_t   proof = build_completeness_proof(0x100, 0x100);
-  json_t     args  = json_parse("[{\"fromBlock\":\"0x0\",\"toBlock\":\"0x100\"}]");
-  c4_state_t st    = {0};
-  TEST_ASSERT_FALSE(run_verify(proof, args, &st));
-  TEST_ASSERT_NOT_NULL(st.error);
-  c4_state_free(&st);
-  safe_free(proof.bytes.data);
-}
-
-// A missing filter object must be rejected (completeness needs the requested range).
+// A missing filter object must be rejected (completeness needs the requested range as its claim).
 static void test_completeness_rejects_missing_filter(void) {
-  ssz_ob_t   proof = build_completeness_proof(0x100, 0x100);
+  ssz_ob_t   proof = build_completeness_proof(0); // single-block range
   json_t     args  = json_parse("[]");
   c4_state_t st    = {0};
   TEST_ASSERT_FALSE(run_verify(proof, args, &st));
@@ -176,10 +167,10 @@ static void test_completeness_rejects_missing_filter(void) {
   safe_free(proof.bytes.data);
 }
 
-// With a matching range but an empty blocks list, the block-count guard must fire.
+// The blocks list length must equal the block count derived from the header chain (headers+1).
 static void test_completeness_rejects_block_count_mismatch(void) {
-  ssz_ob_t   proof = build_completeness_proof(0x100, 0x102); // count 3, but blocks list is empty
-  json_t     args  = json_parse("[{\"fromBlock\":\"0x100\",\"toBlock\":\"0x102\"}]");
+  ssz_ob_t   proof = build_completeness_proof(0); // count 1, but blocks list is empty
+  json_t     args  = json_parse("[{\"fromBlock\":\"0x100\",\"toBlock\":\"0x100\"}]");
   c4_state_t st    = {0};
   TEST_ASSERT_FALSE(run_verify(proof, args, &st));
   TEST_ASSERT_NOT_NULL(st.error);
@@ -195,10 +186,7 @@ int main(void) {
   RUN_TEST(test_bloom_negative_bad_block_len);
   RUN_TEST(test_query_blooms_pap_array);
   RUN_TEST(test_query_blooms_pap_malformed);
-  RUN_TEST(test_completeness_rejects_reversed_range);
   RUN_TEST(test_completeness_rejects_oversized_range);
-  RUN_TEST(test_completeness_rejects_range_shrink);
-  RUN_TEST(test_completeness_rejects_from_mismatch);
   RUN_TEST(test_completeness_rejects_missing_filter);
   RUN_TEST(test_completeness_rejects_block_count_mismatch);
   return UNITY_END();

--- a/test/unittests/test_eth_logs_completeness.c
+++ b/test/unittests/test_eth_logs_completeness.c
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2025 corpus.core
+ * SPDX-License-Identifier: MIT
+ */
+#include "c4_assert.h"
+
+#include "beacon_types.h"
+#include "bytes.h"
+#include "eth_bloom.h"
+#include "eth_verify.h"
+#include "json.h"
+#include "ssz.h"
+#include "unity.h"
+#include "verify.h"
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+// USDT token address, used as a representative filter address for bloom tests.
+#define TEST_ADDRESS "0xdac17f958d2ee523a2206206994597c13d831ec7"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// A block bloom that already contains the query bits cannot be proven negative:
+// the query variant is a bit-subset, so a matching log might exist.
+static void test_bloom_negative_subset_is_not_negative(void) {
+  json_t  filter = json_parse("{\"address\":\"" TEST_ADDRESS "\"}");
+  bytes_t q      = c4_eth_filter_query_blooms(filter);
+  TEST_ASSERT_NOT_NULL(q.data);
+  TEST_ASSERT_TRUE(q.len >= 256);
+  // block bloom == query bloom -> the (only) variant is a subset -> NOT negative
+  TEST_ASSERT_FALSE(c4_eth_bloom_negative(q, bytes(q.data, 256)));
+  safe_free(q.data);
+}
+
+// An all-zero block bloom cannot contain the query address bits, so the block is
+// provably free of any matching log (bloom-negative).
+static void test_bloom_negative_zero_block_is_negative(void) {
+  json_t  filter    = json_parse("{\"address\":\"" TEST_ADDRESS "\"}");
+  bytes_t q         = c4_eth_filter_query_blooms(filter);
+  uint8_t zero[256] = {0};
+  TEST_ASSERT_TRUE(c4_eth_bloom_negative(q, bytes(zero, 256)));
+  safe_free(q.data);
+}
+
+// Without any query variants the function must be conservative and return false
+// (absence cannot be proven), otherwise a prover could drop all blocks.
+static void test_bloom_negative_no_variants(void) {
+  uint8_t zero[256] = {0};
+  TEST_ASSERT_FALSE(c4_eth_bloom_negative(NULL_BYTES, bytes(zero, 256)));
+}
+
+// A block bloom of the wrong length must be rejected conservatively.
+static void test_bloom_negative_bad_block_len(void) {
+  json_t  filter         = json_parse("{\"address\":\"" TEST_ADDRESS "\"}");
+  bytes_t q              = c4_eth_filter_query_blooms(filter);
+  uint8_t short_bloom[10] = {0};
+  TEST_ASSERT_FALSE(c4_eth_bloom_negative(q, bytes(short_bloom, 10)));
+  safe_free(q.data);
+}
+
+// PAP mode: a `bloomFilter` array in the filter is used verbatim (no derivation
+// from address/topics). The returned blooms must equal the provided entries.
+static void test_query_blooms_pap_array(void) {
+  json_t  filter_addr = json_parse("{\"address\":\"" TEST_ADDRESS "\"}");
+  bytes_t q           = c4_eth_filter_query_blooms(filter_addr);
+  TEST_ASSERT_NOT_NULL(q.data);
+
+  buffer_t buf = {0};
+  bprintf(&buf, "{\"bloomFilter\":[\"0x%x\"]}", bytes(q.data, 256));
+  json_t  pap_filter = json_parse((char*) buf.data.data);
+  bytes_t pap        = c4_eth_filter_query_blooms(pap_filter);
+
+  TEST_ASSERT_EQUAL_INT(256, pap.len);
+  TEST_ASSERT_EQUAL_MEMORY(q.data, pap.data, 256);
+
+  safe_free(q.data);
+  safe_free(pap.data);
+  buffer_free(&buf);
+}
+
+// A malformed PAP bloom entry (wrong length) must not be treated as valid, so
+// the verifier cannot be tricked into a wrong negativity decision.
+static void test_query_blooms_pap_malformed(void) {
+  json_t  filter = json_parse("{\"bloomFilter\":[\"0x1234\"]}");
+  bytes_t pap    = c4_eth_filter_query_blooms(filter);
+  TEST_ASSERT_NULL(pap.data);
+  TEST_ASSERT_EQUAL_INT(0, pap.len);
+}
+
+// Builds a structurally well-shaped LogsCompletenessProof blob with the given range and empty
+// header/blocks lists. The sync-committee fields are dummies -- this is only used to exercise the
+// structural guards that run *before* any signature or trie work.
+static ssz_ob_t build_completeness_proof(uint64_t from, uint64_t to) {
+  const ssz_def_t* def = eth_ssz_verification_type(ETH_SSZ_VERIFY_LOGS_COMPLETENESS_PROOF);
+  TEST_ASSERT_NOT_NULL(def);
+
+  uint8_t       header[112] = {0}; // slot(8)+proposerIndex(8)+parentRoot(32)+stateRoot(32)+bodyRoot(32)
+  uint8_t       bits[64]    = {0}; // sync_committee_bits (512 bits)
+  uint8_t       sig[96]     = {0}; // sync_committee_signature
+  ssz_builder_t b           = ssz_builder_for_def(def);
+  ssz_add_uint64(&b, from);
+  ssz_add_uint64(&b, to);
+  ssz_add_bytes(&b, "header", bytes(header, sizeof(header)));
+  ssz_add_bytes(&b, "headers", NULL_BYTES); // empty list
+  ssz_add_bytes(&b, "sync_committee_bits", bytes(bits, sizeof(bits)));
+  ssz_add_bytes(&b, "sync_committee_signature", bytes(sig, sizeof(sig)));
+  ssz_add_bytes(&b, "blocks", NULL_BYTES); // empty list
+  return ssz_builder_to_bytes(&b);
+}
+
+static bool run_verify(ssz_ob_t proof, json_t args, c4_state_t* state_out) {
+  verify_ctx_t ctx = {0};
+  ctx.chain_id     = C4_CHAIN_MAINNET;
+  ctx.proof        = proof;
+  ctx.args         = args;
+  bool ok          = verify_logs_completeness(&ctx);
+  *state_out       = ctx.state;
+  return ok;
+}
+
+// A reversed range (toBlock < fromBlock) must be rejected before any allocation.
+static void test_completeness_rejects_reversed_range(void) {
+  ssz_ob_t   proof = build_completeness_proof(0x200, 0x100);
+  json_t     args  = json_parse("[{\"fromBlock\":\"0x200\",\"toBlock\":\"0x100\"}]");
+  c4_state_t st    = {0};
+  TEST_ASSERT_FALSE(run_verify(proof, args, &st));
+  TEST_ASSERT_NOT_NULL(st.error);
+  c4_state_free(&st);
+  safe_free(proof.bytes.data);
+}
+
+// A range wider than the SSZ list capacity must be rejected up front (DoS guard).
+static void test_completeness_rejects_oversized_range(void) {
+  ssz_ob_t   proof = build_completeness_proof(0, 5000); // count 5001 > 4096
+  json_t     args  = json_parse("[{\"fromBlock\":\"0x0\",\"toBlock\":\"0x1388\"}]");
+  c4_state_t st    = {0};
+  TEST_ASSERT_FALSE(run_verify(proof, args, &st));
+  TEST_ASSERT_NOT_NULL(st.error);
+  c4_state_free(&st);
+  safe_free(proof.bytes.data);
+}
+
+// CRITICAL regression: a prover must not be able to shrink the proven range below the requested
+// range. Here the client asks for 0x100..0x200 but the proof only covers 0x100..0x100.
+static void test_completeness_rejects_range_shrink(void) {
+  ssz_ob_t   proof = build_completeness_proof(0x100, 0x100);
+  json_t     args  = json_parse("[{\"fromBlock\":\"0x100\",\"toBlock\":\"0x200\"}]");
+  c4_state_t st    = {0};
+  TEST_ASSERT_FALSE(run_verify(proof, args, &st));
+  TEST_ASSERT_NOT_NULL(st.error);
+  c4_state_free(&st);
+  safe_free(proof.bytes.data);
+}
+
+// An explicit fromBlock that does not match the proof's fromBlock must be rejected.
+static void test_completeness_rejects_from_mismatch(void) {
+  ssz_ob_t   proof = build_completeness_proof(0x100, 0x100);
+  json_t     args  = json_parse("[{\"fromBlock\":\"0x0\",\"toBlock\":\"0x100\"}]");
+  c4_state_t st    = {0};
+  TEST_ASSERT_FALSE(run_verify(proof, args, &st));
+  TEST_ASSERT_NOT_NULL(st.error);
+  c4_state_free(&st);
+  safe_free(proof.bytes.data);
+}
+
+// A missing filter object must be rejected (completeness needs the requested range).
+static void test_completeness_rejects_missing_filter(void) {
+  ssz_ob_t   proof = build_completeness_proof(0x100, 0x100);
+  json_t     args  = json_parse("[]");
+  c4_state_t st    = {0};
+  TEST_ASSERT_FALSE(run_verify(proof, args, &st));
+  TEST_ASSERT_NOT_NULL(st.error);
+  c4_state_free(&st);
+  safe_free(proof.bytes.data);
+}
+
+// With a matching range but an empty blocks list, the block-count guard must fire.
+static void test_completeness_rejects_block_count_mismatch(void) {
+  ssz_ob_t   proof = build_completeness_proof(0x100, 0x102); // count 3, but blocks list is empty
+  json_t     args  = json_parse("[{\"fromBlock\":\"0x100\",\"toBlock\":\"0x102\"}]");
+  c4_state_t st    = {0};
+  TEST_ASSERT_FALSE(run_verify(proof, args, &st));
+  TEST_ASSERT_NOT_NULL(st.error);
+  c4_state_free(&st);
+  safe_free(proof.bytes.data);
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_bloom_negative_subset_is_not_negative);
+  RUN_TEST(test_bloom_negative_zero_block_is_negative);
+  RUN_TEST(test_bloom_negative_no_variants);
+  RUN_TEST(test_bloom_negative_bad_block_len);
+  RUN_TEST(test_query_blooms_pap_array);
+  RUN_TEST(test_query_blooms_pap_malformed);
+  RUN_TEST(test_completeness_rejects_reversed_range);
+  RUN_TEST(test_completeness_rejects_oversized_range);
+  RUN_TEST(test_completeness_rejects_range_shrink);
+  RUN_TEST(test_completeness_rejects_from_mismatch);
+  RUN_TEST(test_completeness_rejects_missing_filter);
+  RUN_TEST(test_completeness_rejects_block_count_mismatch);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Implements an optional **completeness proof** for `eth_getLogs` (closes #128): a cryptographic guarantee that for a requested range `[fromBlock, toBlock]` **no matching event was omitted**. Fully backward-compatible (new union index 20 in `C4_REQUEST_PROOFS_UNION`).

### How it works
- A contiguous block range is proven via a `parent_root` header chain anchored by a **single** sync-committee signature over the anchor (`toBlock`), plus a gap-free `blockNumber` sequence — ruling out skipped blocks.
- Per block, a 2-variant SSZ union covers the three issue scenarios:
  - **BloomNegative**: the block's `logsBloom` provably cannot match the query bloom (bloom-subset check).
  - **FullReceipts**: all RLP receipts are delivered; the verifier rebuilds the receipts Patricia trie against the signed `receiptsRoot` and filters locally. Matched transactions carry their tx proof.
- Works in **PAP mode** (query supplied as `bloomFilter` array instead of `address`/`topics`).

### Threading & config
- New prover flag `C4_PROVER_FLAG_LOGS_COMPLETENESS` and verify flag `VERIFY_FLAG_LOGS_COMPLETENESS`, threaded through the C core, remote-prover request JSON, server request parsing, and **all bindings** (TypeScript/Emscripten, Python, Kotlin, Swift, Dart).
- Configurable per-proof block-range limit (global var + setter + server config option), prover compute-unit accounting for negative vs. full blocks.

### Security hardening (from review)
- **CRITICAL**: verifier now binds the proven `fromBlock`/`toBlock` to the requested filter range (explicit numbers must match exactly; `latest`/`safe`/`finalized` accept the signature-anchored value; `pending`/`earliest` rejected). Prevents a malicious prover from shrinking the range to omit logs.
- **MEDIUM**: hard upper bound (4096) on the range **before** allocation (DoS guard).
- **LOW**: free SSZ builders on log/topic decode error paths.

## Test plan
- [x] `cmake --build build/default` — clean build
- [x] `ctest --test-dir build/default` — 51/51 pass
- [x] New `test_eth_logs_completeness`: bloom-negative logic, PAP bloom arrays, and verifier structural guards (reversed range, oversized range, **range-shrink regression**, from-mismatch, missing filter, block-count mismatch) — 12/12 pass
- [ ] Integration test with real fixtures for a full multi-block proof (follow-up)

## Follow-ups (non-blocking)
- Refactor duplicated parent-root chain / full-block multiproof helpers (code-review IMPROVE).
- Consider a freshness bound on the anchor timestamp for `latest` ranges.