### PR TITLE
fix(eth/precompiles): enforce EIP-2537 canonical Fp encoding

### DIFF
--- a/src/chains/eth/precompiles/precompiles_bls.c
+++ b/src/chains/eth/precompiles/precompiles_bls.c
@@ -35,6 +35,14 @@
 // G1 point: 128 bytes (X[64] || Y[64])
 // G2 point: 256 bytes (X.c0[64] || X.c1[64] || Y.c0[64] || Y.c1[64])
 
+// BLS12-381 base field modulus p (48-byte big-endian).
+// Mirrors precompiles_kzg.c: BLS_MODULUS_BE (Fr) with Fp width.
+// p = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+static const uint8_t BLS_FP_MODULUS_BE[48] = {
+    0x1a, 0x01, 0x11, 0xea, 0x39, 0x7f, 0xe6, 0x9a, 0x4b, 0x1b, 0xa7, 0xb6, 0x43, 0x4b, 0xac, 0xd7,
+    0x64, 0x77, 0x4b, 0x84, 0xf3, 0x85, 0x12, 0xbf, 0x67, 0x30, 0xd2, 0xa0, 0xf6, 0xb0, 0xf6, 0x24,
+    0x1e, 0xab, 0xff, 0xfe, 0xb1, 0x53, 0xff, 0xff, 0xb9, 0xfe, 0xff, 0xff, 0xff, 0xff, 0xaa, 0xab};
+
 static inline bool is_all_zero(const uint8_t* p, size_t n) {
   for (size_t i = 0; i < n; i++) {
     if (p[i] != 0) return false;
@@ -42,9 +50,22 @@ static inline bool is_all_zero(const uint8_t* p, size_t n) {
   return true;
 }
 
-static inline void blst_fp_from_be64(blst_fp* out, const uint8_t in[64]) {
-  // Take the last 48 bytes as the canonical big-endian encoding
+// Return true iff be < BLS_FP_MODULUS_BE (big-endian compare).
+static inline bool be48_is_canonical_fp(const uint8_t be[48]) {
+  for (int i = 0; i < 48; i++) {
+    if (be[i] < BLS_FP_MODULUS_BE[i]) return true;
+    if (be[i] > BLS_FP_MODULUS_BE[i]) return false;
+  }
+  return false; // equal to modulus is non-canonical
+}
+
+// Decode an EIP-2537 Fp encoding: top 16 bytes must be zero padding and the
+// remaining 48 bytes must encode a value strictly less than p.
+static inline bool blst_fp_from_be64(blst_fp* out, const uint8_t in[64]) {
+  if (!is_all_zero(in, 16)) return false;
+  if (!be48_is_canonical_fp(in + 16)) return false;
   blst_fp_from_bendian(out, in + 16);
+  return true;
 }
 
 static inline void be64_from_blst_fp(uint8_t out[64], const blst_fp* in) {
@@ -59,8 +80,8 @@ static inline bool read_g1_affine(const uint8_t in[128], blst_p1_affine* out, bo
     // isn't constructed directly, so we handle it at call sites.
     return true;
   }
-  blst_fp_from_be64(&out->x, in);
-  blst_fp_from_be64(&out->y, in + 64);
+  if (!blst_fp_from_be64(&out->x, in)) return false;
+  if (!blst_fp_from_be64(&out->y, in + 64)) return false;
   if (!blst_p1_affine_on_curve(out)) return false;
   if (check_subgroup && !blst_p1_affine_in_g1(out)) return false;
   return true;
@@ -79,10 +100,10 @@ static inline bool read_g2_affine(const uint8_t in[256], blst_p2_affine* out, bo
   *is_inf = is_all_zero(in, 256);
   if (*is_inf) return true;
   // X = (c0, c1), Y = (c0, c1)
-  blst_fp_from_be64(&out->x.fp[0], in + 0);
-  blst_fp_from_be64(&out->x.fp[1], in + 64);
-  blst_fp_from_be64(&out->y.fp[0], in + 128);
-  blst_fp_from_be64(&out->y.fp[1], in + 192);
+  if (!blst_fp_from_be64(&out->x.fp[0], in + 0)) return false;
+  if (!blst_fp_from_be64(&out->x.fp[1], in + 64)) return false;
+  if (!blst_fp_from_be64(&out->y.fp[0], in + 128)) return false;
+  if (!blst_fp_from_be64(&out->y.fp[1], in + 192)) return false;
   if (!blst_p2_affine_on_curve(out)) return false;
   if (check_subgroup && !blst_p2_affine_in_g2(out)) return false;
   return true;
@@ -420,7 +441,7 @@ static pre_result_t pre_bls12_map_fp_to_g1(bytes_t input, buffer_t* output, uint
   *gas_used = 5500;
   if (input.len != 64) return PRE_INVALID_INPUT;
   blst_fp u;
-  blst_fp_from_be64(&u, input.data);
+  if (!blst_fp_from_be64(&u, input.data)) return PRE_INVALID_INPUT;
   blst_p1 P;
   blst_map_to_g1(&P, &u, NULL);
   blst_p1_affine Pa;
@@ -438,8 +459,8 @@ static pre_result_t pre_bls12_map_fp2_to_g2(bytes_t input, buffer_t* output, uin
   *gas_used = 23800;
   if (input.len != 128) return PRE_INVALID_INPUT;
   blst_fp2 u;
-  blst_fp_from_be64(&u.fp[0], input.data);
-  blst_fp_from_be64(&u.fp[1], input.data + 64);
+  if (!blst_fp_from_be64(&u.fp[0], input.data)) return PRE_INVALID_INPUT;
+  if (!blst_fp_from_be64(&u.fp[1], input.data + 64)) return PRE_INVALID_INPUT;
   blst_p2 Q;
   blst_map_to_g2(&Q, &u, NULL);
   blst_p2_affine Qa;

--- a/test/unittests/test_eth_precompiles.c
+++ b/test/unittests/test_eth_precompiles.c
@@ -115,6 +115,13 @@ void test_precompile_bls_map_fp_to_g1_zero(void);
 void test_precompile_bls_map_fp2_to_g2_zero(void);
 void test_precompile_bls_g1msm_zero(void);
 void test_precompile_bls_g2msm_zero(void);
+void test_precompile_bls_fp_nonzero_padding_rejected(void);
+void test_precompile_bls_fp_eq_modulus_rejected(void);
+void test_precompile_bls_fp_gt_modulus_rejected(void);
+void test_precompile_bls_fp_max_canonical_accepted(void);
+void test_precompile_bls_fp2_second_limb_eq_modulus_rejected(void);
+void test_precompile_bls_g1add_nonzero_padding_rejected(void);
+void test_precompile_bls_g2add_nonzero_padding_rejected(void);
 
 // Test 1: ECRecover (0x01)
 // Example from https://www.evm.codes/precompiled
@@ -1001,6 +1008,89 @@ void test_precompile_bls_g2msm_zero() {
   buffer_free(&output);
 }
 
+// EIP-2537 Fp encoding (64 bytes): top 16 bytes must be zero and the remaining
+// 48 bytes must encode a value strictly less than the base field modulus p.
+// p = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+static const char* BLS_FP_MODULUS =
+    "000000000000000000000000000000001a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab";
+static const char* BLS_FP_GT_MODULUS =
+    "000000000000000000000000000000001a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaac";
+static const char* BLS_FP_MAX_CANONICAL =
+    "000000000000000000000000000000001a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaaa";
+static const char* BLS_FP_NONZERO_PADDING =
+    "00000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+
+// MAP_FP_TO_G1 must reject a field element with non-zero top-16 padding.
+void test_precompile_bls_fp_nonzero_padding_rejected() {
+  run_precompile_reject(0x10, BLS_FP_NONZERO_PADDING);
+}
+
+// MAP_FP_TO_G1 must reject a field element equal to the modulus p.
+void test_precompile_bls_fp_eq_modulus_rejected() {
+  run_precompile_reject(0x10, BLS_FP_MODULUS);
+}
+
+// MAP_FP_TO_G1 must reject a field element strictly greater than p.
+void test_precompile_bls_fp_gt_modulus_rejected() {
+  run_precompile_reject(0x10, BLS_FP_GT_MODULUS);
+}
+
+// MAP_FP_TO_G1 must accept the largest canonical value p-1.
+void test_precompile_bls_fp_max_canonical_accepted() {
+  uint8_t addr[20];
+  make_precompile_address(0x10, addr);
+  bytes_t      input    = hex_to_bytes_alloc(BLS_FP_MAX_CANONICAL);
+  buffer_t     output   = {0};
+  uint64_t     gas_used = 0;
+  pre_result_t res      = eth_execute_precompile(addr, input, &output, &gas_used);
+  TEST_ASSERT_EQUAL(PRE_SUCCESS, res);
+  TEST_ASSERT_EQUAL_UINT64(5500, gas_used);
+  TEST_ASSERT_EQUAL(128, output.data.len);
+  free(input.data);
+  buffer_free(&output);
+}
+
+// MAP_FP2_TO_G2 must validate both Fp limbs: keep c0 canonical (zero) and set
+// c1 == p so a missing second-limb check would incorrectly succeed.
+void test_precompile_bls_fp2_second_limb_eq_modulus_rejected() {
+  char zero_fp_hex[129];
+  memset(zero_fp_hex, '0', 128);
+  zero_fp_hex[128] = '\0';
+  char input_hex[257];
+  snprintf(input_hex, sizeof(input_hex), "%s%s", zero_fp_hex, BLS_FP_MODULUS);
+  run_precompile_reject(0x11, input_hex);
+}
+
+// G1ADD must also reject non-canonical encodings via the shared point decoder:
+// take a valid P || O input and set one padding byte in P.x non-zero.
+void test_precompile_bls_g1add_nonzero_padding_rejected() {
+  char zero_hex[257];
+  memset(zero_hex, '0', 256);
+  zero_hex[256] = '\0';
+  char point_hex[257];
+  snprintf(point_hex, sizeof(point_hex), "%s", BLS_G1_GENERATOR);
+  // Flip the least-significant nibble of the 16-byte padding of X (byte 15).
+  point_hex[31] = '1';
+  char input_hex[513];
+  snprintf(input_hex, sizeof(input_hex), "%s%s", point_hex, zero_hex);
+  run_precompile_reject(0x0b, input_hex);
+}
+
+// G2ADD must reject non-zero Fp padding via read_g2_affine (mirrors the G1ADD
+// padding test so a G2-only wiring omission cannot slip through).
+void test_precompile_bls_g2add_nonzero_padding_rejected() {
+  char zero_hex[513];
+  memset(zero_hex, '0', 512);
+  zero_hex[512] = '\0';
+  char point_hex[513];
+  snprintf(point_hex, sizeof(point_hex), "%s", BLS_G2_GENERATOR);
+  // Flip the least-significant nibble of the 16-byte padding of X.c0 (byte 15).
+  point_hex[31] = '1';
+  char input_hex[1025];
+  snprintf(input_hex, sizeof(input_hex), "%s%s", point_hex, zero_hex);
+  run_precompile_reject(0x0d, input_hex);
+}
+
 void test_precompile_p256verify_ok() {
   uint8_t  addr[20];
   buffer_t output   = {0};
@@ -1145,6 +1235,13 @@ int main(void) {
   RUN_TEST(test_precompile_bls_map_fp2_to_g2_zero);
   RUN_TEST(test_precompile_bls_g1msm_zero);
   RUN_TEST(test_precompile_bls_g2msm_zero);
+  RUN_TEST(test_precompile_bls_fp_nonzero_padding_rejected);
+  RUN_TEST(test_precompile_bls_fp_eq_modulus_rejected);
+  RUN_TEST(test_precompile_bls_fp_gt_modulus_rejected);
+  RUN_TEST(test_precompile_bls_fp_max_canonical_accepted);
+  RUN_TEST(test_precompile_bls_fp2_second_limb_eq_modulus_rejected);
+  RUN_TEST(test_precompile_bls_g1add_nonzero_padding_rejected);
+  RUN_TEST(test_precompile_bls_g2add_nonzero_padding_rejected);
 
   // EIP-4844 point evaluation
   RUN_TEST(test_precompile_point_evaluation_valid);


### PR DESCRIPTION
## Summary
- Fixes #321: EIP-2537 Fp encodings now reject non-zero top-16 padding and non-canonical values (`>= p`) in the shared `blst_fp_from_be64` decoder.
- Applies to all BLS precompiles that decode field elements (G1/G2 ADD, MSM, pairing, `MAP_FP_TO_G1`, `MAP_FP2_TO_G2`).
- Follow-up to #320 (G1ADD/G2ADD correctness); this closes the remaining input-validation gap.

## Test plan
- [x] `cmake --build build/default`
- [x] `./build/default/test/unittests/test_eth_precompiles` — 50/50 pass
- [x] Reject non-zero padding (`MAP_FP`, `G1ADD`, `G2ADD`)
- [x] Reject coordinate `== p` and `> p` (`MAP_FP`)
- [x] Accept coordinate `== p-1` (`MAP_FP`)
- [x] Reject `MAP_FP2` when second limb `== p`
- [x] Existing #320 EIP-2537 vectors still pass