### PR TITLE
chore(evmone): upgrade to v0.23.0 (keep Osaka)

### DIFF
--- a/libs/evmone/CMakeLists.txt
+++ b/libs/evmone/CMakeLists.txt
@@ -84,7 +84,7 @@ endif()
 FetchContent_Declare(
     evmone_external
     GIT_REPOSITORY https://github.com/ipsilon/evmone.git
-    GIT_TAG v0.19.0
+    GIT_TAG v0.23.0
     GIT_SHALLOW TRUE
     GIT_SUBMODULES_RECURSE TRUE
 )
@@ -107,15 +107,18 @@ if(NOT evmone_external_POPULATED)
     include(${CMAKE_CURRENT_SOURCE_DIR}/compat/patch_baseline_analysis.cmake)
     include(${CMAKE_CURRENT_SOURCE_DIR}/compat/patch_consteval.cmake)
     include(${CMAKE_CURRENT_SOURCE_DIR}/compat/patch_delegation.cmake)
+    include(${CMAKE_CURRENT_SOURCE_DIR}/compat/patch_create_address.cmake)
     
-    # Now create the CMakeLists.txt file
+    # Now create the CMakeLists.txt file.
+    # Intentionally omit upstream evmone_precompiles (and its blst dependency):
+    # Colibri provides keccak via keccak_bridge and precompiles via src/chains/eth/precompiles.
     file(WRITE ${evmone_external_SOURCE_DIR}/CMakeLists.txt "
         # Set deployment target for iOS builds
         if(APPLE)
             set(CMAKE_OSX_DEPLOYMENT_TARGET \"${CMAKE_OSX_DEPLOYMENT_TARGET}\" CACHE STRING \"Minimum deployment target\" FORCE)
         endif()
 
-        add_definitions(-DPROJECT_VERSION=\\\"0.19.0\\\")
+        add_definitions(-DPROJECT_VERSION=\\\"0.23.0\\\")
 
         add_library(evmone STATIC
             include/evmone/evmone.h
@@ -130,6 +133,8 @@ if(NOT evmone_external_POPULATED)
             lib/evmone/baseline_instruction_table.cpp
             lib/evmone/baseline_instruction_table.hpp
             lib/evmone/constants.hpp
+            lib/evmone/create_address.cpp
+            lib/evmone/create_address.hpp
             lib/evmone/delegation.cpp
             lib/evmone/delegation.hpp
             lib/evmone/instructions.hpp
@@ -203,5 +208,3 @@ target_include_directories(evmone_wrapper
 )
 
 target_link_libraries(evmone_wrapper PUBLIC evmone)
-
-

--- a/libs/evmone/CMakeLists.txt
+++ b/libs/evmone/CMakeLists.txt
@@ -103,6 +103,7 @@ if(NOT evmone_external_POPULATED)
     # Apply patches using the CMake scripts
     set(SOURCE_DIR ${evmone_external_SOURCE_DIR})
     include(${CMAKE_CURRENT_SOURCE_DIR}/compat/patch_evmc.cmake)
+    include(${CMAKE_CURRENT_SOURCE_DIR}/compat/patch_evmc_c23_enum.cmake)
     include(${CMAKE_CURRENT_SOURCE_DIR}/compat/patch_instructions_calls.cmake)
     include(${CMAKE_CURRENT_SOURCE_DIR}/compat/patch_baseline_analysis.cmake)
     include(${CMAKE_CURRENT_SOURCE_DIR}/compat/patch_consteval.cmake)

--- a/libs/evmone/compat/cpp20_compat.hpp
+++ b/libs/evmone/compat/cpp20_compat.hpp
@@ -1,6 +1,9 @@
 #pragma once
 #include <algorithm>
+#include <iterator>
 #include <memory>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 // C++20 compatibility for platforms with incomplete C++20 support (like Android NDK)
@@ -21,6 +24,19 @@ OutputIt ranges_copy(InputIt first, InputIt last, OutputIt d_first) {
 template <typename Container, typename OutputIt>
 OutputIt ranges_copy(const Container& container, OutputIt d_first) {
   return std::copy(container.begin(), container.end(), d_first);
+}
+
+// Replacement for std::shift_left (C++20)
+template <typename ForwardIt>
+ForwardIt shift_left(ForwardIt first, ForwardIt last, typename std::iterator_traits<ForwardIt>::difference_type n) {
+  if (n <= 0) return last;
+  const auto dist = std::distance(first, last);
+  if (n >= dist) return first;
+  auto new_last = first;
+  std::advance(new_last, dist - n);
+  auto mid = first;
+  std::advance(mid, n);
+  return std::move(mid, last, first);
 }
 } // namespace cpp20_compat
 

--- a/libs/evmone/compat/cpp20_compat.hpp
+++ b/libs/evmone/compat/cpp20_compat.hpp
@@ -3,7 +3,6 @@
 #include <iterator>
 #include <memory>
 #include <type_traits>
-#include <utility>
 #include <vector>
 
 // C++20 compatibility for platforms with incomplete C++20 support (like Android NDK)
@@ -32,8 +31,6 @@ ForwardIt shift_left(ForwardIt first, ForwardIt last, typename std::iterator_tra
   if (n <= 0) return last;
   const auto dist = std::distance(first, last);
   if (n >= dist) return first;
-  auto new_last = first;
-  std::advance(new_last, dist - n);
   auto mid = first;
   std::advance(mid, n);
   return std::move(mid, last, first);

--- a/libs/evmone/compat/patch_baseline_analysis.cmake
+++ b/libs/evmone/compat/patch_baseline_analysis.cmake
@@ -1,23 +1,34 @@
-# Read source file
+# Patch baseline_analysis.cpp for incomplete C++20 toolchains.
 file(READ ${SOURCE_DIR}/lib/evmone/baseline_analysis.cpp BASELINE_ANALYSIS_CONTENT)
 
-# Include our cpp20 compatibility header
-string(REGEX REPLACE 
-    "#include <memory>" 
-    "#include <memory>\n#include \"cpp20_compat.hpp\"" 
-    TEMP_CONTENT "${BASELINE_ANALYSIS_CONTENT}")
+string(FIND "${BASELINE_ANALYSIS_CONTENT}" "cpp20_compat.hpp" ALREADY_PATCHED)
+string(FIND "${BASELINE_ANALYSIS_CONTENT}" "std::make_unique_for_overwrite" NEEDS_UNIQUE)
+string(FIND "${BASELINE_ANALYSIS_CONTENT}" "std::ranges::copy" NEEDS_RANGES)
 
-# Replace std::make_unique_for_overwrite with cpp20_compat version (generic argument)
-string(REGEX REPLACE 
-    "std::make_unique_for_overwrite<uint8_t\\[\\]>\\(([^)]+)\\)" 
-    "cpp20_compat::make_unique_for_overwrite<uint8_t[]>(\\1)" 
-    TEMP_CONTENT2 "${TEMP_CONTENT}")
+if(ALREADY_PATCHED EQUAL -1 AND NEEDS_UNIQUE EQUAL -1 AND NEEDS_RANGES EQUAL -1)
+  message(FATAL_ERROR
+    "baseline_analysis.cpp patch failed: expected C++20 APIs or existing cpp20_compat include. "
+    "Upstream source may have changed; update libs/evmone/compat/patch_baseline_analysis.cmake.")
+endif()
 
-# Replace std::ranges::copy with cpp20_compat version (generic arguments)
-string(REGEX REPLACE 
-    "std::ranges::copy\\(([^,]+), ([^)]+)\\)" 
-    "cpp20_compat::ranges_copy(\\1, \\2)" 
-    PATCHED_CONTENT "${TEMP_CONTENT2}")
+if(ALREADY_PATCHED EQUAL -1)
+  string(REGEX REPLACE
+      "#include <memory>"
+      "#include <memory>\n#include \"cpp20_compat.hpp\""
+      TEMP_CONTENT "${BASELINE_ANALYSIS_CONTENT}")
 
-file(WRITE ${SOURCE_DIR}/lib/evmone/baseline_analysis.cpp "${PATCHED_CONTENT}")
-message(STATUS "Patched baseline_analysis.cpp for C++20 compatibility")
+  string(REGEX REPLACE
+      "std::make_unique_for_overwrite<uint8_t\\[\\]>\\(([^)]+)\\)"
+      "cpp20_compat::make_unique_for_overwrite<uint8_t[]>(\\1)"
+      TEMP_CONTENT2 "${TEMP_CONTENT}")
+
+  string(REGEX REPLACE
+      "std::ranges::copy\\(([^,]+), ([^)]+)\\)"
+      "cpp20_compat::ranges_copy(\\1, \\2)"
+      PATCHED_CONTENT "${TEMP_CONTENT2}")
+
+  file(WRITE ${SOURCE_DIR}/lib/evmone/baseline_analysis.cpp "${PATCHED_CONTENT}")
+  message(STATUS "Patched baseline_analysis.cpp for C++20 compatibility")
+else()
+  message(STATUS "baseline_analysis.cpp already patched for C++20 compatibility")
+endif()

--- a/libs/evmone/compat/patch_baseline_analysis.cmake
+++ b/libs/evmone/compat/patch_baseline_analysis.cmake
@@ -1,33 +1,46 @@
 # Patch baseline_analysis.cpp for incomplete C++20 toolchains.
 file(READ ${SOURCE_DIR}/lib/evmone/baseline_analysis.cpp BASELINE_ANALYSIS_CONTENT)
 
-string(FIND "${BASELINE_ANALYSIS_CONTENT}" "cpp20_compat.hpp" ALREADY_PATCHED)
 string(FIND "${BASELINE_ANALYSIS_CONTENT}" "std::make_unique_for_overwrite" NEEDS_UNIQUE)
 string(FIND "${BASELINE_ANALYSIS_CONTENT}" "std::ranges::copy" NEEDS_RANGES)
+string(FIND "${BASELINE_ANALYSIS_CONTENT}" "cpp20_compat::make_unique_for_overwrite" HAS_UNIQUE_COMPAT)
+string(FIND "${BASELINE_ANALYSIS_CONTENT}" "cpp20_compat::ranges_copy" HAS_RANGES_COMPAT)
 
-if(ALREADY_PATCHED EQUAL -1 AND NEEDS_UNIQUE EQUAL -1 AND NEEDS_RANGES EQUAL -1)
+if(NEEDS_UNIQUE EQUAL -1 AND NEEDS_RANGES EQUAL -1 AND HAS_UNIQUE_COMPAT EQUAL -1 AND HAS_RANGES_COMPAT EQUAL -1)
   message(FATAL_ERROR
-    "baseline_analysis.cpp patch failed: expected C++20 APIs or existing cpp20_compat include. "
+    "baseline_analysis.cpp patch failed: expected C++20 APIs or existing cpp20_compat replacements. "
     "Upstream source may have changed; update libs/evmone/compat/patch_baseline_analysis.cmake.")
 endif()
 
-if(ALREADY_PATCHED EQUAL -1)
-  string(REGEX REPLACE
-      "#include <memory>"
-      "#include <memory>\n#include \"cpp20_compat.hpp\""
-      TEMP_CONTENT "${BASELINE_ANALYSIS_CONTENT}")
+if(NEEDS_UNIQUE GREATER -1 OR NEEDS_RANGES GREATER -1)
+  string(FIND "${BASELINE_ANALYSIS_CONTENT}" "cpp20_compat.hpp" HAS_INCLUDE)
+  set(TEMP_CONTENT "${BASELINE_ANALYSIS_CONTENT}")
+  if(HAS_INCLUDE EQUAL -1)
+    string(REGEX REPLACE
+        "#include <memory>"
+        "#include <memory>\n#include \"cpp20_compat.hpp\""
+        TEMP_CONTENT "${TEMP_CONTENT}")
+  endif()
 
   string(REGEX REPLACE
       "std::make_unique_for_overwrite<uint8_t\\[\\]>\\(([^)]+)\\)"
       "cpp20_compat::make_unique_for_overwrite<uint8_t[]>(\\1)"
-      TEMP_CONTENT2 "${TEMP_CONTENT}")
+      TEMP_CONTENT "${TEMP_CONTENT}")
 
   string(REGEX REPLACE
       "std::ranges::copy\\(([^,]+), ([^)]+)\\)"
       "cpp20_compat::ranges_copy(\\1, \\2)"
-      PATCHED_CONTENT "${TEMP_CONTENT2}")
+      TEMP_CONTENT "${TEMP_CONTENT}")
 
-  file(WRITE ${SOURCE_DIR}/lib/evmone/baseline_analysis.cpp "${PATCHED_CONTENT}")
+  string(FIND "${TEMP_CONTENT}" "std::make_unique_for_overwrite" STILL_UNIQUE)
+  string(FIND "${TEMP_CONTENT}" "std::ranges::copy" STILL_RANGES)
+  if(STILL_UNIQUE GREATER -1 OR STILL_RANGES GREATER -1)
+    message(FATAL_ERROR
+      "baseline_analysis.cpp patch did not replace all C++20 APIs; "
+      "update libs/evmone/compat/patch_baseline_analysis.cmake.")
+  endif()
+
+  file(WRITE ${SOURCE_DIR}/lib/evmone/baseline_analysis.cpp "${TEMP_CONTENT}")
   message(STATUS "Patched baseline_analysis.cpp for C++20 compatibility")
 else()
   message(STATUS "baseline_analysis.cpp already patched for C++20 compatibility")

--- a/libs/evmone/compat/patch_consteval.cmake
+++ b/libs/evmone/compat/patch_consteval.cmake
@@ -1,38 +1,46 @@
-# Patch instructions_calls.cpp: replace consteval with constexpr and include compat header
-if(EXISTS ${SOURCE_DIR}/lib/evmone/instructions_calls.cpp)
-    file(READ ${SOURCE_DIR}/lib/evmone/instructions_calls.cpp CALLS_CONTENT)
-    
-    # Include our cpp20 compatibility header if not already included
-    string(REGEX MATCH "#include \"cpp20_compat.hpp\"" HAS_INCLUDE "${CALLS_CONTENT}")
-    if(NOT HAS_INCLUDE)
-        string(REGEX REPLACE 
-            "#include \"instructions.hpp\"" 
-            "#include \"instructions.hpp\"\n#include \"cpp20_compat.hpp\"" 
-            CALLS_CONTENT "${CALLS_CONTENT}")
+# Replace consteval with inline constexpr for toolchains with incomplete C++20 support.
+
+function(c4_patch_consteval_file REL_PATH INCLUDE_ANCHOR)
+  set(FULL_PATH ${SOURCE_DIR}/${REL_PATH})
+  if(NOT EXISTS ${FULL_PATH})
+    message(FATAL_ERROR "consteval patch target missing: ${REL_PATH}")
+  endif()
+
+  file(READ ${FULL_PATH} FILE_CONTENT)
+
+  string(FIND "${FILE_CONTENT}" "cpp20_compat.hpp" HAS_INCLUDE)
+  string(FIND "${FILE_CONTENT}" "consteval" HAS_CONSTEVAL)
+
+  if(HAS_INCLUDE EQUAL -1 AND HAS_CONSTEVAL EQUAL -1)
+    # File may not use consteval; only fail when the include anchor itself disappeared.
+    string(FIND "${FILE_CONTENT}" "${INCLUDE_ANCHOR}" HAS_ANCHOR)
+    if(HAS_ANCHOR EQUAL -1)
+      message(FATAL_ERROR
+        "consteval patch failed for ${REL_PATH}: missing include anchor '${INCLUDE_ANCHOR}'. "
+        "Upstream source may have changed; update libs/evmone/compat/patch_consteval.cmake.")
     endif()
+    message(STATUS "No consteval usage in ${REL_PATH}; skipping")
+    return()
+  endif()
 
-    # Replace consteval with inline constexpr
-    string(REGEX REPLACE 
-        "consteval (evmc_call_kind)" 
-        "inline constexpr \\1" 
-        CALLS_CONTENT "${CALLS_CONTENT}")
+  if(HAS_INCLUDE EQUAL -1)
+    string(REPLACE
+        "${INCLUDE_ANCHOR}"
+        "${INCLUDE_ANCHOR}\n#include \"cpp20_compat.hpp\""
+        FILE_CONTENT "${FILE_CONTENT}")
+  endif()
 
-    file(WRITE ${SOURCE_DIR}/lib/evmone/instructions_calls.cpp "${CALLS_CONTENT}")
-    message(STATUS "Patched instructions_calls.cpp for consteval compatibility")
-endif()
+  if(HAS_CONSTEVAL GREATER -1)
+    string(REGEX REPLACE
+        "consteval "
+        "inline constexpr "
+        FILE_CONTENT "${FILE_CONTENT}")
+  endif()
 
-# Patch baseline_execution.cpp to include the header
-if(EXISTS ${SOURCE_DIR}/lib/evmone/baseline_execution.cpp)
-    file(READ ${SOURCE_DIR}/lib/evmone/baseline_execution.cpp EXECUTION_CONTENT)
-    
-    string(REGEX MATCH "#include \"cpp20_compat.hpp\"" HAS_INCLUDE "${EXECUTION_CONTENT}")
-    if(NOT HAS_INCLUDE)
-        string(REGEX REPLACE 
-            "#include \"baseline.hpp\"" 
-            "#include \"baseline.hpp\"\n#include \"cpp20_compat.hpp\"" 
-            EXECUTION_CONTENT "${EXECUTION_CONTENT}")
-        
-        file(WRITE ${SOURCE_DIR}/lib/evmone/baseline_execution.cpp "${EXECUTION_CONTENT}")
-        message(STATUS "Patched baseline_execution.cpp for consteval compatibility")
-    endif()
-endif()
+  file(WRITE ${FULL_PATH} "${FILE_CONTENT}")
+  message(STATUS "Patched ${REL_PATH} for consteval compatibility")
+endfunction()
+
+c4_patch_consteval_file("lib/evmone/instructions_calls.cpp" "#include \"instructions.hpp\"")
+c4_patch_consteval_file("lib/evmone/baseline_execution.cpp" "#include \"baseline.hpp\"")
+c4_patch_consteval_file("lib/evmone/baseline_instruction_table.cpp" "#include \"baseline_instruction_table.hpp\"")

--- a/libs/evmone/compat/patch_create_address.cmake
+++ b/libs/evmone/compat/patch_create_address.cmake
@@ -1,0 +1,38 @@
+# Patch create_address.cpp for incomplete C++20 toolchains (std::shift_left).
+if(NOT EXISTS ${SOURCE_DIR}/lib/evmone/create_address.cpp)
+  message(FATAL_ERROR "create_address.cpp missing; required for evmone >= 0.23")
+endif()
+
+file(READ ${SOURCE_DIR}/lib/evmone/create_address.cpp CREATE_CONTENT)
+
+string(FIND "${CREATE_CONTENT}" "cpp20_compat.hpp" ALREADY_PATCHED)
+string(FIND "${CREATE_CONTENT}" "std::shift_left" NEEDS_PATCH)
+
+if(ALREADY_PATCHED EQUAL -1 AND NEEDS_PATCH EQUAL -1)
+  # Newer upstream may have dropped shift_left; still require the file to look like create_address.
+  string(FIND "${CREATE_CONTENT}" "compute_create_address" HAS_CREATE)
+  if(HAS_CREATE EQUAL -1)
+    message(FATAL_ERROR
+      "create_address.cpp patch failed: unexpected content. "
+      "Update libs/evmone/compat/patch_create_address.cmake.")
+  endif()
+  message(STATUS "No std::shift_left in create_address.cpp; skipping C++20 compat patch")
+  return()
+endif()
+
+if(NEEDS_PATCH GREATER -1)
+  string(REGEX REPLACE
+      "#include \"create_address.hpp\""
+      "#include \"create_address.hpp\"\n#include \"cpp20_compat.hpp\""
+      TEMP_CONTENT "${CREATE_CONTENT}")
+
+  string(REGEX REPLACE
+      "std::shift_left\\("
+      "cpp20_compat::shift_left("
+      PATCHED_CONTENT "${TEMP_CONTENT}")
+
+  file(WRITE ${SOURCE_DIR}/lib/evmone/create_address.cpp "${PATCHED_CONTENT}")
+  message(STATUS "Patched create_address.cpp for C++20 compatibility")
+else()
+  message(STATUS "create_address.cpp already patched for C++20 compatibility")
+endif()

--- a/libs/evmone/compat/patch_delegation.cmake
+++ b/libs/evmone/compat/patch_delegation.cmake
@@ -1,19 +1,32 @@
-# Patch delegation.cpp for C++20 compatibility (std::ranges::copy)
-if(EXISTS ${SOURCE_DIR}/lib/evmone/delegation.cpp)
-    file(READ ${SOURCE_DIR}/lib/evmone/delegation.cpp DELEGATION_CONTENT)
+# Patch delegation.cpp for incomplete C++20 toolchains (std::ranges::copy).
+if(NOT EXISTS ${SOURCE_DIR}/lib/evmone/delegation.cpp)
+  message(FATAL_ERROR "delegation.cpp missing; update libs/evmone/compat/patch_delegation.cmake")
+endif()
 
-    # Include our cpp20 compatibility header after the first include
-    string(REGEX REPLACE
-        "#include \"delegation.hpp\""
-        "#include \"delegation.hpp\"\n#include \"cpp20_compat.hpp\""
-        TEMP_CONTENT "${DELEGATION_CONTENT}")
+file(READ ${SOURCE_DIR}/lib/evmone/delegation.cpp DELEGATION_CONTENT)
 
-    # Replace std::ranges::copy with cpp20_compat version
-    string(REGEX REPLACE
-        "std::ranges::copy\\(([^,]+), ([^)]+)\\)"
-        "cpp20_compat::ranges_copy(\\1, \\2)"
-        PATCHED_CONTENT "${TEMP_CONTENT}")
+string(FIND "${DELEGATION_CONTENT}" "cpp20_compat.hpp" ALREADY_PATCHED)
+string(FIND "${DELEGATION_CONTENT}" "std::ranges::copy" NEEDS_PATCH)
 
-    file(WRITE ${SOURCE_DIR}/lib/evmone/delegation.cpp "${PATCHED_CONTENT}")
-    message(STATUS "Patched delegation.cpp for C++20 compatibility")
+if(ALREADY_PATCHED EQUAL -1 AND NEEDS_PATCH EQUAL -1)
+  message(FATAL_ERROR
+    "delegation.cpp patch failed: expected std::ranges::copy or existing cpp20_compat include. "
+    "Upstream source may have changed; update libs/evmone/compat/patch_delegation.cmake.")
+endif()
+
+if(NEEDS_PATCH GREATER -1)
+  string(REGEX REPLACE
+      "#include \"delegation.hpp\""
+      "#include \"delegation.hpp\"\n#include \"cpp20_compat.hpp\""
+      TEMP_CONTENT "${DELEGATION_CONTENT}")
+
+  string(REGEX REPLACE
+      "std::ranges::copy\\(([^,]+), ([^)]+)\\)"
+      "cpp20_compat::ranges_copy(\\1, \\2)"
+      PATCHED_CONTENT "${TEMP_CONTENT}")
+
+  file(WRITE ${SOURCE_DIR}/lib/evmone/delegation.cpp "${PATCHED_CONTENT}")
+  message(STATUS "Patched delegation.cpp for C++20 compatibility")
+else()
+  message(STATUS "delegation.cpp already patched for C++20 compatibility")
 endif()

--- a/libs/evmone/compat/patch_evmc.cmake
+++ b/libs/evmone/compat/patch_evmc.cmake
@@ -1,17 +1,28 @@
-# Read source file
+# Patch evmc.hpp for iOS std::optional::value() compatibility.
 file(READ ${SOURCE_DIR}/evmc/include/evmc/evmc.hpp EVMC_CONTENT)
 
-# Always include our compatibility header for Apple platforms
-string(REGEX REPLACE 
-    "#include <optional>" 
-    "#include <optional>\n#ifdef __APPLE__\n#include \"ios_compat.hpp\"\n#endif" 
-    TEMP_CONTENT "${EVMC_CONTENT}")
+string(FIND "${EVMC_CONTENT}" "ios_compat.hpp" ALREADY_PATCHED)
+string(FIND "${EVMC_CONTENT}" "from_hex<T>(s).value()" NEEDS_PATCH)
 
-# Replace optional::value() calls directly with the operator* approach
-string(REGEX REPLACE 
-    "from_hex<T>\\(s\\)\\.value\\(\\)" 
-    "*from_hex<T>(s)" 
-    PATCHED_EVMC_CONTENT "${TEMP_CONTENT}")
+if(ALREADY_PATCHED EQUAL -1 AND NEEDS_PATCH EQUAL -1)
+  message(FATAL_ERROR
+    "evmc.hpp patch failed: expected from_hex<T>(s).value() or existing ios_compat.hpp include. "
+    "Upstream EVMC headers may have changed; update libs/evmone/compat/patch_evmc.cmake.")
+endif()
 
-file(WRITE ${SOURCE_DIR}/evmc/include/evmc/evmc.hpp "${PATCHED_EVMC_CONTENT}")
-message(STATUS "Patched evmc.hpp to handle iOS compatibility") 
+if(NEEDS_PATCH GREATER -1)
+  string(REGEX REPLACE
+      "#include <optional>"
+      "#include <optional>\n#ifdef __APPLE__\n#include \"ios_compat.hpp\"\n#endif"
+      TEMP_CONTENT "${EVMC_CONTENT}")
+
+  string(REGEX REPLACE
+      "from_hex<T>\\(s\\)\\.value\\(\\)"
+      "*from_hex<T>(s)"
+      PATCHED_EVMC_CONTENT "${TEMP_CONTENT}")
+
+  file(WRITE ${SOURCE_DIR}/evmc/include/evmc/evmc.hpp "${PATCHED_EVMC_CONTENT}")
+  message(STATUS "Patched evmc.hpp to handle iOS compatibility")
+else()
+  message(STATUS "evmc.hpp already patched for iOS compatibility")
+endif()

--- a/libs/evmone/compat/patch_evmc.cmake
+++ b/libs/evmone/compat/patch_evmc.cmake
@@ -2,26 +2,49 @@
 file(READ ${SOURCE_DIR}/evmc/include/evmc/evmc.hpp EVMC_CONTENT)
 
 string(FIND "${EVMC_CONTENT}" "ios_compat.hpp" ALREADY_PATCHED)
-string(FIND "${EVMC_CONTENT}" "from_hex<T>(s).value()" NEEDS_PATCH)
+string(FIND "${EVMC_CONTENT}" "from_hex<T>(s).value()" NEEDS_VALUE_PATCH)
+string(FIND "${EVMC_CONTENT}" "*from_hex<T>(s)" HAS_VALUE_COMPAT)
 
-if(ALREADY_PATCHED EQUAL -1 AND NEEDS_PATCH EQUAL -1)
+if(ALREADY_PATCHED EQUAL -1 AND NEEDS_VALUE_PATCH EQUAL -1 AND HAS_VALUE_COMPAT EQUAL -1)
   message(FATAL_ERROR
-    "evmc.hpp patch failed: expected from_hex<T>(s).value() or existing ios_compat.hpp include. "
+    "evmc.hpp patch failed: expected from_hex value()/compat pattern. "
     "Upstream EVMC headers may have changed; update libs/evmone/compat/patch_evmc.cmake.")
 endif()
 
-if(NEEDS_PATCH GREATER -1)
-  string(REGEX REPLACE
-      "#include <optional>"
-      "#include <optional>\n#ifdef __APPLE__\n#include \"ios_compat.hpp\"\n#endif"
-      TEMP_CONTENT "${EVMC_CONTENT}")
+if(NEEDS_VALUE_PATCH GREATER -1 OR (HAS_VALUE_COMPAT GREATER -1 AND ALREADY_PATCHED EQUAL -1))
+  set(TEMP_CONTENT "${EVMC_CONTENT}")
 
-  string(REGEX REPLACE
-      "from_hex<T>\\(s\\)\\.value\\(\\)"
-      "*from_hex<T>(s)"
-      PATCHED_EVMC_CONTENT "${TEMP_CONTENT}")
+  # Prefer an include that exists in EVMC ABI 18 headers.
+  if(ALREADY_PATCHED EQUAL -1)
+    string(FIND "${TEMP_CONTENT}" "#include <utility>" HAS_UTILITY)
+    if(HAS_UTILITY GREATER -1)
+      string(REPLACE
+          "#include <utility>"
+          "#include <utility>\n#ifdef __APPLE__\n#include \"ios_compat.hpp\"\n#endif"
+          TEMP_CONTENT "${TEMP_CONTENT}")
+    else()
+      string(REPLACE
+          "#include <evmc/hex.hpp>"
+          "#include <evmc/hex.hpp>\n#ifdef __APPLE__\n#include \"ios_compat.hpp\"\n#endif"
+          TEMP_CONTENT "${TEMP_CONTENT}")
+    endif()
+  endif()
 
-  file(WRITE ${SOURCE_DIR}/evmc/include/evmc/evmc.hpp "${PATCHED_EVMC_CONTENT}")
+  if(NEEDS_VALUE_PATCH GREATER -1)
+    string(REGEX REPLACE
+        "from_hex<T>\\(s\\)\\.value\\(\\)"
+        "*from_hex<T>(s)"
+        TEMP_CONTENT "${TEMP_CONTENT}")
+  endif()
+
+  string(FIND "${TEMP_CONTENT}" "from_hex<T>(s).value()" STILL_VALUE)
+  string(FIND "${TEMP_CONTENT}" "ios_compat.hpp" HAS_COMPAT)
+  if(STILL_VALUE GREATER -1 OR HAS_COMPAT EQUAL -1)
+    message(FATAL_ERROR
+      "evmc.hpp patch incomplete; update libs/evmone/compat/patch_evmc.cmake.")
+  endif()
+
+  file(WRITE ${SOURCE_DIR}/evmc/include/evmc/evmc.hpp "${TEMP_CONTENT}")
   message(STATUS "Patched evmc.hpp to handle iOS compatibility")
 else()
   message(STATUS "evmc.hpp already patched for iOS compatibility")

--- a/libs/evmone/compat/patch_evmc_c23_enum.cmake
+++ b/libs/evmone/compat/patch_evmc_c23_enum.cmake
@@ -1,0 +1,43 @@
+# Patch evmc.h for C compilers without C23 support.
+#
+# EVMC 0.23 declares `enum evmc_access_status : bool` (C23 fixed underlying
+# type). MSVC's C compiler and older GCC (e.g. Debian containers) reject this
+# syntax when the header is included from C code such as keccak_bridge.c or
+# call_evmone.c. Keep the C23 form for C++ and C23-capable compilers and fall
+# back to a plain enum otherwise. The enum is only used as a callback return
+# type (never as a struct field), so the underlying-type difference does not
+# affect any ABI used by Colibri.
+file(READ ${SOURCE_DIR}/evmc/include/evmc/evmc.h EVMC_H_CONTENT)
+
+set(C23_ENUM_MARKER "colibri: C23 enum compat")
+string(FIND "${EVMC_H_CONTENT}" "${C23_ENUM_MARKER}" ALREADY_PATCHED)
+string(FIND "${EVMC_H_CONTENT}" "enum evmc_access_status : bool" HAS_C23_ENUM)
+
+if(ALREADY_PATCHED EQUAL -1 AND HAS_C23_ENUM EQUAL -1)
+  message(FATAL_ERROR
+    "evmc.h patch failed: expected `enum evmc_access_status : bool`. "
+    "Upstream EVMC headers may have changed; update libs/evmone/compat/patch_evmc_c23_enum.cmake.")
+endif()
+
+if(ALREADY_PATCHED EQUAL -1)
+  string(REPLACE
+      "enum evmc_access_status : bool"
+      "/* ${C23_ENUM_MARKER}: plain enum for pre-C23 C compilers (MSVC, older GCC). */
+#if defined(__cplusplus) || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
+enum evmc_access_status : bool
+#else
+enum evmc_access_status
+#endif"
+      EVMC_H_CONTENT "${EVMC_H_CONTENT}")
+
+  string(FIND "${EVMC_H_CONTENT}" "${C23_ENUM_MARKER}" PATCH_APPLIED)
+  if(PATCH_APPLIED EQUAL -1)
+    message(FATAL_ERROR
+      "evmc.h patch incomplete; update libs/evmone/compat/patch_evmc_c23_enum.cmake.")
+  endif()
+
+  file(WRITE ${SOURCE_DIR}/evmc/include/evmc/evmc.h "${EVMC_H_CONTENT}")
+  message(STATUS "Patched evmc.h for pre-C23 C compilers")
+else()
+  message(STATUS "evmc.h already patched for pre-C23 C compilers")
+endif()

--- a/libs/evmone/compat/patch_instructions_calls.cmake
+++ b/libs/evmone/compat/patch_instructions_calls.cmake
@@ -1,11 +1,23 @@
-# Read source file
+# Patch instructions_calls.cpp: avoid std::get<> for iOS libstdc++/variant quirks.
 file(READ ${SOURCE_DIR}/lib/evmone/instructions_calls.cpp CALLS_CONTENT)
 
-# First patch the specific instances we're seeing in the errors
-string(REGEX REPLACE 
-    "const auto& code_addr = std::get<evmc::address>\\(target_addr_or_result\\)" 
-    "const auto* addr_ptr = std::get_if<evmc::address>(&target_addr_or_result);\n    const auto& code_addr = *addr_ptr" 
-    PATCHED_CALLS_CONTENT "${CALLS_CONTENT}")
+string(FIND "${CALLS_CONTENT}" "std::get_if<evmc::address>(&target_addr_or_result)" ALREADY_PATCHED)
+string(FIND "${CALLS_CONTENT}" "std::get<evmc::address>(target_addr_or_result)" NEEDS_PATCH)
 
-file(WRITE ${SOURCE_DIR}/lib/evmone/instructions_calls.cpp "${PATCHED_CALLS_CONTENT}")
-message(STATUS "Patched instructions_calls.cpp to handle iOS compatibility") 
+if(ALREADY_PATCHED EQUAL -1 AND NEEDS_PATCH EQUAL -1)
+  message(FATAL_ERROR
+    "instructions_calls.cpp patch failed: expected std::get<evmc::address>(...) pattern. "
+    "Upstream source may have changed; update libs/evmone/compat/patch_instructions_calls.cmake.")
+endif()
+
+if(NEEDS_PATCH GREATER -1)
+  string(REGEX REPLACE
+      "const auto& code_addr = std::get<evmc::address>\\(target_addr_or_result\\)"
+      "const auto* addr_ptr = std::get_if<evmc::address>(&target_addr_or_result);\n    const auto& code_addr = *addr_ptr"
+      PATCHED_CALLS_CONTENT "${CALLS_CONTENT}")
+
+  file(WRITE ${SOURCE_DIR}/lib/evmone/instructions_calls.cpp "${PATCHED_CALLS_CONTENT}")
+  message(STATUS "Patched instructions_calls.cpp to handle iOS compatibility")
+else()
+  message(STATUS "instructions_calls.cpp already patched for iOS compatibility")
+endif()

--- a/libs/evmone/evmone_c_wrapper.cpp
+++ b/libs/evmone/evmone_c_wrapper.cpp
@@ -16,13 +16,14 @@ static_assert(EVMC_ABI_VERSION == 18, "evmone wrapper requires EVMC ABI 18 (evmo
 
 namespace {
 
-evmc_revision map_revision(int revision) noexcept {
+bool map_revision(int revision, evmc_revision* out) noexcept {
   switch (revision) {
   case EVMONE_REV_OSAKA:
-    return EVMC_OSAKA;
+    *out = EVMC_OSAKA;
+    return true;
   default:
-    // Unknown Colibri revision IDs fall back to Osaka until Amsterdam is activated.
-    return EVMC_OSAKA;
+    // Refuse unknown Colibri revision IDs instead of silently selecting a fork.
+    return false;
   }
 }
 
@@ -204,7 +205,7 @@ public:
       int status = m_adapter.c_interface->access_account(
           m_adapter.context,
           reinterpret_cast<const evmc_address*>(&addr));
-      return status ? EVMC_ACCESS_WARM : EVMC_ACCESS_COLD;
+      return status == EVMONE_ACCESS_WARM ? EVMC_ACCESS_WARM : EVMC_ACCESS_COLD;
     }
     return EVMC_ACCESS_COLD;
   }
@@ -215,7 +216,7 @@ public:
           m_adapter.context,
           reinterpret_cast<const evmc_address*>(&addr),
           reinterpret_cast<const evmc_bytes32*>(&key));
-      return status ? EVMC_ACCESS_WARM : EVMC_ACCESS_COLD;
+      return status == EVMONE_ACCESS_WARM ? EVMC_ACCESS_WARM : EVMC_ACCESS_COLD;
     }
     return EVMC_ACCESS_COLD;
   }
@@ -288,6 +289,13 @@ extern "C" evmone_result evmone_execute(
 
   auto* vm = static_cast<struct evmc_vm*>(executor);
 
+  evmc_revision rev = EVMC_OSAKA;
+  if (!map_revision(revision, &rev)) {
+    evmone_result err{};
+    err.status_code = EVMC_INTERNAL_ERROR;
+    return err;
+  }
+
   HostInterfaceAdapter adapter(host_interface, host_context);
   EvmoneHostAdapter    host(adapter);
 
@@ -310,9 +318,7 @@ extern "C" evmone_result evmone_execute(
   cpp_msg.code         = code;
   cpp_msg.code_size    = code_size;
 
-  evmc_result cpp_result = vm->execute(vm, interface, context,
-                                       map_revision(revision),
-                                       &cpp_msg, code, code_size);
+  evmc_result cpp_result = vm->execute(vm, interface, context, rev, &cpp_msg, code, code_size);
 
   evmone_result c_result{};
   c_result.status_code      = cpp_result.status_code;

--- a/libs/evmone/evmone_c_wrapper.cpp
+++ b/libs/evmone/evmone_c_wrapper.cpp
@@ -3,15 +3,30 @@
  */
 #include "evmone_c_wrapper.h"
 
-// C++ headers
+#include <cstring>
 #include <memory>
 #include <string>
 #include <vector>
 
-// evmone headers - make sure to include these after all C++ standard headers
 #include <evmc/evmc.h>
 #include <evmc/evmc.hpp>
 #include <evmone/evmone.h>
+
+static_assert(EVMC_ABI_VERSION == 18, "evmone wrapper requires EVMC ABI 18 (evmone >= 0.23)");
+
+namespace {
+
+evmc_revision map_revision(int revision) noexcept {
+  switch (revision) {
+  case EVMONE_REV_OSAKA:
+    return EVMC_OSAKA;
+  default:
+    // Unknown Colibri revision IDs fall back to Osaka until Amsterdam is activated.
+    return EVMC_OSAKA;
+  }
+}
+
+} // namespace
 
 /* C++ to C host interface adapter */
 struct HostInterfaceAdapter {
@@ -38,7 +53,6 @@ public:
   evmc::bytes32 get_storage(const evmc::address& addr, const evmc::bytes32& key) const noexcept override {
     if (!m_adapter.c_interface->get_storage) return {};
 
-    // Create a temporary to safely store the result
     evmc_bytes32 result = m_adapter.c_interface->get_storage(
         m_adapter.context,
         reinterpret_cast<const evmc_address*>(&addr),
@@ -63,11 +77,16 @@ public:
   evmc::bytes32 get_balance(const evmc::address& addr) const noexcept override {
     if (!m_adapter.c_interface->get_balance) return {};
 
-    // Create a temporary to safely store the result
     evmc_bytes32 result = m_adapter.c_interface->get_balance(
         m_adapter.context, reinterpret_cast<const evmc_address*>(&addr));
 
     return *reinterpret_cast<const evmc::bytes32*>(&result);
+  }
+
+  uint64_t get_nonce(const evmc::address& addr) const noexcept override {
+    if (!m_adapter.c_interface->get_nonce) return 0;
+    return m_adapter.c_interface->get_nonce(m_adapter.context,
+                                            reinterpret_cast<const evmc_address*>(&addr));
   }
 
   size_t get_code_size(const evmc::address& addr) const noexcept override {
@@ -79,7 +98,6 @@ public:
   evmc::bytes32 get_code_hash(const evmc::address& addr) const noexcept override {
     if (!m_adapter.c_interface->get_code_hash) return {};
 
-    // Create a temporary to safely store the result
     evmc_bytes32 result = m_adapter.c_interface->get_code_hash(
         m_adapter.context, reinterpret_cast<const evmc_address*>(&addr));
 
@@ -97,7 +115,6 @@ public:
         buffer_size);
   }
 
-  // Updated return type to match EVMC API
   bool selfdestruct(const evmc::address& addr, const evmc::address& beneficiary) noexcept override {
     if (m_adapter.c_interface->selfdestruct) {
       m_adapter.c_interface->selfdestruct(
@@ -114,7 +131,8 @@ public:
 
     evmone_message c_msg{};
     c_msg.kind         = static_cast<decltype(c_msg.kind)>(msg.kind);
-    c_msg.is_static    = msg.flags & EVMC_STATIC;
+    c_msg.is_static    = (msg.flags & EVMC_STATIC) != 0;
+    c_msg.is_delegated = (msg.flags & EVMC_DELEGATED) != 0;
     c_msg.depth        = msg.depth;
     c_msg.gas          = msg.gas;
     c_msg.destination  = *reinterpret_cast<const evmc_address*>(&msg.recipient);
@@ -122,24 +140,21 @@ public:
     c_msg.input_data   = msg.input_data;
     c_msg.input_size   = msg.input_size;
     c_msg.value        = *reinterpret_cast<const evmc_bytes32*>(&msg.value);
-    c_msg.create_salt  = *reinterpret_cast<const evmc_bytes32*>(&msg.create2_salt);
     c_msg.code_address = *reinterpret_cast<const evmc_address*>(&msg.code_address);
 
     evmone_result c_result{};
-    m_adapter.c_interface->call(m_adapter.context, &c_msg, nullptr, 0, &c_result);
+    m_adapter.c_interface->call(m_adapter.context, &c_msg, msg.code, msg.code_size, &c_result);
 
-    evmc::Result cpp_result;
-    cpp_result.status_code = static_cast<evmc_status_code>(c_result.status_code);
-    cpp_result.gas_left    = c_result.gas_left;
-    cpp_result.gas_refund  = c_result.gas_refund;
-    cpp_result.output_data = c_result.output_data;
-    cpp_result.output_size = c_result.output_size;
-    if (c_result.create_address) {
-      cpp_result.create_address = *reinterpret_cast<const evmc::address*>(c_result.create_address);
-    }
-
-    // Caller must handle memory management
-    return cpp_result;
+    // Transfer ownership of host-provided output buffers without copying.
+    // The Colibri host keeps results alive until evmone_release_result().
+    evmc_result raw{};
+    raw.status_code = static_cast<evmc_status_code>(c_result.status_code);
+    raw.gas_left    = static_cast<int64_t>(c_result.gas_left);
+    raw.gas_refund  = static_cast<int64_t>(c_result.gas_refund);
+    raw.output_data = c_result.output_data;
+    raw.output_size = c_result.output_size;
+    raw.release     = nullptr;
+    return evmc::Result{raw};
   }
 
   evmc_tx_context get_tx_context() const noexcept override {
@@ -157,13 +172,15 @@ public:
     result.chain_id          = *reinterpret_cast<const evmc_uint256be*>(&c_tx_ctx.chain_id);
     result.block_base_fee    = *reinterpret_cast<const evmc_uint256be*>(&c_tx_ctx.block_base_fee);
     result.blob_base_fee     = *reinterpret_cast<const evmc_uint256be*>(&c_tx_ctx.blob_base_fee);
+    result.blob_hashes       = c_tx_ctx.blob_hashes;
+    result.blob_hashes_count = c_tx_ctx.blob_hashes_count;
+    result.block_slot_number = c_tx_ctx.block_slot_number;
     return result;
   }
 
   evmc::bytes32 get_block_hash(int64_t number) const noexcept override {
     if (!m_adapter.c_interface->get_block_hash) return {};
 
-    // Create a temporary to safely store the result
     evmc_bytes32 result = m_adapter.c_interface->get_block_hash(m_adapter.context, number);
 
     return *reinterpret_cast<const evmc::bytes32*>(&result);
@@ -187,7 +204,7 @@ public:
       int status = m_adapter.c_interface->access_account(
           m_adapter.context,
           reinterpret_cast<const evmc_address*>(&addr));
-      return static_cast<evmc_access_status>(status);
+      return status ? EVMC_ACCESS_WARM : EVMC_ACCESS_COLD;
     }
     return EVMC_ACCESS_COLD;
   }
@@ -198,7 +215,7 @@ public:
           m_adapter.context,
           reinterpret_cast<const evmc_address*>(&addr),
           reinterpret_cast<const evmc_bytes32*>(&key));
-      return static_cast<evmc_access_status>(status);
+      return status ? EVMC_ACCESS_WARM : EVMC_ACCESS_COLD;
     }
     return EVMC_ACCESS_COLD;
   }
@@ -227,25 +244,9 @@ public:
   }
 };
 
-/* Simple holder for result's output */
-struct ResultDataHolder {
-  std::vector<uint8_t> output_data;
-};
-
-/* Release callback for result */
-void release_result_callback(const evmc_result* result) {
-  // This function is called by EVMC to release resources
-  // In our case, there's nothing to do as we don't allocate extra resources
-  // for EVMC results
-  (void) result;
-}
-
 extern "C" {
-// Forward declaration for evmc_create_evmone from evmone.h
 struct evmc_vm* evmc_create_evmone(void) noexcept;
 
-// For WASM compatibility, provide evmone_create as a wrapper around evmc_create_evmone
-// This helps when the symbol is expected under a different name
 #if defined(EVMONE_WASM_BUILD) && defined(__EMSCRIPTEN__)
 struct evmc_vm* evmone_create(void) noexcept {
   return evmc_create_evmone();
@@ -256,19 +257,21 @@ struct evmc_vm* evmone_create(void) noexcept {
 /* Create a new EVM instance */
 extern "C" void* evmone_create_executor() {
 #if defined(EVMONE_WASM_BUILD) && defined(__EMSCRIPTEN__)
-  // For WASM builds, we'll use a simpler approach that calls evmone_create
-  // directly to avoid any linking issues with evmc_create_evmone
-  return evmone_create();
+  auto* vm = evmone_create();
 #else
-  // Standard path for non-WASM builds
-  return evmc_create_evmone();
+  auto* vm = evmc_create_evmone();
 #endif
+  if (!vm) return nullptr;
+  if (vm->abi_version != EVMC_ABI_VERSION) {
+    evmc_destroy(vm);
+    return nullptr;
+  }
+  return vm;
 }
 
 /* Destroy an EVM instance */
 extern "C" void evmone_destroy_executor(void* executor) {
   if (executor) {
-    // Use the evmc helper function to destroy VM
     evmc_destroy(static_cast<evmc_vm*>(executor));
   }
 }
@@ -285,18 +288,17 @@ extern "C" evmone_result evmone_execute(
 
   auto* vm = static_cast<struct evmc_vm*>(executor);
 
-  // Setup host adapter
   HostInterfaceAdapter adapter(host_interface, host_context);
   EvmoneHostAdapter    host(adapter);
 
-  // Create host context & interface for EVMC
   struct evmc_host_context*         context   = reinterpret_cast<struct evmc_host_context*>(&host);
   const struct evmc_host_interface* interface = &evmc::Host::get_interface();
 
-  // Convert message to evmc_message
   evmc_message cpp_msg{};
   cpp_msg.kind         = static_cast<evmc_call_kind>(msg->kind);
-  cpp_msg.flags        = msg->is_static ? EVMC_STATIC : 0;
+  cpp_msg.flags        = 0;
+  if (msg->is_static) cpp_msg.flags |= EVMC_STATIC;
+  if (msg->is_delegated) cpp_msg.flags |= EVMC_DELEGATED;
   cpp_msg.depth        = msg->depth;
   cpp_msg.gas          = msg->gas;
   cpp_msg.recipient    = *reinterpret_cast<const evmc_address*>(&msg->destination);
@@ -304,31 +306,22 @@ extern "C" evmone_result evmone_execute(
   cpp_msg.input_data   = msg->input_data;
   cpp_msg.input_size   = msg->input_size;
   cpp_msg.value        = *reinterpret_cast<const evmc_bytes32*>(&msg->value);
-  cpp_msg.create2_salt = *reinterpret_cast<const evmc_bytes32*>(&msg->create_salt);
   cpp_msg.code_address = *reinterpret_cast<const evmc_address*>(&msg->code_address);
+  cpp_msg.code         = code;
+  cpp_msg.code_size    = code_size;
 
-  // Execute using the VM's execute function directly
   evmc_result cpp_result = vm->execute(vm, interface, context,
-                                       static_cast<evmc_revision>(revision),
+                                       map_revision(revision),
                                        &cpp_msg, code, code_size);
 
-  // Convert result
   evmone_result c_result{};
   c_result.status_code      = cpp_result.status_code;
-  c_result.gas_left         = cpp_result.gas_left;
-  c_result.gas_refund       = cpp_result.gas_refund;
+  c_result.gas_left         = static_cast<uint64_t>(cpp_result.gas_left);
+  c_result.gas_refund       = static_cast<uint64_t>(cpp_result.gas_refund);
   c_result.output_data      = cpp_result.output_data;
   c_result.output_size      = cpp_result.output_size;
   c_result.release_callback = reinterpret_cast<void*>(cpp_result.release);
-  c_result.release_context  = nullptr; // We don't need additional context
-
-  // Handle create address if present
-  if (cpp_result.create_address.bytes[0] != 0) {
-    c_result.create_address = reinterpret_cast<const evmc_address*>(&cpp_result.create_address);
-  }
-  else {
-    c_result.create_address = nullptr;
-  }
+  c_result.release_context  = nullptr;
 
   return c_result;
 }
@@ -338,16 +331,13 @@ extern "C" void evmone_release_result(evmone_result* result) {
   if (result && result->release_callback) {
     auto release_fn = reinterpret_cast<evmc_release_result_fn>(result->release_callback);
 
-    // Create a temporary evmc_result to release
     evmc_result cpp_result{};
     cpp_result.output_data = result->output_data;
     cpp_result.output_size = result->output_size;
 
-    // Release the resources
     release_fn(&cpp_result);
   }
 
-  // Clear the result data to prevent double-free
   result->output_data      = nullptr;
   result->output_size      = 0;
   result->release_callback = nullptr;

--- a/libs/evmone/evmone_c_wrapper.h
+++ b/libs/evmone/evmone_c_wrapper.h
@@ -51,16 +51,23 @@ typedef struct {
 #include <evmc/evmc.h>
 #endif
 
-/* Result structure */
+/**
+ * Stable Colibri revision IDs mapped to EVMC revisions inside the C++ wrapper.
+ *
+ * Do not pass raw `evmc_revision` numeric values from C: EVMC ABI 18 removed
+ * explicit enumerator values, so Osaka is no longer safely hard-coded as 14.
+ */
+#define EVMONE_REV_OSAKA 0
+
+/* Result structure (CREATE address is computed by the VM since EVMC ABI 18). */
 typedef struct evmone_result {
-  int                 status_code;
-  uint64_t            gas_left;
-  uint64_t            gas_refund;
-  const uint8_t*      output_data;
-  size_t              output_size;
-  void*               release_callback; /* Function pointer to release resources */
-  void*               release_context;  /* Context for the release callback */
-  const evmc_address* create_address;
+  int            status_code;
+  uint64_t       gas_left;
+  uint64_t       gas_refund;
+  const uint8_t* output_data;
+  size_t         output_size;
+  void*          release_callback; /* Function pointer to release resources */
+  void*          release_context;  /* Context for the release callback */
 } evmone_result;
 
 /* Message structure */
@@ -71,6 +78,7 @@ typedef struct evmone_message {
          EVMONE_CREATE,
          EVMONE_CREATE2 } kind;
   bool           is_static;
+  bool           is_delegated; /* EIP-7702 delegated call flag (EVMC_DELEGATED) */
   int32_t        depth;
   int64_t        gas;
   evmc_address   destination;
@@ -78,7 +86,6 @@ typedef struct evmone_message {
   const uint8_t* input_data;
   size_t         input_size;
   evmc_bytes32   value;
-  evmc_bytes32   create_salt;
   evmc_address   code_address; /* Address of the code to execute (for DELEGATECALL) */
 } evmone_message;
 
@@ -97,16 +104,19 @@ typedef enum {
 
 /* Transaction context passed from host to EVM for opcodes like ORIGIN, NUMBER, TIMESTAMP, etc. */
 typedef struct evmone_tx_context {
-  evmc_bytes32 tx_gas_price;
-  evmc_address tx_origin;
-  evmc_address block_coinbase;
-  int64_t      block_number;
-  int64_t      block_timestamp;
-  int64_t      block_gas_limit;
-  evmc_bytes32 block_prev_randao;
-  evmc_bytes32 chain_id;
-  evmc_bytes32 block_base_fee;
-  evmc_bytes32 blob_base_fee;
+  evmc_bytes32        tx_gas_price;
+  evmc_address        tx_origin;
+  evmc_address        block_coinbase;
+  int64_t             block_number;
+  int64_t             block_timestamp;
+  int64_t             block_gas_limit;
+  evmc_bytes32        block_prev_randao;
+  evmc_bytes32        chain_id;
+  evmc_bytes32        block_base_fee;
+  evmc_bytes32        blob_base_fee;
+  const evmc_bytes32* blob_hashes;       /* EIP-4844; pointers must outlive execute() */
+  size_t              blob_hashes_count; /* EIP-4844 */
+  uint64_t            block_slot_number; /* EIP-7843; unused until Amsterdam activation */
 } evmone_tx_context;
 
 /* Access status returned by access_account / access_storage (EIP-2929) */
@@ -118,6 +128,7 @@ typedef bool (*evmone_account_exists_fn)(void* context, const evmc_address* addr
 typedef evmc_bytes32 (*evmone_get_storage_fn)(void* context, const evmc_address* addr, const evmc_bytes32* key);
 typedef evmone_storage_status (*evmone_set_storage_fn)(void* context, const evmc_address* addr, const evmc_bytes32* key, const evmc_bytes32* value);
 typedef evmc_bytes32 (*evmone_get_balance_fn)(void* context, const evmc_address* addr);
+typedef uint64_t (*evmone_get_nonce_fn)(void* context, const evmc_address* addr);
 typedef size_t (*evmone_get_code_size_fn)(void* context, const evmc_address* addr);
 typedef evmc_bytes32 (*evmone_get_code_hash_fn)(void* context, const evmc_address* addr);
 typedef size_t (*evmone_copy_code_fn)(void* context, const evmc_address* addr, size_t code_offset, uint8_t* buffer_data, size_t buffer_size);
@@ -133,22 +144,23 @@ typedef void (*evmone_set_transient_storage_fn)(void* context, const evmc_addres
 
 /* Host interface */
 typedef struct evmone_host_interface {
-  evmone_account_exists_fn          account_exists;
-  evmone_get_storage_fn             get_storage;
-  evmone_set_storage_fn             set_storage;
-  evmone_get_balance_fn             get_balance;
-  evmone_get_code_size_fn           get_code_size;
-  evmone_get_code_hash_fn           get_code_hash;
-  evmone_copy_code_fn               copy_code;
-  evmone_selfdestruct_fn            selfdestruct;
-  evmone_call_fn                    call;
-  evmone_get_tx_context_fn          get_tx_context;
-  evmone_get_block_hash_fn          get_block_hash;
-  evmone_emit_log_fn                emit_log;
-  evmone_access_account_fn          access_account;
-  evmone_access_storage_fn          access_storage;
-  evmone_get_transient_storage_fn   get_transient_storage;
-  evmone_set_transient_storage_fn   set_transient_storage;
+  evmone_account_exists_fn        account_exists;
+  evmone_get_storage_fn           get_storage;
+  evmone_set_storage_fn           set_storage;
+  evmone_get_balance_fn           get_balance;
+  evmone_get_nonce_fn             get_nonce;
+  evmone_get_code_size_fn         get_code_size;
+  evmone_get_code_hash_fn         get_code_hash;
+  evmone_copy_code_fn             copy_code;
+  evmone_selfdestruct_fn          selfdestruct;
+  evmone_call_fn                  call;
+  evmone_get_tx_context_fn        get_tx_context;
+  evmone_get_block_hash_fn        get_block_hash;
+  evmone_emit_log_fn              emit_log;
+  evmone_access_account_fn        access_account;
+  evmone_access_storage_fn        access_storage;
+  evmone_get_transient_storage_fn get_transient_storage;
+  evmone_set_transient_storage_fn set_transient_storage;
 } evmone_host_interface;
 
 /* Create EVM executor instance */

--- a/libs/evmone/evmone_c_wrapper.h
+++ b/libs/evmone/evmone_c_wrapper.h
@@ -57,7 +57,8 @@ typedef struct {
  * Do not pass raw `evmc_revision` numeric values from C: EVMC ABI 18 removed
  * explicit enumerator values, so Osaka is no longer safely hard-coded as 14.
  */
-#define EVMONE_REV_OSAKA 0
+/* Non-zero so zero-initialized callers cannot silently select Osaka. */
+#define EVMONE_REV_OSAKA 1
 
 /* Result structure (CREATE address is computed by the VM since EVMC ABI 18). */
 typedef struct evmone_result {
@@ -70,7 +71,11 @@ typedef struct evmone_result {
   void*          release_context;  /* Context for the release callback */
 } evmone_result;
 
-/* Message structure */
+/* Message structure.
+ *
+ * CREATE2 salt is no longer part of EVMC ABI 18 messages; the VM derives the
+ * CREATE/CREATE2 address itself and passes it via `destination`/`recipient`.
+ */
 typedef struct evmone_message {
   enum { EVMONE_CALL,
          EVMONE_DELEGATECALL,

--- a/src/chains/eth/verifier/call_evmone.c
+++ b/src/chains/eth/verifier/call_evmone.c
@@ -353,6 +353,19 @@ static trace_entry_t* create_trace_entry(evmone_context_t* ctx, const struct evm
   return entry;
 }
 
+/**
+ * Bumps the CREATE/CREATE2 sender nonce on the parent context.
+ *
+ * EVMC ABI 18: the VM reads the pre-bump nonce via get_nonce() to compute the
+ * create address, then the host must increment before the child state checkpoint.
+ * The bump is not reverted when creation fails (Yellow Paper / evmone Host::call).
+ */
+static void bump_creator_nonce(evmone_context_t* ctx, const address_t sender) {
+  call_account_t* acc = call_account_get_or_create(ctx, sender);
+  acc->nonce++;
+  acc->flags |= ACCOUNT_HAS_NONCE;
+}
+
 static void host_call(void* context, const struct evmone_message* msg, const uint8_t* code, size_t code_size, struct evmone_result* result) {
   evmone_context_t* ctx = (evmone_context_t*) context;
   EVM_LOG("========Executing child call...");
@@ -384,11 +397,24 @@ static void host_call(void* context, const struct evmone_message* msg, const uin
     return;
   }
 
+  const bool is_create = (msg->kind == CALL_KIND_CREATE || msg->kind == CALL_KIND_CREATE2);
+
+  // Must run before the child context so a failed CREATE cannot roll the bump back.
+  if (is_create) {
+    bump_creator_nonce(ctx, msg->sender.bytes);
+    EVM_LOG("CREATE/CREATE2: bumped creator nonce");
+  }
+
   const uint8_t* execution_code      = code;
   size_t         execution_code_size = code_size;
   bytes_t        fetched_code        = {0};
 
-  if ((execution_code == NULL || execution_code_size == 0) && msg->kind != CALL_KIND_CREATE && msg->kind != CALL_KIND_CREATE2) {
+  if (is_create) {
+    // Initcode is passed as call input; the VM already put the create address in destination.
+    execution_code      = msg->input_data;
+    execution_code_size = msg->input_size;
+  }
+  else if (execution_code == NULL || execution_code_size == 0) {
     EVM_LOG("Code not provided, fetching from code_address");
     fetched_code        = call_account_get_code(ctx, msg->code_address.bytes);
     execution_code      = fetched_code.data;
@@ -430,12 +456,26 @@ static void host_call(void* context, const struct evmone_message* msg, const uin
     child.trace_address = trace->trace_address; // borrowed, owned by root trace list
   }
 
+  // Spurious Dragon+: newly created accounts start at nonce 1 (revertible with child).
+  if (is_create) {
+    call_account_t* created = call_account_get_or_create(&child, msg->destination.bytes);
+    created->nonce = 1;
+    created->flags |= ACCOUNT_HAS_NONCE;
+  }
+
+  // During initcode execution CALLDATA must be empty (initcode is the code, not input).
+  evmone_message exec_msg = *msg;
+  if (is_create) {
+    exec_msg.input_data = NULL;
+    exec_msg.input_size = 0;
+  }
+
   evmone_result exec_result = evmone_execute(
       ctx->executor,
       &host_interface,
       &child,
       EVMONE_REV_OSAKA,
-      msg,
+      &exec_msg,
       execution_code,
       execution_code_size);
 

--- a/src/chains/eth/verifier/call_evmone.c
+++ b/src/chains/eth/verifier/call_evmone.c
@@ -56,7 +56,7 @@ static void debug_print_bytes32(const char* prefix, const evmc_bytes32* data) {
 #define debug_print_bytes32(prefix, data) (void) 0
 #endif
 
-#define EVMC_REV_OSAKA 14
+/* Execution uses EVMONE_REV_OSAKA from evmone_c_wrapper.h (mapped to EVMC_OSAKA). */
 
 static const char* evmone_status_message(int code) {
   static const char* positive_msgs[] = {
@@ -236,6 +236,19 @@ static evmc_bytes32 host_get_balance(void* context, const evmc_address* addr) {
 
   debug_print_bytes32("get_balance result", &result);
   return result;
+}
+
+static uint64_t host_get_nonce(void* context, const evmc_address* addr) {
+  evmone_context_t* ctx = (evmone_context_t*) context;
+  debug_print_address("get_nonce for", addr);
+
+  call_account_t* acc = call_account_find(ctx, addr->bytes);
+  if (acc && (acc->flags & ACCOUNT_HAS_NONCE)) {
+    EVM_LOG("get_nonce result: %l", (size_t) acc->nonce);
+    return acc->nonce;
+  }
+  EVM_LOG("get_nonce result: 0 (missing)");
+  return 0;
 }
 
 static size_t host_get_code_size(void* context, const evmc_address* addr) {
@@ -421,7 +434,7 @@ static void host_call(void* context, const struct evmone_message* msg, const uin
       ctx->executor,
       &host_interface,
       &child,
-      EVMC_REV_OSAKA,
+      EVMONE_REV_OSAKA,
       msg,
       execution_code,
       execution_code_size);
@@ -465,9 +478,13 @@ static void host_get_tx_context(void* context, evmone_tx_context* result) {
   memcpy(result->block_prev_randao.bytes, root->block_prev_randao, 32);
   memcpy(result->block_base_fee.bytes, root->block_base_fee, 32);
   memcpy(result->blob_base_fee.bytes, root->blob_base_fee, 32);
-  result->block_number    = (int64_t) root->block_number;
-  result->block_timestamp = (int64_t) root->timestamp;
-  result->block_gas_limit = (int64_t) root->block_gas_limit;
+  result->block_number      = (int64_t) root->block_number;
+  result->block_timestamp   = (int64_t) root->timestamp;
+  result->block_gas_limit   = (int64_t) root->block_gas_limit;
+  result->blob_hashes       = NULL;
+  result->blob_hashes_count = 0;
+  // SLOTNUM (EIP-7843) stays zero until Amsterdam is activated explicitly.
+  result->block_slot_number = 0;
   // gas_price as big-endian uint256
   uint64_t gp = root->gas_price;
   for (int i = 31; i >= 0 && gp; i--) {
@@ -612,6 +629,7 @@ static const struct evmone_host_interface host_interface = {
     .get_storage           = host_get_storage,
     .set_storage           = host_set_storage,
     .get_balance           = host_get_balance,
+    .get_nonce             = host_get_nonce,
     .get_code_size         = host_get_code_size,
     .get_code_hash         = host_get_code_hash,
     .copy_code             = host_copy_code,
@@ -804,7 +822,7 @@ INTERNAL c4_status_t eth_run_call_evmone_with_events(verify_ctx_t* ctx, evm_call
       executor,
       &host_interface,
       &context,
-      EVMC_REV_OSAKA,
+      EVMONE_REV_OSAKA,
       &message,
       code.data,
       code.len);

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -77,6 +77,13 @@ foreach(test_source ${TEST_SOURCES})
         target_link_libraries(${test_name} PRIVATE eth_bn254 intx_wrapper eth_precompiles)
     endif()
 
+    if("${test_name}" STREQUAL "test_evmone_abi")
+        if(EVMONE)
+            target_compile_definitions(${test_name} PRIVATE EVMONE)
+            target_link_libraries(${test_name} PRIVATE evmone_wrapper)
+        endif()
+    endif()
+
     if("${test_name}" STREQUAL "test_bn254")
         target_link_libraries(${test_name} PRIVATE eth_bn254 intx_wrapper util)
     endif()

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -77,7 +77,7 @@ foreach(test_source ${TEST_SOURCES})
         target_link_libraries(${test_name} PRIVATE eth_bn254 intx_wrapper eth_precompiles)
     endif()
 
-    if("${test_name}" STREQUAL "test_evmone_abi")
+    if("${test_name}" MATCHES "^test_evmone_")
         if(EVMONE)
             target_compile_definitions(${test_name} PRIVATE EVMONE)
             target_link_libraries(${test_name} PRIVATE evmone_wrapper)

--- a/test/unittests/test_evmone_abi.c
+++ b/test/unittests/test_evmone_abi.c
@@ -114,6 +114,8 @@ static void host_call(void* context, const struct evmone_message* msg, const uin
   if (msg->kind == EVMONE_CREATE || msg->kind == EVMONE_CREATE2) {
     host->saw_create       = true;
     host->last_create_dest = msg->destination;
+    // EVMC ABI 18 host contract: bump creator nonce; not reverted on failure.
+    host->nonce++;
   }
 }
 
@@ -267,8 +269,46 @@ void test_evmone_create_uses_get_nonce(void) {
   TEST_ASSERT_EQUAL_INT(0, result.status_code);
   TEST_ASSERT_TRUE(host.saw_create);
   TEST_ASSERT_EQUAL_UINT32(1, host.nonce_calls);
+  TEST_ASSERT_EQUAL_UINT64(2, host.nonce); // host bumped after pre-bump read of 1
   TEST_ASSERT_EQUAL_MEMORY(zero_address, host.last_nonce_addr.bytes, sizeof(zero_address));
   TEST_ASSERT_EQUAL_MEMORY(expected, host.last_create_dest.bytes, 20);
+
+  evmone_release_result(&result);
+  evmone_destroy_executor(executor);
+}
+
+void test_evmone_create_bumps_nonce_between_creates(void) {
+  // Two empty CREATEs; second address must use bumped nonce.
+  // PUSH1 0 / PUSH1 0 / PUSH1 0 / CREATE / PUSH1 0 / PUSH1 0 / PUSH1 0 / CREATE / STOP
+  const uint8_t code[] = {
+      0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0xf0,
+      0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0xf0,
+      0x00};
+
+  // create(0x00..00, nonce=0) and create(0x00..00, nonce=1)
+  const uint8_t addr_nonce0[20] = {
+      0xbd, 0x77, 0x04, 0x16, 0xa3, 0x34, 0x5f, 0x91, 0xe4, 0xb3,
+      0x45, 0x76, 0xcb, 0x80, 0x4a, 0x57, 0x6f, 0xa4, 0x8e, 0xb1};
+  const uint8_t addr_nonce1[20] = {
+      0x5a, 0x44, 0x37, 0x04, 0xdd, 0x4b, 0x59, 0x4b, 0x38, 0x2c,
+      0x22, 0xa0, 0x83, 0xe2, 0xbd, 0x30, 0x90, 0xa6, 0xfe, 0xf3};
+
+  void*       executor = evmone_create_executor();
+  test_host_t host     = {.nonce = 0};
+  TEST_ASSERT_NOT_NULL(executor);
+
+  evmone_message msg = {0};
+  msg.kind           = EVMONE_CALL;
+  msg.gas            = 1000000;
+
+  evmone_result result = evmone_execute(executor, &g_host, &host, EVMONE_REV_OSAKA, &msg, code, sizeof(code));
+  TEST_ASSERT_EQUAL_INT(0, result.status_code);
+  TEST_ASSERT_EQUAL_UINT32(2, host.nonce_calls);
+  TEST_ASSERT_EQUAL_UINT64(2, host.nonce);
+
+  // Without the host-side bump the second CREATE would reuse the nonce=0 address.
+  TEST_ASSERT_TRUE(memcmp(addr_nonce0, addr_nonce1, 20) != 0);
+  TEST_ASSERT_EQUAL_MEMORY(addr_nonce1, host.last_create_dest.bytes, 20);
 
   evmone_release_result(&result);
   evmone_destroy_executor(executor);
@@ -320,6 +360,7 @@ int main(void) {
   RUN_TEST(test_evmone_osaka_stop);
   RUN_TEST(test_evmone_revision_stays_on_osaka);
   RUN_TEST(test_evmone_create_uses_get_nonce);
+  RUN_TEST(test_evmone_create_bumps_nonce_between_creates);
   RUN_TEST(test_evmone_tx_context_blob_hashes);
 #else
   RUN_TEST(test_evmone_skipped);

--- a/test/unittests/test_evmone_abi.c
+++ b/test/unittests/test_evmone_abi.c
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2025 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "unity.h"
+
+#ifdef EVMONE
+#include "evmone_c_wrapper.h"
+#include <evmc/evmc.h>
+#include <string.h>
+
+typedef struct {
+  uint64_t     nonce;
+  evmc_address last_create_dest;
+  bool         saw_create;
+  evmc_bytes32 blob_hashes[1];
+} test_host_t;
+
+static bool host_account_exists(void* context, const evmc_address* addr) {
+  (void) context;
+  (void) addr;
+  return true;
+}
+
+static evmc_bytes32 host_get_storage(void* context, const evmc_address* addr, const evmc_bytes32* key) {
+  (void) context;
+  (void) addr;
+  (void) key;
+  return (evmc_bytes32){0};
+}
+
+static evmone_storage_status host_set_storage(void* context, const evmc_address* addr, const evmc_bytes32* key,
+                                              const evmc_bytes32* value) {
+  (void) context;
+  (void) addr;
+  (void) key;
+  (void) value;
+  return EVMONE_STORAGE_ASSIGNED;
+}
+
+static evmc_bytes32 host_get_balance(void* context, const evmc_address* addr) {
+  (void) context;
+  (void) addr;
+  evmc_bytes32 bal = {0};
+  bal.bytes[31]    = 1; // non-zero balance so CREATE with endowment can proceed if needed
+  return bal;
+}
+
+static uint64_t host_get_nonce(void* context, const evmc_address* addr) {
+  (void) addr;
+  return ((test_host_t*) context)->nonce;
+}
+
+static size_t host_get_code_size(void* context, const evmc_address* addr) {
+  (void) context;
+  (void) addr;
+  return 0;
+}
+
+static evmc_bytes32 host_get_code_hash(void* context, const evmc_address* addr) {
+  (void) context;
+  (void) addr;
+  return (evmc_bytes32){0};
+}
+
+static size_t host_copy_code(void* context, const evmc_address* addr, size_t code_offset, uint8_t* buffer_data,
+                             size_t buffer_size) {
+  (void) context;
+  (void) addr;
+  (void) code_offset;
+  (void) buffer_data;
+  (void) buffer_size;
+  return 0;
+}
+
+static void host_selfdestruct(void* context, const evmc_address* addr, const evmc_address* beneficiary) {
+  (void) context;
+  (void) addr;
+  (void) beneficiary;
+}
+
+static void host_call(void* context, const struct evmone_message* msg, const uint8_t* code, size_t code_size,
+                      struct evmone_result* result) {
+  test_host_t* host = (test_host_t*) context;
+  (void) code;
+  (void) code_size;
+  memset(result, 0, sizeof(*result));
+  result->status_code = 0;
+  result->gas_left    = msg->gas;
+
+  if (msg->kind == EVMONE_CREATE || msg->kind == EVMONE_CREATE2) {
+    host->saw_create       = true;
+    host->last_create_dest = msg->destination;
+  }
+}
+
+static void host_get_tx_context(void* context, struct evmone_tx_context* result) {
+  test_host_t* host = (test_host_t*) context;
+  memset(result, 0, sizeof(*result));
+  result->block_gas_limit   = 30000000;
+  result->blob_hashes       = host->blob_hashes;
+  result->blob_hashes_count = 1;
+  result->block_slot_number = 0;
+}
+
+static evmc_bytes32 host_get_block_hash(void* context, int64_t number) {
+  (void) context;
+  (void) number;
+  return (evmc_bytes32){0};
+}
+
+static void host_emit_log(void* context, const evmc_address* addr, const uint8_t* data, size_t data_size,
+                          const evmc_bytes32 topics[], size_t topic_count) {
+  (void) context;
+  (void) addr;
+  (void) data;
+  (void) data_size;
+  (void) topics;
+  (void) topic_count;
+}
+
+static int host_access_account(void* context, const evmc_address* addr) {
+  (void) context;
+  (void) addr;
+  return EVMONE_ACCESS_COLD;
+}
+
+static int host_access_storage(void* context, const evmc_address* addr, const evmc_bytes32* key) {
+  (void) context;
+  (void) addr;
+  (void) key;
+  return EVMONE_ACCESS_COLD;
+}
+
+static evmc_bytes32 host_get_transient_storage(void* context, const evmc_address* addr, const evmc_bytes32* key) {
+  (void) context;
+  (void) addr;
+  (void) key;
+  return (evmc_bytes32){0};
+}
+
+static void host_set_transient_storage(void* context, const evmc_address* addr, const evmc_bytes32* key,
+                                       const evmc_bytes32* value) {
+  (void) context;
+  (void) addr;
+  (void) key;
+  (void) value;
+}
+
+static const evmone_host_interface g_host = {
+    .account_exists        = host_account_exists,
+    .get_storage           = host_get_storage,
+    .set_storage           = host_set_storage,
+    .get_balance           = host_get_balance,
+    .get_nonce             = host_get_nonce,
+    .get_code_size         = host_get_code_size,
+    .get_code_hash         = host_get_code_hash,
+    .copy_code             = host_copy_code,
+    .selfdestruct          = host_selfdestruct,
+    .call                  = host_call,
+    .get_tx_context        = host_get_tx_context,
+    .get_block_hash        = host_get_block_hash,
+    .emit_log              = host_emit_log,
+    .access_account        = host_access_account,
+    .access_storage        = host_access_storage,
+    .get_transient_storage = host_get_transient_storage,
+    .set_transient_storage = host_set_transient_storage,
+};
+
+void test_evmone_abi_version_and_executor(void) {
+  TEST_ASSERT_EQUAL_INT(18, EVMC_ABI_VERSION);
+
+  void* executor = evmone_create_executor();
+  TEST_ASSERT_NOT_NULL(executor);
+
+  struct evmc_vm* vm = (struct evmc_vm*) executor;
+  TEST_ASSERT_EQUAL_INT(EVMC_ABI_VERSION, vm->abi_version);
+
+  evmone_destroy_executor(executor);
+}
+
+void test_evmone_osaka_stop(void) {
+  void*      executor = evmone_create_executor();
+  test_host_t host     = {.nonce = 0};
+  TEST_ASSERT_NOT_NULL(executor);
+
+  uint8_t        code[] = {0x00}; // STOP
+  evmone_message msg    = {0};
+  msg.kind              = EVMONE_CALL;
+  msg.gas               = 100000;
+
+  evmone_result result = evmone_execute(executor, &g_host, &host, EVMONE_REV_OSAKA, &msg, code, sizeof(code));
+  TEST_ASSERT_EQUAL_INT(0, result.status_code);
+
+  evmone_release_result(&result);
+  evmone_destroy_executor(executor);
+}
+
+void test_evmone_create_uses_get_nonce(void) {
+  // CREATE with empty initcode: value=0, offset=0, size=0
+  // PUSH1 0 / PUSH1 0 / PUSH1 0 / CREATE / STOP
+  const uint8_t code[] = {0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0xf0, 0x00};
+
+  // CREATE address for sender=0x00..00 and nonce=0:
+  // keccak256(rlp([sender, 0]))[12:] == 0xbd770416a3345f91e4b34576cb804a576fa48eb1
+  const uint8_t expected[20] = {
+      0xbd, 0x77, 0x04, 0x16, 0xa3, 0x34, 0x5f, 0x91, 0xe4, 0xb3,
+      0x45, 0x76, 0xcb, 0x80, 0x4a, 0x57, 0x6f, 0xa4, 0x8e, 0xb1};
+
+  void*       executor = evmone_create_executor();
+  test_host_t host     = {.nonce = 0};
+  TEST_ASSERT_NOT_NULL(executor);
+
+  evmone_message msg = {0};
+  msg.kind           = EVMONE_CALL;
+  msg.gas            = 1000000;
+
+  evmone_result result = evmone_execute(executor, &g_host, &host, EVMONE_REV_OSAKA, &msg, code, sizeof(code));
+  TEST_ASSERT_EQUAL_INT(0, result.status_code);
+  TEST_ASSERT_TRUE(host.saw_create);
+  TEST_ASSERT_EQUAL_MEMORY(expected, host.last_create_dest.bytes, 20);
+
+  evmone_release_result(&result);
+  evmone_destroy_executor(executor);
+}
+
+void test_evmone_tx_context_blob_hashes(void) {
+  void*      executor = evmone_create_executor();
+  test_host_t host     = {.nonce = 0};
+  memset(host.blob_hashes[0].bytes, 0xab, 32);
+  TEST_ASSERT_NOT_NULL(executor);
+
+  // BLOBHASH 0 / POP / STOP  -- under Osaka, returns the blob hash or zero
+  const uint8_t code[] = {0x60, 0x00, 0x49, 0x50, 0x00};
+
+  evmone_message msg = {0};
+  msg.kind           = EVMONE_CALL;
+  msg.gas            = 100000;
+
+  evmone_result result = evmone_execute(executor, &g_host, &host, EVMONE_REV_OSAKA, &msg, code, sizeof(code));
+  TEST_ASSERT_EQUAL_INT(0, result.status_code);
+
+  evmone_release_result(&result);
+  evmone_destroy_executor(executor);
+}
+
+#else
+
+void test_evmone_skipped(void) {
+  TEST_IGNORE_MESSAGE("EVMONE disabled");
+}
+
+#endif
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(void) {
+  UNITY_BEGIN();
+#ifdef EVMONE
+  RUN_TEST(test_evmone_abi_version_and_executor);
+  RUN_TEST(test_evmone_osaka_stop);
+  RUN_TEST(test_evmone_create_uses_get_nonce);
+  RUN_TEST(test_evmone_tx_context_blob_hashes);
+#else
+  RUN_TEST(test_evmone_skipped);
+#endif
+  return UNITY_END();
+}

--- a/test/unittests/test_evmone_abi.c
+++ b/test/unittests/test_evmone_abi.c
@@ -30,6 +30,8 @@
 
 typedef struct {
   uint64_t     nonce;
+  uint32_t     nonce_calls;
+  evmc_address last_nonce_addr;
   evmc_address last_create_dest;
   bool         saw_create;
   evmc_bytes32 blob_hashes[1];
@@ -66,8 +68,10 @@ static evmc_bytes32 host_get_balance(void* context, const evmc_address* addr) {
 }
 
 static uint64_t host_get_nonce(void* context, const evmc_address* addr) {
-  (void) addr;
-  return ((test_host_t*) context)->nonce;
+  test_host_t* host     = (test_host_t*) context;
+  host->nonce_calls++;
+  host->last_nonce_addr = *addr;
+  return host->nonce;
 }
 
 static size_t host_get_code_size(void* context, const evmc_address* addr) {
@@ -215,19 +219,44 @@ void test_evmone_osaka_stop(void) {
   evmone_destroy_executor(executor);
 }
 
+void test_evmone_revision_stays_on_osaka(void) {
+  void*       executor = evmone_create_executor();
+  test_host_t host     = {0};
+  TEST_ASSERT_NOT_NULL(executor);
+
+  // CLZ is active in Osaka, while SLOTNUM is introduced in Amsterdam.
+  const uint8_t osaka_code[]     = {0x60, 0x00, 0x1e, 0x50, 0x00};
+  const uint8_t amsterdam_code[] = {0x4b, 0x50, 0x00};
+  evmone_message msg             = {0};
+  msg.kind                       = EVMONE_CALL;
+  msg.gas                        = 100000;
+
+  evmone_result osaka_result =
+      evmone_execute(executor, &g_host, &host, EVMONE_REV_OSAKA, &msg, osaka_code, sizeof(osaka_code));
+  TEST_ASSERT_EQUAL_INT(0, osaka_result.status_code);
+  evmone_release_result(&osaka_result);
+
+  evmone_result amsterdam_result =
+      evmone_execute(executor, &g_host, &host, EVMONE_REV_OSAKA, &msg, amsterdam_code, sizeof(amsterdam_code));
+  TEST_ASSERT_EQUAL_INT(EVMC_UNDEFINED_INSTRUCTION, amsterdam_result.status_code);
+  evmone_release_result(&amsterdam_result);
+
+  evmone_destroy_executor(executor);
+}
+
 void test_evmone_create_uses_get_nonce(void) {
   // CREATE with empty initcode: value=0, offset=0, size=0
   // PUSH1 0 / PUSH1 0 / PUSH1 0 / CREATE / STOP
   const uint8_t code[] = {0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0xf0, 0x00};
 
-  // CREATE address for sender=0x00..00 and nonce=0:
-  // keccak256(rlp([sender, 0]))[12:] == 0xbd770416a3345f91e4b34576cb804a576fa48eb1
+  // CREATE address for sender=0x00..00 and nonce=1.
   const uint8_t expected[20] = {
-      0xbd, 0x77, 0x04, 0x16, 0xa3, 0x34, 0x5f, 0x91, 0xe4, 0xb3,
-      0x45, 0x76, 0xcb, 0x80, 0x4a, 0x57, 0x6f, 0xa4, 0x8e, 0xb1};
+      0x5a, 0x44, 0x37, 0x04, 0xdd, 0x4b, 0x59, 0x4b, 0x38, 0x2c,
+      0x22, 0xa0, 0x83, 0xe2, 0xbd, 0x30, 0x90, 0xa6, 0xfe, 0xf3};
+  const uint8_t zero_address[20] = {0};
 
   void*       executor = evmone_create_executor();
-  test_host_t host     = {.nonce = 0};
+  test_host_t host     = {.nonce = 1};
   TEST_ASSERT_NOT_NULL(executor);
 
   evmone_message msg = {0};
@@ -237,6 +266,8 @@ void test_evmone_create_uses_get_nonce(void) {
   evmone_result result = evmone_execute(executor, &g_host, &host, EVMONE_REV_OSAKA, &msg, code, sizeof(code));
   TEST_ASSERT_EQUAL_INT(0, result.status_code);
   TEST_ASSERT_TRUE(host.saw_create);
+  TEST_ASSERT_EQUAL_UINT32(1, host.nonce_calls);
+  TEST_ASSERT_EQUAL_MEMORY(zero_address, host.last_nonce_addr.bytes, sizeof(zero_address));
   TEST_ASSERT_EQUAL_MEMORY(expected, host.last_create_dest.bytes, 20);
 
   evmone_release_result(&result);
@@ -244,13 +275,13 @@ void test_evmone_create_uses_get_nonce(void) {
 }
 
 void test_evmone_tx_context_blob_hashes(void) {
-  void*      executor = evmone_create_executor();
+  void*       executor = evmone_create_executor();
   test_host_t host     = {.nonce = 0};
   memset(host.blob_hashes[0].bytes, 0xab, 32);
   TEST_ASSERT_NOT_NULL(executor);
 
-  // BLOBHASH 0 / POP / STOP  -- under Osaka, returns the blob hash or zero
-  const uint8_t code[] = {0x60, 0x00, 0x49, 0x50, 0x00};
+  // PUSH1 0 / BLOBHASH / PUSH1 0 / MSTORE / PUSH1 32 / PUSH1 0 / RETURN
+  const uint8_t code[] = {0x60, 0x00, 0x49, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3};
 
   evmone_message msg = {0};
   msg.kind           = EVMONE_CALL;
@@ -258,8 +289,16 @@ void test_evmone_tx_context_blob_hashes(void) {
 
   evmone_result result = evmone_execute(executor, &g_host, &host, EVMONE_REV_OSAKA, &msg, code, sizeof(code));
   TEST_ASSERT_EQUAL_INT(0, result.status_code);
+  TEST_ASSERT_EQUAL_UINT32(32, (uint32_t) result.output_size);
+  TEST_ASSERT_EQUAL_MEMORY(host.blob_hashes[0].bytes, result.output_data, 32);
 
   evmone_release_result(&result);
+
+  // Unknown Colibri revision IDs must not silently map to Osaka.
+  evmone_result bad = evmone_execute(executor, &g_host, &host, 0, &msg, code, sizeof(code));
+  TEST_ASSERT_EQUAL_INT(EVMC_INTERNAL_ERROR, bad.status_code);
+  evmone_release_result(&bad);
+
   evmone_destroy_executor(executor);
 }
 
@@ -279,6 +318,7 @@ int main(void) {
 #ifdef EVMONE
   RUN_TEST(test_evmone_abi_version_and_executor);
   RUN_TEST(test_evmone_osaka_stop);
+  RUN_TEST(test_evmone_revision_stays_on_osaka);
   RUN_TEST(test_evmone_create_uses_get_nonce);
   RUN_TEST(test_evmone_tx_context_blob_hashes);
 #else

--- a/test/unittests/test_evmone_create_nonce.c
+++ b/test/unittests/test_evmone_create_nonce.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2025 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "bytes.h"
+#include "call_ctx.h"
+#include "chains.h"
+#include "eth_call_account.h"
+#include "json.h"
+#include "unity.h"
+#include "verify.h"
+#include <string.h>
+
+#ifdef EVMONE
+
+static call_account_t* make_contract(const address_t addr, const uint8_t* code, size_t code_len, uint64_t nonce) {
+  call_account_t* acc = safe_calloc(1, sizeof(call_account_t));
+  memcpy(acc->address, addr, 20);
+  acc->nonce     = nonce;
+  acc->src_nonce = nonce;
+  acc->code      = bytes_dup(bytes((uint8_t*) code, (uint32_t) code_len));
+  acc->flags     = ACCOUNT_HAS_CODE | ACCOUNT_FREE_CODE | ACCOUNT_HAS_NONCE;
+  return acc;
+}
+
+static call_account_t* find_account(call_account_t* list, const address_t addr) {
+  for (call_account_t* a = list; a; a = a->next)
+    if (memcmp(a->address, addr, 20) == 0) return a;
+  return NULL;
+}
+
+/**
+ * Two empty CREATEs must bump the creator nonce twice and produce distinct addresses.
+ */
+void test_colibri_host_create_bumps_nonce(void) {
+  // PUSH1 0 / PUSH1 0 / PUSH1 0 / CREATE /
+  // PUSH1 0 / MSTORE /
+  // PUSH1 0 / PUSH1 0 / PUSH1 0 / CREATE /
+  // PUSH1 32 / MSTORE /
+  // PUSH1 64 / PUSH1 0 / RETURN
+  const uint8_t code[] = {
+      0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0xf0,
+      0x60, 0x00, 0x52,
+      0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0xf0,
+      0x60, 0x20, 0x52,
+      0x60, 0x40, 0x60, 0x00, 0xf3};
+
+  address_t contract = {0};
+  memset(contract, 0x11, 20);
+
+  // cast compute-address --nonce 0/1 0x1111...11
+  const uint8_t expect0[20] = {
+      0x8f, 0x7a, 0x45, 0xeb, 0xde, 0x05, 0x93, 0x92, 0xe4, 0x6a,
+      0x46, 0xdc, 0xc1, 0x4a, 0xb2, 0x46, 0x81, 0xa9, 0x61, 0xea};
+  const uint8_t expect1[20] = {
+      0x15, 0x45, 0x2e, 0xc0, 0x16, 0xc4, 0xdc, 0x8c, 0x54, 0x9e,
+      0x7f, 0xe6, 0xff, 0x4b, 0x26, 0x32, 0x4e, 0xa8, 0xb7, 0xa4};
+
+  verify_ctx_t ctx = {0};
+  ctx.chain_id     = C4_CHAIN_MAINNET;
+  ctx.args         = json_parse(
+      "[{\"from\":\"0x2222222222222222222222222222222222222222\","
+      "\"to\":\"0x1111111111111111111111111111111111111111\","
+      "\"gas\":\"0xf4240\"},\"latest\"]");
+
+  evm_call_ctx_t evm = {0};
+  evm.accounts       = make_contract(contract, code, sizeof(code), 0);
+
+  TEST_ASSERT_EQUAL_INT(C4_SUCCESS, eth_run_call_evmone_with_events(&ctx, &evm, false));
+  TEST_ASSERT_FALSE(evm.reverted);
+  TEST_ASSERT_NULL(ctx.state.error);
+
+  call_account_t* after = find_account(evm.accounts, contract);
+  TEST_ASSERT_NOT_NULL(after);
+  TEST_ASSERT_EQUAL_UINT64(2, after->nonce);
+
+  TEST_ASSERT_EQUAL_UINT32(64, evm.call_result.len);
+  // Addresses are right-aligned in the 32-byte words returned by MSTORE of CREATE results.
+  TEST_ASSERT_EQUAL_MEMORY(expect0, evm.call_result.data + 12, 20);
+  TEST_ASSERT_EQUAL_MEMORY(expect1, evm.call_result.data + 32 + 12, 20);
+
+  evm_call_ctx_free(&evm);
+}
+
+/**
+ * A failed CREATE (reverting initcode) must still bump the creator nonce.
+ */
+void test_colibri_host_failed_create_still_bumps_nonce(void) {
+  // The reverting initcode `PUSH1 0 / PUSH1 0 / REVERT` is stored via MSTORE, which
+  // right-aligns it in the 32-byte word, so it ends up at mem[27..31].
+  const uint8_t code[] = {
+      0x64, 0x60, 0x00, 0x60, 0x00, 0xfd,       // PUSH5 initcode
+      0x60, 0x00, 0x52,                         // MSTORE at 0
+      0x60, 0x05, 0x60, 0x1b, 0x60, 0x00, 0xf0, // CREATE size=5 offset=27 value=0 -> reverts
+      0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0xf0, // CREATE with empty initcode
+      0x60, 0x00, 0x52,                         // MSTORE second address
+      0x60, 0x20, 0x60, 0x00, 0xf3              // RETURN 32 bytes
+  };
+
+  address_t contract = {0};
+  memset(contract, 0x11, 20);
+
+  const uint8_t expect1[20] = {
+      0x15, 0x45, 0x2e, 0xc0, 0x16, 0xc4, 0xdc, 0x8c, 0x54, 0x9e,
+      0x7f, 0xe6, 0xff, 0x4b, 0x26, 0x32, 0x4e, 0xa8, 0xb7, 0xa4};
+
+  verify_ctx_t ctx = {0};
+  ctx.chain_id     = C4_CHAIN_MAINNET;
+  ctx.args         = json_parse(
+      "[{\"from\":\"0x2222222222222222222222222222222222222222\","
+      "\"to\":\"0x1111111111111111111111111111111111111111\","
+      "\"gas\":\"0xf4240\"},\"latest\"]");
+
+  evm_call_ctx_t evm = {0};
+  evm.accounts       = make_contract(contract, code, sizeof(code), 0);
+
+  TEST_ASSERT_EQUAL_INT(C4_SUCCESS, eth_run_call_evmone_with_events(&ctx, &evm, false));
+  TEST_ASSERT_FALSE(evm.reverted);
+  TEST_ASSERT_NULL(ctx.state.error);
+
+  call_account_t* after = find_account(evm.accounts, contract);
+  TEST_ASSERT_NOT_NULL(after);
+  TEST_ASSERT_EQUAL_UINT64(2, after->nonce);
+
+  TEST_ASSERT_EQUAL_UINT32(32, evm.call_result.len);
+  TEST_ASSERT_EQUAL_MEMORY(expect1, evm.call_result.data + 12, 20);
+
+  evm_call_ctx_free(&evm);
+}
+
+#else
+
+void test_evmone_create_nonce_skipped(void) {
+  TEST_IGNORE_MESSAGE("EVMONE disabled");
+}
+
+#endif
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(void) {
+  UNITY_BEGIN();
+#ifdef EVMONE
+  RUN_TEST(test_colibri_host_create_bumps_nonce);
+  RUN_TEST(test_colibri_host_failed_create_still_bumps_nonce);
+#else
+  RUN_TEST(test_evmone_create_nonce_skipped);
+#endif
+  return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- Upgrade evmone from `v0.19.0` to `v0.23.0` and adapt the C wrapper/host to EVMC ABI 18 (`get_nonce`, VM-side CREATE address, tx-context extensions, delegated flag).
- Keep execution on **Osaka** via stable `EVMONE_REV_OSAKA` mapping; Amsterdam remains available in upstream but is intentionally not activated until the activation block is known.
- Continue using Colibri's `keccak_bridge` and `eth_precompiles` instead of linking upstream `evmone_precompiles` / a second `blst`.
- Harden FetchContent compat patches and add focused ABI/CREATE regression tests.

## Test plan
- [x] `cmake --preset default && cmake --build build/default`
- [x] `./build/default/test/unittests/test_evmone_abi`
- [x] `ctest --test-dir build/default --output-on-failure` (52/52 passed)
- [x] Confirm CI green on Linux/macOS/Windows
- [x] Follow-up PR later: activate Amsterdam once the activation block/slot is known