### PR TITLE
fix(test): eliminate race conditions causing sporadic segfault in beacon watcher test

### DIFF
--- a/src/chains/eth/server/head_watcher.c
+++ b/src/chains/eth/server/head_watcher.c
@@ -140,6 +140,12 @@ static CURLM* beacon_multi_handle = NULL;
 // Libuv timer for curl_multi_socket_action timeouts
 static uv_timer_t beacon_curl_timer;
 
+// The three timer handles above and in watcher_state are static and live in the
+// default loop for the whole process lifetime. Calling uv_timer_init again on a
+// handle that is still registered in the loop corrupts the loop's handle queue,
+// so they must be initialized exactly once.
+static bool beacon_timers_initialized = false;
+
 // Structure to hold socket context for libuv polling
 typedef struct beacon_curl_context_s {
   uv_poll_t                     poll_handle;
@@ -527,12 +533,17 @@ void c4_watch_beacon_events() {
     return;
   }
 
-  // Initialize timers (inactivity, reconnect, AND curl timer)
-  uv_timer_init(loop, &watcher_state.inactivity_timer);
-  watcher_state.inactivity_timer.data = &watcher_state;
-  uv_timer_init(loop, &watcher_state.reconnect_timer);
-  watcher_state.reconnect_timer.data = &watcher_state;
-  uv_timer_init(loop, &beacon_curl_timer); // Initialize the CURL timer
+  // Initialize timers (inactivity, reconnect, AND curl timer) exactly once:
+  // they are never uv_close'd on stop, so a second uv_timer_init on the same
+  // still-registered handle would corrupt the loop's handle queue.
+  if (!beacon_timers_initialized) {
+    uv_timer_init(loop, &watcher_state.inactivity_timer);
+    watcher_state.inactivity_timer.data = &watcher_state;
+    uv_timer_init(loop, &watcher_state.reconnect_timer);
+    watcher_state.reconnect_timer.data = &watcher_state;
+    uv_timer_init(loop, &beacon_curl_timer); // Initialize the CURL timer
+    beacon_timers_initialized = true;
+  }
 
   // --- Configure CURL Multi Handle for Libuv ---
   curl_multi_setopt(beacon_multi_handle, CURLMOPT_SOCKETFUNCTION, beacon_socket_callback);

--- a/test/unittests/test_beacon_watcher.c
+++ b/test/unittests/test_beacon_watcher.c
@@ -30,6 +30,9 @@ void setUp(void) {
 // Unity teardown - called after each test
 void tearDown(void) {
   c4_test_stop_beacon_watcher();
+  // Reset the stream flag so the next setUp does not auto-start the watcher
+  // from the server thread with the previous test's URL.
+  eth_config.stream_beacon_events = 0;
   c4_test_server_teardown();
 }
 
@@ -46,13 +49,15 @@ void test_beacon_watcher_head_event(void) {
   fprintf(stderr, "[TEST] Starting watcher (head_event)\n");
   // Enable watcher start for this test
   eth_config.stream_beacon_events = 1;
-  // Start watcher
-  c4_watch_beacon_events();
+  // Start watcher on the loop thread (never touch the loop from this thread)
+  c4_test_start_beacon_watcher();
 
-  // Sehr kurze Eventloop-Phase: brich ab, sobald 2 Events verarbeitet wurden (head + finalized)
-  for (int i = 0; i < 5; i++) {
-    if (http_server.stats.beacon_events_total >= 2) break;
-    c4_server_run_once(&server_instance);
+  // Wait until head AND finalized events were processed. The recorded SSE
+  // stream contains many head events before the single finalized_checkpoint,
+  // so waiting for beacon_events_total alone would race with the assertions.
+  // The server thread drives the loop; this thread must only poll and sleep.
+  for (int i = 0; i < 50; i++) {
+    if (http_server.stats.beacon_events_head >= 1 && http_server.stats.beacon_events_finalized >= 1) break;
     usleep(20000);
   }
 
@@ -79,12 +84,11 @@ void test_beacon_watcher_event_parsing(void) {
   uint64_t start_time = http_server.stats.last_sync_event;
 
   eth_config.stream_beacon_events = 1;
-  c4_watch_beacon_events();
+  c4_test_start_beacon_watcher();
 
-  // Sehr kurze Eventloop-Phase
-  for (int i = 0; i < 3; i++) {
+  // Wait until a head event was processed (server thread drives the loop)
+  for (int i = 0; i < 50; i++) {
     if (http_server.stats.beacon_events_head >= 1) break;
-    c4_server_run_once(&server_instance);
     usleep(20000);
   }
 
@@ -102,12 +106,12 @@ void test_beacon_watcher_stops_after_eof(void) {
   c4_test_set_beacon_watcher_no_reconnect(true);
 
   eth_config.stream_beacon_events = 1;
-  c4_watch_beacon_events();
+  c4_test_start_beacon_watcher();
 
-  // File-EOF sollte den watcher stoppen (Reconnect disabled)
-  for (int i = 0; i < 5; i++) {
+  // File-EOF should stop the watcher (reconnect disabled);
+  // the server thread drives the loop, this thread only polls.
+  for (int i = 0; i < 50; i++) {
     if (!c4_beacon_watcher_is_running()) break;
-    c4_server_run_once(&server_instance);
     usleep(20000);
   }
 

--- a/test/unittests/test_server_helper.h
+++ b/test/unittests/test_server_helper.h
@@ -36,6 +36,7 @@
 #endif
 
 void c4_stop_beacon_watcher(void);
+void c4_watch_beacon_events(void);
 
 // Test configuration
 #define TEST_PORT 28545
@@ -59,7 +60,8 @@ static volatile bool server_should_stop = false;
 static const char*   current_test_name  = NULL;
 
 typedef struct {
-  uv_async_t async;
+  uv_async_t async;       // dispatches c4_stop_beacon_watcher() to the loop thread
+  uv_async_t start_async; // dispatches c4_watch_beacon_events() to the loop thread
   uv_sem_t   sem;
   bool       initialized;
 } test_beacon_stop_dispatcher_t;
@@ -69,6 +71,12 @@ static test_beacon_stop_dispatcher_t beacon_stop_dispatcher = {0};
 static void c4_test_beacon_stop_async_cb(uv_async_t* handle) {
   (void) handle;
   c4_stop_beacon_watcher();
+  uv_sem_post(&beacon_stop_dispatcher.sem);
+}
+
+static void c4_test_beacon_start_async_cb(uv_async_t* handle) {
+  (void) handle;
+  c4_watch_beacon_events();
   uv_sem_post(&beacon_stop_dispatcher.sem);
 }
 
@@ -88,6 +96,14 @@ static void c4_test_init_beacon_stop_dispatcher(void) {
     return;
   }
 
+  rc = uv_async_init(server_instance.loop, &beacon_stop_dispatcher.start_async, c4_test_beacon_start_async_cb);
+  if (rc != 0) {
+    log_error("[TEST] uv_async_init failed for beacon start helper: %s", uv_strerror(rc));
+    uv_close((uv_handle_t*) &beacon_stop_dispatcher.async, NULL);
+    uv_sem_destroy(&beacon_stop_dispatcher.sem);
+    return;
+  }
+
   beacon_stop_dispatcher.initialized = true;
 }
 
@@ -95,6 +111,9 @@ static void c4_test_close_beacon_stop_dispatcher(void) {
   if (!beacon_stop_dispatcher.initialized) return;
   if (!uv_is_closing((uv_handle_t*) &beacon_stop_dispatcher.async)) {
     uv_close((uv_handle_t*) &beacon_stop_dispatcher.async, NULL);
+  }
+  if (!uv_is_closing((uv_handle_t*) &beacon_stop_dispatcher.start_async)) {
+    uv_close((uv_handle_t*) &beacon_stop_dispatcher.start_async, NULL);
   }
 }
 
@@ -111,6 +130,19 @@ static void c4_test_stop_beacon_watcher(void) {
   }
 
   uv_async_send(&beacon_stop_dispatcher.async);
+  uv_sem_wait(&beacon_stop_dispatcher.sem);
+}
+
+// Starts the beacon watcher on the loop thread. c4_watch_beacon_events()
+// registers libuv handles, which must never happen from a foreign thread
+// while the server thread is running the loop.
+static void c4_test_start_beacon_watcher(void) {
+  if (!beacon_stop_dispatcher.initialized || !server_instance.is_running) {
+    c4_watch_beacon_events();
+    return;
+  }
+
+  uv_async_send(&beacon_stop_dispatcher.start_async);
   uv_sem_wait(&beacon_stop_dispatcher.sem);
 }
 
@@ -259,8 +291,6 @@ static void c4_test_server_setup(http_server_t* config) {
 
 // Teardown function - call from Unity tearDown()
 static void c4_test_server_teardown(void) {
-  c4_test_close_beacon_stop_dispatcher();
-
   // Signal server to stop
   server_should_stop = true;
 
@@ -270,6 +300,11 @@ static void c4_test_server_teardown(void) {
 
   // Join thread (should be quick now that it's stopping)
   pthread_join(server_thread, NULL);
+
+  // Close dispatcher handles only after the server thread stopped:
+  // uv_close from a foreign thread while the loop is running is unsafe.
+  // The close callbacks are processed by the uv_run calls in c4_server_stop.
+  c4_test_close_beacon_stop_dispatcher();
 
   // Stop server and cleanup resources
   c4_server_stop(&server_instance);


### PR DESCRIPTION
## Summary

`test_beacon_watcher` failed sporadically with a segfault. Runtime instrumentation (thread IDs, a uv_run depth counter, and a crash handler logging the test phase) identified three race conditions:

- **Concurrent `uv_run`**: the test's wait loops called `c4_server_run_once()` on the main thread while the helper's server thread was driving the same default libuv loop (confirmed 34x in logs; the crash always followed such an event).
- **Cross-thread handle registration**: `c4_watch_beacon_events()` was called from the main thread and registered libuv timers/polls while the server thread was inside `uv_run`.
- **Handle re-initialization**: the static watcher timers were never `uv_close`'d on stop, and each watcher start re-ran `uv_timer_init` on handles still registered in the loop, corrupting the loop's handle queue.

## Changes

- `test/unittests/test_server_helper.h`: new `c4_test_start_beacon_watcher()` dispatches the watcher start to the loop thread via `uv_async` (like the existing stop dispatcher); dispatcher handles are closed only after the server thread has joined.
- `test/unittests/test_beacon_watcher.c`: wait loops only poll and sleep instead of pumping the loop; `stream_beacon_events` is reset in `tearDown` so the next `setUp` does not auto-start the watcher with a stale URL; the head-event test now waits for head AND finalized events (the recorded SSE stream contains 17 head events before the single `finalized_checkpoint`, which caused a separate flaky assertion).
- `src/chains/eth/server/head_watcher.c`: the three static timer handles are initialized exactly once per process instead of on every watcher start.

## Test plan

- [x] `cmake --build build/default` clean
- [x] 200 consecutive runs of `test_beacon_watcher` without segfault or test failure (previously crashed reliably within ~50 runs)
- [x] Instrumented verification logs showed zero concurrent-uv_run events after the fix