### PR TITLE
feat(ssz): ProgressiveContainer (EIP-7495) and ProgressiveList/Bitlist (EIP-7916)

### DIFF
--- a/src/chains/eth/ssz/verify_types.c
+++ b/src/chains/eth/ssz/verify_types.c
@@ -191,6 +191,8 @@ static const ssz_def_t C4_ETH_ZK_SYNCDATA_V6[6] = {
  */
 static inline size_t array_idx(const ssz_def_t* array, size_t len, const ssz_def_t* target) {
   for (size_t i = 0; i < len; i++) {
+    // >= SSZ_TYPE_CONTAINER matches any def whose first union member is a child-def
+    // pointer (container, vector, list, union and the progressive variants)
     if (array[i].type >= SSZ_TYPE_CONTAINER && array[i].def.container.elements == target) return i;
   }
   return 0;

--- a/src/chains/eth/verifier/verify_call.c
+++ b/src/chains/eth/verifier/verify_call.c
@@ -90,7 +90,7 @@ static call_account_t* call_accounts_from_ssz(ssz_ob_t ssz_accounts) {
     // code) or a boolean "code_used" flag (false = no code, true = code
     // exists but was not included in the proof).
     ssz_ob_t code = ssz_get(&acc, "code");
-    if (code.def && code.def->type == SSZ_TYPE_LIST && code.bytes.len > 0) {
+    if (code.def && ssz_is_list_type(code.def) && code.bytes.len > 0) {
       ca->code = code.bytes;
       ca->flags |= ACCOUNT_HAS_CODE;
     }
@@ -129,7 +129,7 @@ bool c4_eth_verify_accounts(verify_ctx_t* ctx, ssz_ob_t accounts, bytes32_t stat
     ssz_ob_t acc = ssz_at(accounts, i);
     if (!eth_verify_account_proof_exec(ctx, &acc, root, ETH_ACCOUNT_CODE_HASH, bytes(code_hash_exepected, 32))) RETURN_VERIFY_ERROR(ctx, "Failed to verify account proof");
     ssz_ob_t code = ssz_get(&acc, "code");
-    if (code.def->type == SSZ_TYPE_LIST) {
+    if (ssz_is_list_type(code.def)) {
       bytes32_t code_hash_passed = {0};
       keccak(code.bytes, code_hash_passed);
       if (memcmp(code_hash_exepected, code_hash_passed, 32) != 0) RETURN_VERIFY_ERROR(ctx, "Code hash mismatch");

--- a/src/chains/op/ssz/op_types.c
+++ b/src/chains/op/ssz/op_types.c
@@ -85,6 +85,8 @@ static const ssz_def_t C4_REQUEST_CONTAINER = SSZ_CONTAINER("C4Request", C4_OP_R
  */
 static inline size_t array_idx(const ssz_def_t* array, size_t len, const ssz_def_t* target) {
   for (size_t i = 0; i < len; i++) {
+    // >= SSZ_TYPE_CONTAINER matches any def whose first union member is a child-def
+    // pointer (container, vector, list, union and the progressive variants)
     if (array[i].type >= SSZ_TYPE_CONTAINER && array[i].def.container.elements == target) return i;
   }
   return 0;

--- a/src/cli/ssz.c
+++ b/src/cli/ssz.c
@@ -131,7 +131,7 @@ int main(int argc, char* argv[]) {
         }
       }
     }
-    else if (res.def && res.def->type != SSZ_TYPE_CONTAINER) {
+    else if (res.def && !ssz_is_container_type(res.def)) {
       char* endptr;
       long  value = strtol(argv[i], &endptr, 10);
       if (endptr && *endptr == '\0')

--- a/src/util/ssz.c
+++ b/src/util/ssz.c
@@ -55,14 +55,14 @@ static bool is_basic_type(const ssz_def_t* def) {
 
 // checks if a definition has a dynamic length
 bool ssz_is_dynamic(const ssz_def_t* def) {
-  if (def->type == SSZ_TYPE_CONTAINER) {
+  if (ssz_is_container_type(def)) {
     for (int i = 0; i < def->def.container.len; i++) {
       if (ssz_is_dynamic(def->def.container.elements + i))
         return true;
     }
   }
 
-  return def->type == SSZ_TYPE_LIST || def->type == SSZ_TYPE_BIT_LIST || def->type == SSZ_TYPE_UNION;
+  return ssz_is_list_type(def) || ssz_is_bit_list_type(def) || def->type == SSZ_TYPE_UNION;
 }
 
 size_t ssz_fixed_length(const ssz_def_t* def) {
@@ -73,7 +73,8 @@ size_t ssz_fixed_length(const ssz_def_t* def) {
       return def->def.uint.len;
     case SSZ_TYPE_BOOLEAN:
       return 1;
-    case SSZ_TYPE_CONTAINER: {
+    case SSZ_TYPE_CONTAINER:
+    case SSZ_TYPE_PROG_CONTAINER: {
       size_t len = 0;
       for (int i = 0; i < def->def.container.len; i++)
         len += ssz_fixed_length(def->def.container.elements + i);
@@ -146,20 +147,21 @@ bool ssz_is_valid(ssz_ob_t ob, bool recursive, c4_state_t* state) {
       }
       return true;
     }
-    case SSZ_TYPE_LIST: {
+    case SSZ_TYPE_LIST:
+    case SSZ_TYPE_PROG_LIST: {
       // List with dynamic elements: offset array followed by data
       // List with fixed elements: concatenated elements
       if (ssz_is_dynamic(ob.def->def.vector.type)) {
         if (ob.bytes.len == 0) return true;
         if (ob.bytes.len < SSZ_OFFSET_SIZE) THROW_INVALID("Invalid bytelength for list");
         uint32_t first_offset = uint32_from_le(ob.bytes.data);
-        // First offset must be aligned and within bounds
-        if (first_offset >= ob.bytes.len || first_offset < SSZ_OFFSET_SIZE || first_offset % SSZ_OFFSET_SIZE != 0)
+        // First offset must be aligned and within bounds (== len is valid: all elements are empty)
+        if (first_offset > ob.bytes.len || first_offset < SSZ_OFFSET_SIZE || first_offset % SSZ_OFFSET_SIZE != 0)
           THROW_INVALID("Invalid first offset for list");
         uint32_t offset = first_offset;
         for (int i = SSZ_OFFSET_SIZE; i < first_offset; i += SSZ_OFFSET_SIZE) {
           uint32_t next_offset = uint32_from_le(ob.bytes.data + i);
-          if (next_offset >= ob.bytes.len || next_offset < offset) THROW_INVALID("Invalid offset(%d for i=%d) for list. Must be between %d and %d", next_offset, i, offset, ob.bytes.len);
+          if (next_offset > ob.bytes.len || next_offset < offset) THROW_INVALID("Invalid offset(%d for i=%d) for list. Must be between %d and %d", next_offset, i, offset, ob.bytes.len);
           if (recursive && !ssz_is_valid(ssz_ob(*ob.def->def.vector.type, bytes(ob.bytes.data + offset, next_offset - offset)), recursive, state)) return false;
           offset = next_offset;
         }
@@ -167,9 +169,10 @@ bool ssz_is_valid(ssz_ob_t ob, bool recursive, c4_state_t* state) {
         return true;
       }
       // Fixed-size elements: total length must be multiple of element size
+      // (progressive lists have no capacity, so the max-length check only applies to List)
       size_t fixed_length = ssz_fixed_length(ob.def->def.vector.type);
       if (fixed_length == 0 || ob.bytes.len % fixed_length != 0 ||
-          ob.bytes.len > ob.def->def.vector.len * fixed_length) THROW_INVALID("Invalid length for list");
+          (ob.def->type == SSZ_TYPE_LIST && ob.bytes.len > ob.def->def.vector.len * fixed_length)) THROW_INVALID("Invalid length for list");
       if (recursive && ob.def->type != SSZ_TYPE_UINT) {
         for (int i = 0; i < ob.bytes.len; i += fixed_length) {
           if (!ssz_is_valid(ssz_ob(*ob.def->def.vector.type, bytes(ob.bytes.data + i, fixed_length)), recursive, state)) return false;
@@ -183,9 +186,19 @@ bool ssz_is_valid(ssz_ob_t ob, bool recursive, c4_state_t* state) {
     case SSZ_TYPE_BIT_LIST:
       // Bit list length can be up to max length
       RETURN_VALID_IF(ob.bytes.len <= (ob.def->def.vector.len + 7) >> 3, "Invalid length for bit list");
+    case SSZ_TYPE_PROG_BIT_LIST:
+      // Progressive bit list has no capacity, but requires at least the sentinel bit.
+      // The size is capped so the bit length can never wrap the 32-bit arithmetic in ssz_len.
+      RETURN_VALID_IF(ob.bytes.len >= 1 && ob.bytes.len <= SSZ_MAX_PROG_BITLIST_BYTES && ob.bytes.data[ob.bytes.len - 1] != 0, "Invalid progressive bit list");
     case SSZ_TYPE_UINT:
       // Uint length must match definition
       RETURN_VALID_IF(ob.bytes.len == ob.def->def.uint.len, "Invalid length for uint");
+    case SSZ_TYPE_PROG_CONTAINER:
+      // ProgressiveContainer: at most 256 field positions, active_fields must not end in 0 (EIP-7495)
+      if (ob.def->def.container.len == 0 || ob.def->def.container.len > 256 ||
+          ob.def->def.container.elements[ob.def->def.container.len - 1].type == SSZ_TYPE_NONE)
+        THROW_INVALID("Invalid progressive container definition");
+      // fallthrough: remaining checks are identical to Container
     case SSZ_TYPE_CONTAINER: {
       // Container with mixed fixed/dynamic fields
       if (ssz_is_dynamic(ob.def) ? (ob.bytes.len < ssz_fixed_length(ob.def)) : (ob.bytes.len != ssz_fixed_length(ob.def))) THROW_INVALID("Invalid length for container");
@@ -248,7 +261,8 @@ ssz_ob_t ssz_union(ssz_ob_t ob) {
 uint32_t ssz_len(ssz_ob_t ob) {
   switch (ob.def->type) {
     case SSZ_TYPE_VECTOR: return ob.def->def.vector.len;
-    case SSZ_TYPE_LIST: {
+    case SSZ_TYPE_LIST:
+    case SSZ_TYPE_PROG_LIST: {
       size_t fixed_length = ssz_fixed_length(ob.def->def.vector.type);
       if (fixed_length == 0) return 0;
       return ob.bytes.len > SSZ_OFFSET_SIZE && ssz_is_dynamic(ob.def->def.vector.type)
@@ -257,7 +271,9 @@ uint32_t ssz_len(ssz_ob_t ob) {
     }
     case SSZ_TYPE_BIT_VECTOR:
       return ob.bytes.len * 8;
+    case SSZ_TYPE_PROG_BIT_LIST:
     case SSZ_TYPE_BIT_LIST: {
+      if (ob.bytes.len == 0) return 0;
       uint8_t last_bit = ob.bytes.data[ob.bytes.len - 1];
       if (last_bit == 1) return ob.bytes.len * 8 - 8;
       for (int i = 7; i >= 0; i--) {
@@ -306,8 +322,8 @@ bool ssz_is_type(ssz_ob_t* ob, const ssz_def_t* def) {
     ssz_ob_t union_ob = ssz_union(*ob);
     return ssz_is_type(&union_ob, def);
   }
-  if (ob->def->type == SSZ_TYPE_CONTAINER) return ob->def->def.container.elements == def;
-  if (ob->def->type == SSZ_TYPE_LIST) return ob->def->def.vector.type == def;
+  if (ssz_is_container_type(ob->def)) return ob->def->def.container.elements == def;
+  if (ssz_is_list_type(ob->def)) return ob->def->def.vector.type == def;
   switch (def->type) {
     case SSZ_TYPE_UINT:
       return def->type == SSZ_TYPE_UINT && ob->def->def.uint.len == def->def.uint.len;
@@ -393,6 +409,7 @@ static void dump(ssz_dump_t* ctx, ssz_ob_t ob, const char* name, int intend) {
       // Boolean renders as JSON true/false
       buffer_add_chars(buf, ob.bytes.data[0] ? "true" : "false");
       break;
+    case SSZ_TYPE_PROG_CONTAINER:
     case SSZ_TYPE_CONTAINER: {
       // Container: iterate through fields, respect optional field mask
       uint64_t mask  = 0;
@@ -401,12 +418,14 @@ static void dump(ssz_dump_t* ctx, ssz_ob_t ob, const char* name, int intend) {
       bool first     = true;
       buffer_add_chars(buf, "{\n");
       for (int i = 0; i < def->def.container.len; i++) {
+        if (def->def.container.elements[i].type == SSZ_TYPE_NONE) continue; // inactive slot of a progressive container
         ssz_ob_t val = ssz_get(&ob, (char*) def->def.container.elements[i].name);
         if (val.def->flags & SSZ_FLAG_OPT_MASK) {
           mask |= bytes_as_le(val.bytes);
           continue;
         }
-        if (mask && (mask & (1 << i)) == 0) continue;
+        // the opt mask covers at most 64 fields; fields beyond that are always included
+        if (mask && i < 64 && (mask & (((uint64_t) 1) << i)) == 0) continue;
         if (first)
           first = false;
         else
@@ -416,13 +435,15 @@ static void dump(ssz_dump_t* ctx, ssz_ob_t ob, const char* name, int intend) {
       break;
     }
     case SSZ_TYPE_BIT_VECTOR:
-    case SSZ_TYPE_BIT_LIST: {
+    case SSZ_TYPE_BIT_LIST:
+    case SSZ_TYPE_PROG_BIT_LIST: {
       // Bit vectors/lists render as hex strings
       bprintf(buf, ctx->no_quotes ? "0x%x" : "\"0x%x\"", ob.bytes);
       break;
     }
     case SSZ_TYPE_VECTOR:
-    case SSZ_TYPE_LIST: {
+    case SSZ_TYPE_LIST:
+    case SSZ_TYPE_PROG_LIST: {
       // Lists/vectors: special handling for byte arrays, strings, and complex types
       if (def == &ssz_string_def || def->flags & SSZ_FLAG_STRING)
         bprintf(buf, ctx->no_quotes ? "%J" : "\"%J\"", (json_t) {.type = JSON_TYPE_OBJECT, .start = (char*) ob.bytes.data, .len = ob.bytes.len});

--- a/src/util/ssz.c
+++ b/src/util/ssz.c
@@ -56,8 +56,10 @@ static bool is_basic_type(const ssz_def_t* def) {
 // checks if a definition has a dynamic length
 bool ssz_is_dynamic(const ssz_def_t* def) {
   if (ssz_is_container_type(def)) {
-    for (int i = 0; i < def->def.container.len; i++) {
-      if (ssz_is_dynamic(def->def.container.elements + i))
+    const ssz_def_t* elements = ssz_container_elements(def);
+    uint32_t         len      = ssz_container_len(def);
+    for (uint32_t i = 0; i < len; i++) {
+      if (ssz_field_active(def, i) && ssz_is_dynamic(elements + i))
         return true;
     }
   }
@@ -75,9 +77,13 @@ size_t ssz_fixed_length(const ssz_def_t* def) {
       return 1;
     case SSZ_TYPE_CONTAINER:
     case SSZ_TYPE_PROG_CONTAINER: {
-      size_t len = 0;
-      for (int i = 0; i < def->def.container.len; i++)
-        len += ssz_fixed_length(def->def.container.elements + i);
+      const ssz_def_t* elements = ssz_container_elements(def);
+      uint32_t         count    = ssz_container_len(def);
+      size_t           len      = 0;
+      for (uint32_t i = 0; i < count; i++) {
+        if (ssz_field_active(def, i))
+          len += ssz_fixed_length(elements + i);
+      }
       return len;
     }
     case SSZ_TYPE_VECTOR:
@@ -193,21 +199,33 @@ bool ssz_is_valid(ssz_ob_t ob, bool recursive, c4_state_t* state) {
     case SSZ_TYPE_UINT:
       // Uint length must match definition
       RETURN_VALID_IF(ob.bytes.len == ob.def->def.uint.len, "Invalid length for uint");
-    case SSZ_TYPE_PROG_CONTAINER:
-      // ProgressiveContainer: at most 256 field positions, active_fields must not end in 0 (EIP-7495)
-      if (ob.def->def.container.len == 0 || ob.def->def.container.len > 256 ||
-          ob.def->def.container.elements[ob.def->def.container.len - 1].type == SSZ_TYPE_NONE)
+    case SSZ_TYPE_PROG_CONTAINER: {
+      // ProgressiveContainer (EIP-7495): the def must reference a valid base container,
+      // the mask must be non-zero (highest set bit < base_len), and at most 64 positions
+      // are supported by the uint64 mask.
+      const ssz_def_t* base = ob.def->def.progressive_container.container;
+      uint64_t         mask = ob.def->def.progressive_container.active_fields;
+      if (!base || base->type != SSZ_TYPE_CONTAINER || base->def.container.len == 0 || base->def.container.len > 64 || mask == 0)
         THROW_INVALID("Invalid progressive container definition");
-      // fallthrough: remaining checks are identical to Container
+      // highest set bit of the mask must reference an existing field position
+      uint64_t mask_bound = base->def.container.len < 64 ? (((uint64_t) 1) << base->def.container.len) : (uint64_t) -1;
+      if (base->def.container.len < 64 && mask >= mask_bound)
+        THROW_INVALID("Invalid progressive container active_fields mask");
+    }
+      // fallthrough: remaining checks are identical to Container (using helpers that
+      // resolve base container + active_fields for progressive containers)
     case SSZ_TYPE_CONTAINER: {
       // Container with mixed fixed/dynamic fields
       if (ssz_is_dynamic(ob.def) ? (ob.bytes.len < ssz_fixed_length(ob.def)) : (ob.bytes.len != ssz_fixed_length(ob.def))) THROW_INVALID("Invalid length for container");
       if (recursive) {
-        ssz_ob_t last_ob     = {0};
-        uint32_t last_offset = 0;
-        uint32_t pos         = 0;
-        for (int i = 0; i < ob.def->def.container.len; i++) {
-          const ssz_def_t* def = ob.def->def.container.elements + i;
+        const ssz_def_t* elements    = ssz_container_elements(ob.def);
+        uint32_t         count       = ssz_container_len(ob.def);
+        ssz_ob_t         last_ob     = {0};
+        uint32_t         last_offset = 0;
+        uint32_t         pos         = 0;
+        for (uint32_t i = 0; i < count; i++) {
+          if (!ssz_field_active(ob.def, i)) continue; // inactive slot of a progressive container
+          const ssz_def_t* def = elements + i;
           if (ssz_is_dynamic(def)) {
             uint32_t offset = uint32_from_le(ob.bytes.data + pos);
             // Validate offset: must be within bounds, after fixed portion, and monotonically increasing
@@ -322,7 +340,11 @@ bool ssz_is_type(ssz_ob_t* ob, const ssz_def_t* def) {
     ssz_ob_t union_ob = ssz_union(*ob);
     return ssz_is_type(&union_ob, def);
   }
-  if (ssz_is_container_type(ob->def)) return ob->def->def.container.elements == def;
+  // progressive containers with the same base and mask are the same variant
+  if (ob->def->type == SSZ_TYPE_PROG_CONTAINER && def->type == SSZ_TYPE_PROG_CONTAINER)
+    return ob->def->def.progressive_container.container == def->def.progressive_container.container &&
+           ob->def->def.progressive_container.active_fields == def->def.progressive_container.active_fields;
+  if (ssz_is_container_type(ob->def)) return ssz_container_elements(ob->def) == def;
   if (ssz_is_list_type(ob->def)) return ob->def->def.vector.type == def;
   switch (def->type) {
     case SSZ_TYPE_UINT:
@@ -334,7 +356,7 @@ bool ssz_is_type(ssz_ob_t* ob, const ssz_def_t* def) {
     case SSZ_TYPE_BIT_VECTOR:
       return def->type == SSZ_TYPE_BIT_VECTOR && ob->def->def.uint.len == def->def.uint.len;
     case SSZ_TYPE_CONTAINER:
-      return ob->def->def.container.elements == def;
+      return ssz_container_elements(ob->def) == def;
     case SSZ_TYPE_VECTOR: {
       ssz_ob_t el = {.def = ob->def->def.vector.type, .bytes = ob->bytes};
       return def->type == SSZ_TYPE_VECTOR && ob->def->def.uint.len == def->def.uint.len && ssz_is_type(&el, def->def.vector.type);
@@ -411,15 +433,18 @@ static void dump(ssz_dump_t* ctx, ssz_ob_t ob, const char* name, int intend) {
       break;
     case SSZ_TYPE_PROG_CONTAINER:
     case SSZ_TYPE_CONTAINER: {
-      // Container: iterate through fields, respect optional field mask
-      uint64_t mask  = 0;
-      ctx->no_quotes = false;
-      close_char     = '}';
-      bool first     = true;
+      // Container: iterate through fields, respect optional field mask and (for
+      // progressive containers) skip inactive positions
+      const ssz_def_t* elements = ssz_container_elements(def);
+      uint32_t         count    = ssz_container_len(def);
+      uint64_t         mask     = 0;
+      ctx->no_quotes            = false;
+      close_char                = '}';
+      bool first                = true;
       buffer_add_chars(buf, "{\n");
-      for (int i = 0; i < def->def.container.len; i++) {
-        if (def->def.container.elements[i].type == SSZ_TYPE_NONE) continue; // inactive slot of a progressive container
-        ssz_ob_t val = ssz_get(&ob, (char*) def->def.container.elements[i].name);
+      for (uint32_t i = 0; i < count; i++) {
+        if (!ssz_field_active(def, i)) continue; // inactive position of a progressive container
+        ssz_ob_t val = ssz_get(&ob, (char*) elements[i].name);
         if (val.def->flags & SSZ_FLAG_OPT_MASK) {
           mask |= bytes_as_le(val.bytes);
           continue;
@@ -430,7 +455,7 @@ static void dump(ssz_dump_t* ctx, ssz_ob_t ob, const char* name, int intend) {
           first = false;
         else
           buffer_add_chars(buf, ",\n");
-        dump(ctx, val, def->def.container.elements[i].name, intend + 2);
+        dump(ctx, val, elements[i].name, intend + 2);
       }
       break;
     }

--- a/src/util/ssz.h
+++ b/src/util/ssz.h
@@ -51,6 +51,10 @@ extern "C" {
 #define SSZ_MAX_UINT_SIZE   32                   /**< Maximum size for uint types in bytes */
 #define SSZ_MAX_BYTES       (1024 * 1024 * 1024) /**< Maximum SSZ object size (1GB) to prevent integer overflows */
 
+/** Maximum serialized size for progressive bit lists (EIP-7916 defines no capacity),
+ * chosen so the bit length always fits into 32 bits without wrapping. */
+#define SSZ_MAX_PROG_BITLIST_BYTES (((uint32_t) 1 << 29) - 1)
+
 // Forward declarations
 typedef struct ssz_def       ssz_def_t;
 typedef struct ssz_list      ssz_list_t;
@@ -59,15 +63,18 @@ typedef uint64_t             gindex_t;
 
 /** the available SSZ Types */
 typedef enum {
-  SSZ_TYPE_UINT       = 0, /**< Basic uint type */
-  SSZ_TYPE_BOOLEAN    = 1, /**< Basic boolean type (true or false) */
-  SSZ_TYPE_CONTAINER  = 2, /**< Container type */
-  SSZ_TYPE_VECTOR     = 3, /**< Vector type wih a fixed length*/
-  SSZ_TYPE_LIST       = 4, /**< List type with a variable length*/
-  SSZ_TYPE_BIT_VECTOR = 5, /**< Bit vector type  with a fixed length*/
-  SSZ_TYPE_BIT_LIST   = 6, /**< Bit list type with a variable length*/
-  SSZ_TYPE_UNION      = 7, /**< Union type with a variable length*/
-  SSZ_TYPE_NONE       = 8, /**< a NONE-Type (only used in unions) */
+  SSZ_TYPE_UINT           = 0,  /**< Basic uint type */
+  SSZ_TYPE_BOOLEAN        = 1,  /**< Basic boolean type (true or false) */
+  SSZ_TYPE_CONTAINER      = 2,  /**< Container type */
+  SSZ_TYPE_VECTOR         = 3,  /**< Vector type with a fixed length*/
+  SSZ_TYPE_LIST           = 4,  /**< List type with a variable length*/
+  SSZ_TYPE_BIT_VECTOR     = 5,  /**< Bit vector type  with a fixed length*/
+  SSZ_TYPE_BIT_LIST       = 6,  /**< Bit list type with a variable length*/
+  SSZ_TYPE_UNION          = 7,  /**< Union type with a variable length*/
+  SSZ_TYPE_NONE           = 8,  /**< a NONE-Type (only used in unions and as inactive slot in progressive containers) */
+  SSZ_TYPE_PROG_CONTAINER = 9,  /**< ProgressiveContainer (EIP-7495): container with progressive merkleization and active_fields mix-in */
+  SSZ_TYPE_PROG_LIST      = 10, /**< ProgressiveList (EIP-7916): list without capacity, progressive merkleization */
+  SSZ_TYPE_PROG_BIT_LIST  = 11, /**< ProgressiveBitlist (EIP-7916): bit list without capacity, progressive merkleization */
 } ssz_type_t;
 
 /**
@@ -85,7 +92,7 @@ typedef enum {
 /** a SSZ Type Definition */
 struct ssz_def {
   const char* name;      /**< name of the property or SSZ Def*/
-  uint8_t     type : 4;  /**< General SSZ type (4 bits, 0-8 fits) */
+  uint8_t     type : 4;  /**< General SSZ type (4 bits, 0-11 fits) */
   uint8_t     flags : 4; /**< flags of the object (4 bits) */
   union {
     struct {
@@ -135,6 +142,26 @@ typedef struct {
  */
 #define ssz_builder_for_def(typename) \
   (ssz_builder_t) { .def = (const ssz_def_t*) (typename), .fixed = (buffer_t) {.data = (bytes_t) {.data = NULL, .len = 0}, .allocated = 0}, .dynamic = (buffer_t) {.data = (bytes_t) {.data = NULL, .len = 0}, .allocated = 0} }
+
+/** checks if the definition is a container type (Container or ProgressiveContainer) */
+static inline bool ssz_is_container_type(const ssz_def_t* def) {
+  return def->type == SSZ_TYPE_CONTAINER || def->type == SSZ_TYPE_PROG_CONTAINER;
+}
+
+/** checks if the definition is a list type (List or ProgressiveList) */
+static inline bool ssz_is_list_type(const ssz_def_t* def) {
+  return def->type == SSZ_TYPE_LIST || def->type == SSZ_TYPE_PROG_LIST;
+}
+
+/** checks if the definition is a bit list type (Bitlist or ProgressiveBitlist) */
+static inline bool ssz_is_bit_list_type(const ssz_def_t* def) {
+  return def->type == SSZ_TYPE_BIT_LIST || def->type == SSZ_TYPE_PROG_BIT_LIST;
+}
+
+/** checks if the definition uses progressive merkleization (EIP-7495 / EIP-7916) */
+static inline bool ssz_is_progressive_type(const ssz_def_t* def) {
+  return def->type == SSZ_TYPE_PROG_CONTAINER || def->type == SSZ_TYPE_PROG_LIST || def->type == SSZ_TYPE_PROG_BIT_LIST;
+}
 
 /** gets the uint64 value of the object */
 static inline uint64_t ssz_uint64(ssz_ob_t ob) {
@@ -705,6 +732,89 @@ extern const ssz_def_t ssz_none;                // special value for none in uio
     .def.container = {.elements = children,                         \
                       .len      = sizeof(children) / sizeof(ssz_def_t) } \
   }
+
+/**
+ * Defines a ProgressiveContainer (EIP-7495) type with named fields.
+ *
+ * The container is merkleized using the progressive Merkle tree shape
+ * (EIP-7916) and the `active_fields` bitvector is mixed into the root.
+ * Inactive field positions (gaps in `active_fields`) are represented by
+ * `SSZ_NONE` entries in the field array: they are not serialized, but they
+ * occupy a chunk position (zero chunk) in the Merkle tree, keeping the
+ * generalized indices of the remaining fields stable across versions.
+ *
+ * The last entry must not be `SSZ_NONE` (per EIP-7495 `active_fields`
+ * must not end in 0) and at most 256 field positions are allowed.
+ *
+ * @param propname Name of the container type
+ * @param children Array of ssz_def_t field definitions (with SSZ_NONE gaps)
+ *
+ * Example:
+ * ```c
+ * // active_fields = [1, 0, 1]
+ * static const ssz_def_t SQUARE[] = {
+ *     SSZ_UINT16("side"),  // merkleized at field index 0
+ *     SSZ_NONE,            // inactive slot
+ *     SSZ_UINT8("color"),  // merkleized at field index 2
+ * };
+ * const ssz_def_t SQUARE_CONTAINER = SSZ_PROG_CONTAINER("Square", SQUARE);
+ * ```
+ */
+#define SSZ_PROG_CONTAINER(propname, children)                          \
+  {                                                                     \
+    .name          = propname,                                         \
+    .type          = SSZ_TYPE_PROG_CONTAINER,                          \
+    .def.container = {.elements = children,                            \
+                      .len      = sizeof(children) / sizeof(ssz_def_t) } \
+  }
+
+/**
+ * Defines a ProgressiveList (EIP-7916) field: a list without a capacity
+ * limit, merkleized using the progressive Merkle tree shape.
+ *
+ * Serialization is identical to `SSZ_LIST`, only the merkleization differs.
+ *
+ * @param property Name of the field
+ * @param typePtr Element type definition (without &)
+ *
+ * Example:
+ * ```c
+ * SSZ_PROG_LIST("transactions", Transaction)
+ * ```
+ */
+#define SSZ_PROG_LIST(property, typePtr)                                       \
+  {                                                                            \
+    .name = property, .type = SSZ_TYPE_PROG_LIST, .def.vector = {.len  = 0,   \
+                                                                 .type = &typePtr } \
+  }
+
+/**
+ * Defines a ProgressiveBitlist (EIP-7916) field: a bit list without a
+ * capacity limit, merkleized using the progressive Merkle tree shape.
+ *
+ * Serialization is identical to `SSZ_BIT_LIST` (incl. sentinel bit).
+ *
+ * @param property Name of the field
+ *
+ * Example:
+ * ```c
+ * SSZ_PROG_BIT_LIST("aggregation_bits")
+ * ```
+ */
+#define SSZ_PROG_BIT_LIST(property)                                            \
+  {                                                                            \
+    .name = property, .type = SSZ_TYPE_PROG_BIT_LIST, .def.vector = {.len  = 0,    \
+                                                                     .type = NULL } \
+  }
+
+/**
+ * Defines a ProgressiveList of bytes (rendered as hex in JSON).
+ *
+ * @param name Field name
+ *
+ * Example: SSZ_PROG_BYTES("extra_data")
+ */
+#define SSZ_PROG_BYTES(name) SSZ_PROG_LIST(name, ssz_uint8)
 
 /**
  * Defines a union type (one of several variants).

--- a/src/util/ssz.h
+++ b/src/util/ssz.h
@@ -71,7 +71,7 @@ typedef enum {
   SSZ_TYPE_BIT_VECTOR     = 5,  /**< Bit vector type  with a fixed length*/
   SSZ_TYPE_BIT_LIST       = 6,  /**< Bit list type with a variable length*/
   SSZ_TYPE_UNION          = 7,  /**< Union type with a variable length*/
-  SSZ_TYPE_NONE           = 8,  /**< a NONE-Type (only used in unions and as inactive slot in progressive containers) */
+  SSZ_TYPE_NONE           = 8,  /**< a NONE-Type (used as the null variant in unions) */
   SSZ_TYPE_PROG_CONTAINER = 9,  /**< ProgressiveContainer (EIP-7495): container with progressive merkleization and active_fields mix-in */
   SSZ_TYPE_PROG_LIST      = 10, /**< ProgressiveList (EIP-7916): list without capacity, progressive merkleization */
   SSZ_TYPE_PROG_BIT_LIST  = 11, /**< ProgressiveBitlist (EIP-7916): bit list without capacity, progressive merkleization */
@@ -106,6 +106,10 @@ struct ssz_def {
       const ssz_def_t* type; /**< the type of the elements in the vector or list */
       uint32_t         len;  /**< either the fixed length of the vector or max length of the list.*/
     } vector;                /**< vector or list defintions */
+    struct ssz_progressive_container {
+      const ssz_def_t* container;     /**< base container def (SSZ_TYPE_CONTAINER) defining the field layout */
+      uint64_t         active_fields; /**< bit i set = field position i is active (max 64 positions, EIP-7495) */
+    } progressive_container;          /**< progressive container definitions */
   } def;
 };
 
@@ -161,6 +165,33 @@ static inline bool ssz_is_bit_list_type(const ssz_def_t* def) {
 /** checks if the definition uses progressive merkleization (EIP-7495 / EIP-7916) */
 static inline bool ssz_is_progressive_type(const ssz_def_t* def) {
   return def->type == SSZ_TYPE_PROG_CONTAINER || def->type == SSZ_TYPE_PROG_LIST || def->type == SSZ_TYPE_PROG_BIT_LIST;
+}
+
+/** returns the field array of a container or progressive container definition */
+static inline const ssz_def_t* ssz_container_elements(const ssz_def_t* def) {
+  if (def->type == SSZ_TYPE_PROG_CONTAINER)
+    return def->def.progressive_container.container->def.container.elements;
+  return def->def.container.elements;
+}
+
+/** returns the number of field positions in a container or progressive container definition */
+static inline uint32_t ssz_container_len(const ssz_def_t* def) {
+  if (def->type == SSZ_TYPE_PROG_CONTAINER)
+    return def->def.progressive_container.container->def.container.len;
+  return def->def.container.len;
+}
+
+/** checks whether field position i is active. For regular containers this is
+ * always true; for progressive containers it consults the active_fields mask. */
+static inline bool ssz_field_active(const ssz_def_t* def, uint32_t i) {
+  if (def->type == SSZ_TYPE_PROG_CONTAINER)
+    return i < 64 && (def->def.progressive_container.active_fields & (((uint64_t) 1) << i)) != 0;
+  return true;
+}
+
+/** returns the active_fields bitmask for progressive containers, 0 otherwise */
+static inline uint64_t ssz_active_fields(const ssz_def_t* def) {
+  return def->type == SSZ_TYPE_PROG_CONTAINER ? def->def.progressive_container.active_fields : 0;
 }
 
 /** gets the uint64 value of the object */
@@ -734,38 +765,45 @@ extern const ssz_def_t ssz_none;                // special value for none in uio
   }
 
 /**
- * Defines a ProgressiveContainer (EIP-7495) type with named fields.
+ * Defines a ProgressiveContainer (EIP-7495) as a variant of a shared base
+ * container plus an `active_fields` bitmask.
  *
- * The container is merkleized using the progressive Merkle tree shape
- * (EIP-7916) and the `active_fields` bitvector is mixed into the root.
- * Inactive field positions (gaps in `active_fields`) are represented by
- * `SSZ_NONE` entries in the field array: they are not serialized, but they
- * occupy a chunk position (zero chunk) in the Merkle tree, keeping the
- * generalized indices of the remaining fields stable across versions.
+ * The base container defines the canonical field layout (position i = field i);
+ * the bitmask selects which of these positions are active in this variant.
+ * Inactive positions are not serialized, but they occupy a chunk position
+ * (zero chunk) in the Merkle tree, keeping the generalized indices of the
+ * remaining fields stable across versions. The bitmask is mixed into the root.
  *
- * The last entry must not be `SSZ_NONE` (per EIP-7495 `active_fields`
- * must not end in 0) and at most 256 field positions are allowed.
+ * The mask must be non-zero (EIP-7495: `active_fields` must not end in 0) and
+ * at most 64 positions are supported. The highest set bit must be `< base_len`.
  *
- * @param propname Name of the container type
- * @param children Array of ssz_def_t field definitions (with SSZ_NONE gaps)
+ * The base container **must** be an `SSZ_TYPE_CONTAINER` (not itself a
+ * progressive container); this is validated by `ssz_is_valid`. Chaining
+ * `SSZ_PROG_CONTAINER` on top of another progressive container is undefined
+ * behavior and will produce incorrect Merkle roots.
+ *
+ * @param propname Name of the container variant
+ * @param base_container Pointer to a `SSZ_TYPE_CONTAINER` def (without &)
+ * @param active_mask uint64_t bitmask: bit i set = field position i is active
  *
  * Example:
  * ```c
- * // active_fields = [1, 0, 1]
- * static const ssz_def_t SQUARE[] = {
- *     SSZ_UINT16("side"),  // merkleized at field index 0
- *     SSZ_NONE,            // inactive slot
- *     SSZ_UINT8("color"),  // merkleized at field index 2
+ * static const ssz_def_t SHAPE_FIELDS[] = {
+ *     SSZ_UINT16("side"),   // field index 0
+ *     SSZ_UINT16("radius"), // field index 1
+ *     SSZ_UINT8("color"),   // field index 2
  * };
- * const ssz_def_t SQUARE_CONTAINER = SSZ_PROG_CONTAINER("Square", SQUARE);
+ * static const ssz_def_t SHAPE_CONTAINER = SSZ_CONTAINER("Shape", SHAPE_FIELDS);
+ * const ssz_def_t SQUARE = SSZ_PROG_CONTAINER("Square", SHAPE_CONTAINER, 0b101);
+ * const ssz_def_t CIRCLE = SSZ_PROG_CONTAINER("Circle", SHAPE_CONTAINER, 0b110);
  * ```
  */
-#define SSZ_PROG_CONTAINER(propname, children)                          \
-  {                                                                     \
-    .name          = propname,                                         \
-    .type          = SSZ_TYPE_PROG_CONTAINER,                          \
-    .def.container = {.elements = children,                            \
-                      .len      = sizeof(children) / sizeof(ssz_def_t) } \
+#define SSZ_PROG_CONTAINER(propname, base_container, active_mask)  \
+  {                                                                \
+    .name = propname,                                              \
+    .type = SSZ_TYPE_PROG_CONTAINER,                               \
+    .def.progressive_container = {.container     = &(base_container), \
+                                  .active_fields = (active_mask) } \
   }
 
 /**

--- a/src/util/ssz_builder.c
+++ b/src/util/ssz_builder.c
@@ -42,8 +42,10 @@
  */
 static const ssz_def_t* find_def(const ssz_def_t* def, const char* name) {
   if (!ssz_is_container_type(def)) return NULL;
-  for (int i = 0; i < def->def.container.len; i++) {
-    if (strcmp(def->def.container.elements[i].name, name) == 0) return def->def.container.elements + i;
+  const ssz_def_t* elements = ssz_container_elements(def);
+  uint32_t         count    = ssz_container_len(def);
+  for (uint32_t i = 0; i < count; i++) {
+    if (ssz_field_active(def, i) && strcmp(elements[i].name, name) == 0) return elements + i;
   }
   return NULL;
 }
@@ -125,26 +127,31 @@ void ssz_add_bytes(ssz_builder_t* buffer, const char* name, bytes_t data) {
     fbprintf(stderr, "ssz_add_bytes: name %s not found in %s\n", name, buffer->def->name);
     return;
   }
-  buffer_t* bytes        = &(buffer->fixed);
-  size_t    fixed_length = 0;
+  const ssz_def_t* elements = ssz_container_elements(buffer->def);
+  uint32_t         count    = ssz_container_len(buffer->def);
+  buffer_t*        bytes    = &(buffer->fixed);
+  size_t           fixed_length = 0;
 
   // check offset
   size_t offset = 0;
-  for (int i = 0; i < buffer->def->def.container.len; i++) {
-    if (buffer->def->def.container.elements + i == def) {
+  for (uint32_t i = 0; i < count; i++) {
+    if (!ssz_field_active(buffer->def, i)) continue; // inactive position of a progressive container
+    if (elements + i == def) {
       if (offset != buffer->fixed.data.len) {
         fbprintf(stderr, "ssz_add_bytes: %d ( +%d ) %s\n", buffer->fixed.data.len, data.len, name);
         fbprintf(stderr, "ssz_add_bytes:    offset mismatch %l != %d\n", (uint64_t) offset, buffer->fixed.data.len);
       }
       break;
     }
-    offset += ssz_fixed_length(buffer->def->def.container.elements + i);
+    offset += ssz_fixed_length(elements + i);
   }
 
   if (ssz_is_dynamic(def)) {
     offset = 0;
-    for (int i = 0; i < buffer->def->def.container.len; i++)
-      offset += ssz_fixed_length(buffer->def->def.container.elements + i);
+    for (uint32_t i = 0; i < count; i++) {
+      if (ssz_field_active(buffer->def, i))
+        offset += ssz_fixed_length(elements + i);
+    }
     ssz_add_uint32(buffer, offset + buffer->dynamic.data.len);
     bytes = &(buffer->dynamic);
   }
@@ -229,25 +236,27 @@ ssz_ob_t ssz_from_json(json_t json, const ssz_def_t* def, c4_state_t* state) {
   switch (def->type) {
     case SSZ_TYPE_PROG_CONTAINER:
     case SSZ_TYPE_CONTAINER: {
-      // Container: iterate over all fields, convert JSON to SSZ
+      // Container: iterate over active fields, convert JSON to SSZ
       // Handle optional fields (opt_mask) and CamelCase/snake_case field names
-      uint64_t optmask     = 0;
-      int      optmask_len = 0;
-      int      optmask_idx = -1;
-      for (int i = 0; i < def->def.container.len; i++) {
-        if (def->def.container.elements[i].type == SSZ_TYPE_NONE) continue; // inactive slot of a progressive container
-        if (def->def.container.elements[i].flags & SSZ_FLAG_OPT_MASK) {
+      const ssz_def_t* elements    = ssz_container_elements(def);
+      uint32_t         count       = ssz_container_len(def);
+      uint64_t         optmask     = 0;
+      int              optmask_len = 0;
+      int              optmask_idx = -1;
+      for (uint32_t i = 0; i < count; i++) {
+        if (!ssz_field_active(def, i)) continue; // inactive position of a progressive container
+        if (elements[i].flags & SSZ_FLAG_OPT_MASK) {
           optmask_idx = buf.fixed.data.len;
-          optmask_len = def->def.container.elements[i].def.uint.len;
-          ssz_add_bytes(&buf, def->def.container.elements[i].name, NULL_BYTES);
+          optmask_len = elements[i].def.uint.len;
+          ssz_add_bytes(&buf, elements[i].name, NULL_BYTES);
           continue;
         }
-        json_t element = json_get(json, def->def.container.elements[i].name);
+        json_t element = json_get(json, elements[i].name);
         if (element.type == JSON_TYPE_NOT_FOUND) {
           // Field not found: try converting CamelCase to snake_case
           // e.g., "blockNumber" -> "block_number"
           buffer_t pascal_name = {0};
-          for (const char* c = def->def.container.elements[i].name; *c; c++) {
+          for (const char* c = elements[i].name; *c; c++) {
             char cc = *c;
             if (cc >= 'A' && cc <= 'Z') {
               if (pascal_name.data.len && pascal_name.data.data[pascal_name.data.len - 1] != '_')
@@ -263,16 +272,16 @@ ssz_ob_t ssz_from_json(json_t json, const ssz_def_t* def, c4_state_t* state) {
         }
         if (element.type == JSON_TYPE_NOT_FOUND) {
           if (optmask_idx != -1) {
-            ssz_add_bytes(&buf, def->def.container.elements[i].name, NULL_BYTES);
+            ssz_add_bytes(&buf, elements[i].name, NULL_BYTES);
             continue;
           }
-          char* error = bprintf(NULL, "ssz_from_json: %s.%s not found", def->name, def->def.container.elements[i].name);
+          char* error = bprintf(NULL, "ssz_from_json: %s.%s not found", def->name, elements[i].name);
           c4_state_add_error(state, error);
           free(error);
         }
         if (i < 64) optmask |= ((uint64_t) 1) << i; // the opt mask covers at most 64 fields
-        ssz_ob_t ob = ssz_from_json(element, def->def.container.elements + i, state);
-        ssz_add_bytes(&buf, def->def.container.elements[i].name, ob.bytes);
+        ssz_ob_t ob = ssz_from_json(element, elements + i, state);
+        ssz_add_bytes(&buf, elements[i].name, ob.bytes);
         safe_free(ob.bytes.data);
       }
       if (optmask_len == 4 && buf.fixed.data.data)

--- a/src/util/ssz_builder.c
+++ b/src/util/ssz_builder.c
@@ -41,7 +41,7 @@
  * @return Pointer to the field's type definition, or NULL if not found
  */
 static const ssz_def_t* find_def(const ssz_def_t* def, const char* name) {
-  if (def->type != SSZ_TYPE_CONTAINER) return NULL;
+  if (!ssz_is_container_type(def)) return NULL;
   for (int i = 0; i < def->def.container.len; i++) {
     if (strcmp(def->def.container.elements[i].name, name) == 0) return def->def.container.elements + i;
   }
@@ -227,6 +227,7 @@ ssz_ob_t ssz_from_json(json_t json, const ssz_def_t* def, c4_state_t* state) {
   ssz_builder_t buf = {0};
   buf.def           = def;
   switch (def->type) {
+    case SSZ_TYPE_PROG_CONTAINER:
     case SSZ_TYPE_CONTAINER: {
       // Container: iterate over all fields, convert JSON to SSZ
       // Handle optional fields (opt_mask) and CamelCase/snake_case field names
@@ -234,6 +235,7 @@ ssz_ob_t ssz_from_json(json_t json, const ssz_def_t* def, c4_state_t* state) {
       int      optmask_len = 0;
       int      optmask_idx = -1;
       for (int i = 0; i < def->def.container.len; i++) {
+        if (def->def.container.elements[i].type == SSZ_TYPE_NONE) continue; // inactive slot of a progressive container
         if (def->def.container.elements[i].flags & SSZ_FLAG_OPT_MASK) {
           optmask_idx = buf.fixed.data.len;
           optmask_len = def->def.container.elements[i].def.uint.len;
@@ -268,7 +270,7 @@ ssz_ob_t ssz_from_json(json_t json, const ssz_def_t* def, c4_state_t* state) {
           c4_state_add_error(state, error);
           free(error);
         }
-        optmask |= 1 << i;
+        if (i < 64) optmask |= ((uint64_t) 1) << i; // the opt mask covers at most 64 fields
         ssz_ob_t ob = ssz_from_json(element, def->def.container.elements + i, state);
         ssz_add_bytes(&buf, def->def.container.elements[i].name, ob.bytes);
         safe_free(ob.bytes.data);
@@ -329,6 +331,7 @@ ssz_ob_t ssz_from_json(json_t json, const ssz_def_t* def, c4_state_t* state) {
         return (ssz_ob_t) {.def = def, .bytes = buf.fixed.data};
       }
     }
+    case SSZ_TYPE_PROG_LIST:
     case SSZ_TYPE_LIST: {
       // List: convert JSON array to variable-length SSZ list
       if (def->def.vector.type->type == SSZ_TYPE_UINT && def->def.vector.type->def.uint.len == 1)
@@ -363,6 +366,7 @@ ssz_ob_t ssz_from_json(json_t json, const ssz_def_t* def, c4_state_t* state) {
       return (ssz_ob_t) {.def = def, .bytes = buf.fixed.data};
     }
     case SSZ_TYPE_BIT_LIST:
+    case SSZ_TYPE_PROG_BIT_LIST:
       return (ssz_ob_t) {.def = def, .bytes = json_as_bytes(json, &buf.fixed)};
     default:
       return (ssz_ob_t) {.def = def, .bytes = {0}};

--- a/src/util/ssz_merkle.c
+++ b/src/util/ssz_merkle.c
@@ -79,6 +79,28 @@ static bool is_basic_type(const ssz_def_t* def) {
   return def->type == SSZ_TYPE_UINT || def->type == SSZ_TYPE_BOOLEAN || def->type == SSZ_TYPE_NONE;
 }
 
+/**
+ * Computes the generalized index of a chunk within a progressive Merkle
+ * tree (EIP-7916), relative to the progressive data root (excluding the
+ * length / active_fields mix-in).
+ *
+ * The progressive tree is a chain of balanced subtrees with 4^level leaves:
+ * chunk ranges 0..<1, 1..<5, 5..<21, 21..<85, ...
+ *
+ * @param chunk_i The chunk index
+ * @return The gindex of the chunk relative to the progressive data root
+ */
+static gindex_t prog_chunk_gindex(uint64_t chunk_i) {
+  gindex_t gindex = 1;
+  uint32_t depth  = 0;
+  while (chunk_i >= ((uint64_t) 1) << depth) {
+    chunk_i -= ((uint64_t) 1) << depth;
+    depth += 2;
+    gindex = (gindex << 1) | 1;
+  }
+  return ((gindex << 1) << depth) + chunk_i;
+}
+
 gindex_t ssz_gindex(const ssz_def_t* def, int num_elements, ...) {
   if (!def || num_elements <= 0) return 0;
   gindex_t gindex = 1;
@@ -90,7 +112,36 @@ gindex_t ssz_gindex(const ssz_def_t* def, int num_elements, ...) {
     uint64_t leafes = 0;
     uint64_t idx    = 0;
 
-    if (def->type == SSZ_TYPE_CONTAINER) {
+    if (def->type == SSZ_TYPE_PROG_CONTAINER) {
+      // progressive containers: the chunk index is the field position (incl. inactive SSZ_NONE slots),
+      // the data tree sits at gindex 2 below the active_fields mix-in
+      const char*      path_element = va_arg(args, const char*);
+      const ssz_def_t* found        = NULL;
+      uint64_t         chunk_i      = 0;
+      for (uint32_t n = 0; n < def->def.container.len; n++) {
+        if (def->def.container.elements[n].type != SSZ_TYPE_NONE && strcmp(def->def.container.elements[n].name, path_element) == 0) {
+          found   = def->def.container.elements + n;
+          chunk_i = n;
+          break;
+        }
+      }
+      if (!found) {
+        va_end(args);
+        return 0;
+      }
+      def    = found;
+      gindex = ssz_add_gindex(gindex, ssz_add_gindex(2, prog_chunk_gindex(chunk_i)));
+      continue;
+    }
+    else if (def->type == SSZ_TYPE_PROG_LIST) {
+      // like List, the index addresses the chunk for basic element types and the element otherwise,
+      // the data tree sits at gindex 2 below the length mix-in
+      idx    = (uint64_t) va_arg(args, int);
+      def    = def->def.vector.type;
+      gindex = ssz_add_gindex(gindex, ssz_add_gindex(2, prog_chunk_gindex(idx)));
+      continue;
+    }
+    else if (def->type == SSZ_TYPE_CONTAINER) {
       const char* path_element = va_arg(args, const char*);
       for (int i = 0; i < def->def.container.len; i++) {
         if (strcmp(def->def.container.elements[i].name, path_element) == 0) {
@@ -177,7 +228,7 @@ static void ssz_add_multi_merkle_proof(gindex_t gindex, buffer_t* witnesses, buf
 static ssz_ob_t ssz_get_field(ssz_ob_t* ob, int index) {
   ssz_ob_t res = {0};
   // check if the object is valid
-  if (!ob || !ob->def || ob->def->type != SSZ_TYPE_CONTAINER || !ob->bytes.data || !ob->bytes.len || index < 0 || index >= ob->def->def.container.len)
+  if (!ob || !ob->def || !ssz_is_container_type(ob->def) || !ob->bytes.data || !ob->bytes.len || index < 0 || index >= ob->def->def.container.len)
     return res;
 
   // iterate over the fields of the container
@@ -240,7 +291,7 @@ const ssz_def_t* ssz_get_def(const ssz_def_t* def, const char* name) {
 }
 
 ssz_ob_t ssz_get(ssz_ob_t* ob, const char* name) {
-  if (ob->def->type != SSZ_TYPE_CONTAINER) return (ssz_ob_t) {0};
+  if (!ssz_is_container_type(ob->def)) return (ssz_ob_t) {0};
   for (int i = 0; i < ob->def->def.container.len; i++) {
     if (strcmp(ob->def->def.container.elements[i].name, name) == 0) return ssz_get_field(ob, i);
   }
@@ -276,7 +327,17 @@ static int calc_num_leafes(const ssz_ob_t* ob, bool only_used) {
   const ssz_def_t* def = ob->def;
   switch (def->type) {
     case SSZ_TYPE_CONTAINER:
+    case SSZ_TYPE_PROG_CONTAINER: // all field positions (incl. inactive SSZ_NONE slots) occupy a chunk
       return def->def.container.len;
+    case SSZ_TYPE_PROG_LIST: { // progressive lists have no capacity, so the chunk count is always the used count
+      uint32_t len = ssz_len(*ob);
+      if (is_basic_type(def->def.vector.type))
+        return (len * ssz_fixed_length(def->def.vector.type) + 31) >> 5;
+      else
+        return len;
+    }
+    case SSZ_TYPE_PROG_BIT_LIST:
+      return (ssz_len(*ob) + (SSZ_BITS_PER_CHUNK - 1)) >> 8;
     case SSZ_TYPE_VECTOR:
       if (is_basic_type(def->def.vector.type))
         return (def->def.vector.len * ssz_fixed_length(def->def.vector.type) + 31) >> 5;
@@ -299,26 +360,29 @@ static int calc_num_leafes(const ssz_ob_t* ob, bool only_used) {
 }
 
 static void hash_tree_root(ssz_ob_t ob, uint8_t* out, merkle_ctx_t* parent);
-static void set_leaf(ssz_ob_t ob, int index, uint8_t* out, merkle_ctx_t* ctx) {
+// the chunk index is 64 bit, since progressive trees pad the deepest subtree
+// with virtual zero chunks beyond the used chunk count
+static void set_leaf(ssz_ob_t ob, uint64_t index, uint8_t* out, merkle_ctx_t* ctx) {
   memset(out, 0, 32);
   const ssz_def_t* def = ob.def;
   switch (def->type) {
     case SSZ_TYPE_NONE: break;
-    case SSZ_TYPE_CONTAINER: {
-      if (index < def->def.container.len)
-        hash_tree_root(
-            ssz_get(&ob, (char*) def->def.container.elements[index].name),
-            out, ctx);
+    case SSZ_TYPE_CONTAINER:
+    case SSZ_TYPE_PROG_CONTAINER: {
+      // inactive slots (SSZ_NONE) of progressive containers merkleize as zero chunks
+      if (index < def->def.container.len && def->def.container.elements[index].type != SSZ_TYPE_NONE)
+        hash_tree_root(ssz_get_field(&ob, (int) index), out, ctx);
       break;
     }
+    case SSZ_TYPE_PROG_BIT_LIST:
     case SSZ_TYPE_BIT_LIST: {
       uint32_t bit_len = ssz_len(ob);
       uint32_t chunks  = (bit_len + (SSZ_BITS_PER_CHUNK - 1)) >> 8;
       if (index < chunks) {
-        uint32_t byte_offset = index << 5; // index * 32
+        uint64_t byte_offset = index << 5; // index * 32
         // Buffer overflow protection
         if (byte_offset >= ob.bytes.len) return;
-        uint32_t rest = ob.bytes.len - byte_offset;
+        uint32_t rest = ob.bytes.len - (uint32_t) byte_offset;
         if (bit_len % 8 == 0) rest--; // Account for sentinel byte
         if (rest > SSZ_BYTES_PER_CHUNK) rest = SSZ_BYTES_PER_CHUNK;
         memcpy(out, ob.bytes.data + byte_offset, rest);
@@ -329,21 +393,23 @@ static void set_leaf(ssz_ob_t ob, int index, uint8_t* out, merkle_ctx_t* ctx) {
     }
     case SSZ_TYPE_VECTOR:
     case SSZ_TYPE_LIST:
+    case SSZ_TYPE_PROG_LIST:
     case SSZ_TYPE_BIT_VECTOR: {
 
       // handle complex types
-      if ((def->type == SSZ_TYPE_VECTOR || def->type == SSZ_TYPE_LIST) && !is_basic_type(def->def.vector.type)) {
+      if (def->type != SSZ_TYPE_BIT_VECTOR && !is_basic_type(def->def.vector.type)) {
         uint32_t len = ssz_len(ob);
         if (index < len)
-          hash_tree_root(ssz_at(ob, index), out, ctx);
+          hash_tree_root(ssz_at(ob, (uint32_t) index), out, ctx);
         return;
       }
 
-      int offset = index * SSZ_BYTES_PER_CHUNK;
-      int len    = ob.bytes.len - offset;
-      if (len > SSZ_BYTES_PER_CHUNK) len = SSZ_BYTES_PER_CHUNK;
-      if (offset < ob.bytes.len)
+      uint64_t offset = index * SSZ_BYTES_PER_CHUNK;
+      if (offset < ob.bytes.len) {
+        uint32_t len = ob.bytes.len - (uint32_t) offset;
+        if (len > SSZ_BYTES_PER_CHUNK) len = SSZ_BYTES_PER_CHUNK;
         memcpy(out, ob.bytes.data + offset, len);
+      }
       break;
     }
     case SSZ_TYPE_UINT:
@@ -355,6 +421,39 @@ static void set_leaf(ssz_ob_t ob, int index, uint8_t* out, merkle_ctx_t* ctx) {
       // TODO imoplement it
       break;
   }
+}
+
+/**
+ * Records a node hash as proof witness if the given global gindex
+ * is part of the requested witness set.
+ *
+ * @param ctx Merkle context (no-op if NULL or no proof is attached)
+ * @param gindex global gindex of the node
+ * @param value The node hash to record (32 bytes)
+ */
+static void record_witness_at(merkle_ctx_t* ctx, gindex_t gindex, const uint8_t* value) {
+  if (!ctx || !ctx->proof) return;
+  int pos = gindex_indexOf(ctx->proof->witnesses, gindex);
+  log_debug_full("gindex: %l (r:%l) %s %x",
+                 gindex, ctx->root_gindex, pos >= 0 ? "X" : " ", bytes(value, 32));
+  if (pos >= 0) {
+    buffer_grow(ctx->proof->proof, (ctx->proof->witnesses->data.len / sizeof(gindex_t)) * 32);
+    ctx->proof->proof->data.len = ctx->proof->witnesses->data.len / sizeof(gindex_t) * 32;
+    memcpy(ctx->proof->proof->data.data + pos * 32, value, 32);
+  }
+}
+
+/**
+ * Records a computed node hash as proof witness if its global gindex
+ * is part of the requested witness set.
+ *
+ * @param ctx Merkle context (no-op if no proof is attached)
+ * @param local_gindex gindex of the node relative to the object's data root
+ * @param out The computed node hash (32 bytes)
+ */
+static void record_witness(merkle_ctx_t* ctx, gindex_t local_gindex, const uint8_t* out) {
+  if (!ctx->proof) return;
+  record_witness_at(ctx, ssz_add_gindex(ctx->root_gindex, local_gindex), out);
 }
 
 /**
@@ -406,19 +505,63 @@ static void merkle_hash(merkle_ctx_t* ctx, int index, int depth, uint8_t* out) {
     //   safe_free(s);
   }
 
-  if (ctx->proof) {
-    gindex  = ssz_add_gindex(ctx->root_gindex, gindex); // global gindex
-    int pos = gindex_indexOf(ctx->proof->witnesses, gindex);
-    log_debug_full("gindex: %l (i: %d  d:%d  r:%l) %s %x",
-                   gindex, index, depth, ctx->root_gindex, pos >= 0 ? "X" : " ", bytes(out, 32));
-    //    fprintf(stderr, "gindex: %llu (i: %d  d:%d  r:%llu) %s", gindex, index, depth, ctx->root_gindex, pos >= 0 ? "X" : " ");
-    //    print_hex(stderr, bytes(out, 32), " : ", "\n");
-    if (pos >= 0) {
-      buffer_grow(ctx->proof->proof, (ctx->proof->witnesses->data.len / sizeof(gindex_t)) * 32);
-      ctx->proof->proof->data.len = ctx->proof->witnesses->data.len / sizeof(gindex_t) * 32;
-      memcpy(ctx->proof->proof->data.data + pos * 32, out, 32);
-    }
+  record_witness(ctx, gindex, out);
+}
+
+/**
+ * Computes a node of a balanced binary subtree within a progressive Merkle
+ * tree (EIP-7916). The subtree rooted at this node covers 2^depth chunks
+ * starting at chunk_index; chunks beyond the used chunk count are zero.
+ *
+ * @param ctx Merkle context with object data and proof state
+ * @param chunk_index Index of the first chunk covered by this node
+ * @param depth Remaining depth below this node
+ * @param local_gindex gindex of this node relative to the object's data root
+ * @param out Output buffer for the node hash (32 bytes)
+ */
+static void merkle_hash_prog_subtree(merkle_ctx_t* ctx, uint64_t chunk_index, uint32_t depth, gindex_t local_gindex, uint8_t* out) {
+  if (depth == 0) {
+    if (ctx->proof) ctx->last_gindex = ssz_add_gindex(ctx->root_gindex, local_gindex);
+    set_leaf(ctx->ob, chunk_index, out, ctx);
   }
+#ifdef PRECOMPILE_ZERO_HASHES
+  else if (chunk_index >= (uint64_t) ctx->num_used_leafes && depth <= MAX_DEPTH)
+    cached_zero_hash((int) depth - 1, out);
+#endif
+  else {
+    uint8_t temp[64];
+    merkle_hash_prog_subtree(ctx, chunk_index, depth - 1, local_gindex << 1, temp);
+    merkle_hash_prog_subtree(ctx, chunk_index + (((uint64_t) 1) << (depth - 1)), depth - 1, (local_gindex << 1) | 1, temp + 32);
+    sha256(bytes(temp, 64), out);
+  }
+  record_witness(ctx, local_gindex, out);
+}
+
+/**
+ * Computes a chain node of a progressive Merkle tree (EIP-7916).
+ *
+ * The progressive tree is a chain of balanced binary subtrees with
+ * 4^level leaves each: the left child of a chain node is the balanced
+ * subtree covering the next 4^level chunks, the right child is the next
+ * chain node. The chain terminates with a zero node once all used chunks
+ * are covered.
+ *
+ * @param ctx Merkle context with object data and proof state
+ * @param chunk_offset Index of the first chunk covered by this chain node
+ * @param level Progressive level (the left subtree covers 4^level chunks)
+ * @param local_gindex gindex of this chain node relative to the object's data root
+ * @param out Output buffer for the node hash (32 bytes)
+ */
+static void merkle_hash_progressive(merkle_ctx_t* ctx, uint64_t chunk_offset, uint32_t level, gindex_t local_gindex, uint8_t* out) {
+  if (chunk_offset >= (uint64_t) ctx->num_used_leafes)
+    memset(out, 0, 32); // zero terminator of the subtree chain
+  else {
+    uint8_t temp[64];
+    merkle_hash_prog_subtree(ctx, chunk_offset, 2 * level, local_gindex << 1, temp);
+    merkle_hash_progressive(ctx, chunk_offset + (((uint64_t) 1) << (2 * level)), level + 1, (local_gindex << 1) | 1, temp + 32);
+    sha256(bytes(temp, 64), out);
+  }
+  record_witness(ctx, local_gindex, out);
 }
 
 static inline void calc_leafes(merkle_ctx_t* ctx, ssz_ob_t ob) {
@@ -441,11 +584,29 @@ static void mix_in_length(uint8_t* root, uint32_t length, merkle_ctx_t* ctx) {
   uint64_to_le(length_bytes, (uint64_t) length);
   sha256_merkle(bytes(root, 32), bytes(length_bytes, 32), root);
 
-  if (ctx && ctx->proof) {
-    int pos = gindex_indexOf(ctx->proof->witnesses, ctx->root_gindex + 1);
-    if (pos >= 0 && ctx->proof->proof->data.data)
-      memcpy(ctx->proof->proof->data.data + pos * 32, length_bytes, 32);
+  // the length node is the right sibling of the data root
+  if (ctx) record_witness_at(ctx, ctx->root_gindex + 1, length_bytes);
+}
+
+/**
+ * Mixes in the active_fields bitvector for progressive containers (EIP-7495).
+ * The bitmask is derived from the type definition: bit i is set if field
+ * position i holds an active field (not SSZ_NONE).
+ *
+ * @param root The current root hash (will be modified in place)
+ * @param def The progressive container definition
+ * @param ctx Merkle context for proof generation (can be NULL)
+ */
+static void mix_in_active_fields(uint8_t* root, const ssz_def_t* def, merkle_ctx_t* ctx) {
+  uint8_t active_fields[32] = {0};
+  for (uint32_t i = 0; i < def->def.container.len && i < 256; i++) {
+    if (def->def.container.elements[i].type != SSZ_TYPE_NONE)
+      active_fields[i >> 3] |= (uint8_t) (1 << (i & 7));
   }
+  sha256_merkle(bytes(root, 32), bytes(active_fields, 32), root);
+
+  // the active_fields node is the right sibling of the data root
+  if (ctx) record_witness_at(ctx, ctx->root_gindex + 1, active_fields);
 }
 
 /**
@@ -459,22 +620,30 @@ static void mix_in_length(uint8_t* root, uint32_t length, merkle_ctx_t* ctx) {
 static void hash_tree_root(ssz_ob_t ob, uint8_t* out, merkle_ctx_t* parent) {
   memset(out, 0, 32);
   if (!ob.def) return;
-  merkle_ctx_t ctx = {0};
-  ctx.root_gindex  = 1;
+  merkle_ctx_t ctx         = {0};
+  bool         progressive = ssz_is_progressive_type(ob.def);
+  ctx.root_gindex          = 1;
   calc_leafes(&ctx, ob);
   if (parent) {
-    ctx.proof       = parent->proof;
-    ctx.root_gindex = ob.def->type == SSZ_TYPE_LIST ? parent->last_gindex * 2 : parent->last_gindex;
+    ctx.proof = parent->proof;
+    // lists and progressive types adjust root_gindex for their mix-in, so their data
+    // tree becomes the left child of the object root (bit lists keep the legacy behavior)
+    ctx.root_gindex = (ob.def->type == SSZ_TYPE_LIST || progressive) ? parent->last_gindex * 2 : parent->last_gindex;
   }
 
-  if (ctx.num_leafes == 1)
+  if (progressive)
+    merkle_hash_progressive(&ctx, 0, 0, 1, out);
+  else if (ctx.num_leafes == 1)
     set_leaf(ob, 0, out, NULL);
   else
     merkle_hash(&ctx, 0, 0, out);
 
   // Mix in length for variable-length types (lists and bit lists)
-  if (ob.def->type == SSZ_TYPE_LIST || ob.def->type == SSZ_TYPE_BIT_LIST)
+  if (ssz_is_list_type(ob.def) || ssz_is_bit_list_type(ob.def))
     mix_in_length(out, ssz_len(ob), &ctx);
+  // Mix in the active_fields bitvector for progressive containers
+  else if (ob.def->type == SSZ_TYPE_PROG_CONTAINER)
+    mix_in_active_fields(out, ob.def, &ctx);
 }
 
 void ssz_hash_tree_root(ssz_ob_t ob, uint8_t* out) {
@@ -710,10 +879,13 @@ void ssz_verify_single_merkle_proof(bytes_t proof_data, bytes32_t leaf, gindex_t
 }
 
 gindex_t ssz_add_gindex(gindex_t gindex1, gindex_t gindex2) {
-  uint32_t depth = log2_ceil((uint32_t) gindex2 + 1) - 1;
-  if (depth > 63) {
-    log_error("gindex depth is too large: %u", depth);
-    return 0;
-  }
-  return (gindex1 << depth) | (gindex2 & ((1 << depth) - 1));
+  if (gindex1 == 0 || gindex2 == 0) return 0;
+  // 64-bit floor(log2(gindex)) = depth of the gindex in the tree
+  uint32_t depth1 = 0;
+  for (gindex_t g = gindex1 >> 1; g; g >>= 1) depth1++;
+  uint32_t depth2 = 0;
+  for (gindex_t g = gindex2 >> 1; g; g >>= 1) depth2++;
+  // combined depth must fit into 64 bits, otherwise the gindex would silently wrap
+  if (depth1 + depth2 > 63) return 0;
+  return (gindex1 << depth2) | (gindex2 & ((((gindex_t) 1) << depth2) - 1));
 }

--- a/src/util/ssz_merkle.c
+++ b/src/util/ssz_merkle.c
@@ -113,14 +113,17 @@ gindex_t ssz_gindex(const ssz_def_t* def, int num_elements, ...) {
     uint64_t idx    = 0;
 
     if (def->type == SSZ_TYPE_PROG_CONTAINER) {
-      // progressive containers: the chunk index is the field position (incl. inactive SSZ_NONE slots),
-      // the data tree sits at gindex 2 below the active_fields mix-in
+      // progressive containers: the chunk index is the field position in the base
+      // container (inactive positions are unreachable), the data tree sits at gindex 2
+      // below the active_fields mix-in
       const char*      path_element = va_arg(args, const char*);
+      const ssz_def_t* elements     = ssz_container_elements(def);
+      uint32_t         base_len     = ssz_container_len(def);
       const ssz_def_t* found        = NULL;
       uint64_t         chunk_i      = 0;
-      for (uint32_t n = 0; n < def->def.container.len; n++) {
-        if (def->def.container.elements[n].type != SSZ_TYPE_NONE && strcmp(def->def.container.elements[n].name, path_element) == 0) {
-          found   = def->def.container.elements + n;
+      for (uint32_t n = 0; n < base_len; n++) {
+        if (ssz_field_active(def, n) && strcmp(elements[n].name, path_element) == 0) {
+          found   = elements + n;
           chunk_i = n;
           break;
         }
@@ -224,23 +227,27 @@ static void ssz_add_multi_merkle_proof(gindex_t gindex, buffer_t* witnesses, buf
   }
 }
 
-// gets the value of a field from a container
+// gets the value of a field from a container by base-container position index
 static ssz_ob_t ssz_get_field(ssz_ob_t* ob, int index) {
   ssz_ob_t res = {0};
   // check if the object is valid
-  if (!ob || !ob->def || !ssz_is_container_type(ob->def) || !ob->bytes.data || !ob->bytes.len || index < 0 || index >= ob->def->def.container.len)
+  if (!ob || !ob->def || !ssz_is_container_type(ob->def) || !ob->bytes.data || !ob->bytes.len || index < 0)
     return res;
+  const ssz_def_t* elements = ssz_container_elements(ob->def);
+  uint32_t         count    = ssz_container_len(ob->def);
+  if ((uint32_t) index >= count || !ssz_field_active(ob->def, (uint32_t) index)) return res;
 
-  // iterate over the fields of the container
+  // iterate over the (active) fields of the container
   size_t           pos = 0;
   const ssz_def_t* def = NULL;
-  for (int i = 0; i < ob->def->def.container.len; i++) {
-    def        = ob->def->def.container.elements + i;
+  for (uint32_t i = 0; i < count; i++) {
+    if (!ssz_field_active(ob->def, i)) continue; // inactive position of a progressive container
+    def        = elements + i;
     size_t len = ssz_fixed_length(def);
 
     if (pos + len > ob->bytes.len) return res;
 
-    if (i == index) {
+    if ((int) i == index) {
       res.def = def;
       if (ssz_is_dynamic(def)) {
         uint32_t offset = uint32_from_le(ob->bytes.data + pos);
@@ -249,9 +256,10 @@ static ssz_ob_t ssz_get_field(ssz_ob_t* ob, int index) {
         res.bytes.len  = ob->bytes.len - offset;
         pos += len;
 
-        // find next offset
-        for (int n = i + 1; n < ob->def->def.container.len; n++) {
-          if (ssz_is_dynamic(ob->def->def.container.elements + n)) {
+        // find next active dynamic offset
+        for (uint32_t n = i + 1; n < count; n++) {
+          if (!ssz_field_active(ob->def, n)) continue;
+          if (ssz_is_dynamic(elements + n)) {
             if (pos + 4 > ob->bytes.len) return (ssz_ob_t) {0};
 
             offset = uint32_from_le(ob->bytes.data + pos);
@@ -259,7 +267,7 @@ static ssz_ob_t ssz_get_field(ssz_ob_t* ob, int index) {
               res.bytes.len = ob->bytes.data + offset - res.bytes.data;
             break;
           }
-          pos += ssz_fixed_length(ob->def->def.container.elements + n);
+          pos += ssz_fixed_length(elements + n);
         }
       }
       else {
@@ -284,16 +292,20 @@ static ssz_ob_t ssz_get_field(ssz_ob_t* ob, int index) {
 }
 
 const ssz_def_t* ssz_get_def(const ssz_def_t* def, const char* name) {
-  for (int i = 0; i < def->def.container.len; i++) {
-    if (strcmp(def->def.container.elements[i].name, name) == 0) return def->def.container.elements + i;
+  const ssz_def_t* elements = ssz_container_elements(def);
+  uint32_t         count    = ssz_container_len(def);
+  for (uint32_t i = 0; i < count; i++) {
+    if (ssz_field_active(def, i) && strcmp(elements[i].name, name) == 0) return elements + i;
   }
   return NULL;
 }
 
 ssz_ob_t ssz_get(ssz_ob_t* ob, const char* name) {
   if (!ssz_is_container_type(ob->def)) return (ssz_ob_t) {0};
-  for (int i = 0; i < ob->def->def.container.len; i++) {
-    if (strcmp(ob->def->def.container.elements[i].name, name) == 0) return ssz_get_field(ob, i);
+  const ssz_def_t* elements = ssz_container_elements(ob->def);
+  uint32_t         count    = ssz_container_len(ob->def);
+  for (uint32_t i = 0; i < count; i++) {
+    if (ssz_field_active(ob->def, i) && strcmp(elements[i].name, name) == 0) return ssz_get_field(ob, (int) i);
   }
   log_error("ssz_get: %s not found in %s", name, ob->def->name);
   return (ssz_ob_t) {0};
@@ -327,8 +339,8 @@ static int calc_num_leafes(const ssz_ob_t* ob, bool only_used) {
   const ssz_def_t* def = ob->def;
   switch (def->type) {
     case SSZ_TYPE_CONTAINER:
-    case SSZ_TYPE_PROG_CONTAINER: // all field positions (incl. inactive SSZ_NONE slots) occupy a chunk
-      return def->def.container.len;
+    case SSZ_TYPE_PROG_CONTAINER: // all base-container field positions occupy a chunk (inactive positions merkleize as zero chunks)
+      return (int) ssz_container_len(def);
     case SSZ_TYPE_PROG_LIST: { // progressive lists have no capacity, so the chunk count is always the used count
       uint32_t len = ssz_len(*ob);
       if (is_basic_type(def->def.vector.type))
@@ -369,8 +381,8 @@ static void set_leaf(ssz_ob_t ob, uint64_t index, uint8_t* out, merkle_ctx_t* ct
     case SSZ_TYPE_NONE: break;
     case SSZ_TYPE_CONTAINER:
     case SSZ_TYPE_PROG_CONTAINER: {
-      // inactive slots (SSZ_NONE) of progressive containers merkleize as zero chunks
-      if (index < def->def.container.len && def->def.container.elements[index].type != SSZ_TYPE_NONE)
+      // inactive positions of progressive containers merkleize as zero chunks
+      if (index < ssz_container_len(def) && ssz_field_active(def, (uint32_t) index))
         hash_tree_root(ssz_get_field(&ob, (int) index), out, ctx);
       break;
     }
@@ -590,19 +602,18 @@ static void mix_in_length(uint8_t* root, uint32_t length, merkle_ctx_t* ctx) {
 
 /**
  * Mixes in the active_fields bitvector for progressive containers (EIP-7495).
- * The bitmask is derived from the type definition: bit i is set if field
- * position i holds an active field (not SSZ_NONE).
+ * The bitmask is stored directly in the type definition.
  *
  * @param root The current root hash (will be modified in place)
  * @param def The progressive container definition
  * @param ctx Merkle context for proof generation (can be NULL)
  */
 static void mix_in_active_fields(uint8_t* root, const ssz_def_t* def, merkle_ctx_t* ctx) {
-  uint8_t active_fields[32] = {0};
-  for (uint32_t i = 0; i < def->def.container.len && i < 256; i++) {
-    if (def->def.container.elements[i].type != SSZ_TYPE_NONE)
-      active_fields[i >> 3] |= (uint8_t) (1 << (i & 7));
-  }
+  uint8_t  active_fields[32] = {0};
+  uint64_t mask              = def->def.progressive_container.active_fields;
+  // serialize the mask as a 256-bit little-endian bitvector (only bits 0..63 are used)
+  for (uint32_t i = 0; i < 8; i++)
+    active_fields[i] = (uint8_t) ((mask >> (i * 8)) & 0xff);
   sha256_merkle(bytes(root, 32), bytes(active_fields, 32), root);
 
   // the active_fields node is the right sibling of the data root

--- a/test/unittests/test_ssz_progressive.c
+++ b/test/unittests/test_ssz_progressive.c
@@ -1,0 +1,582 @@
+/*
+ * Copyright (c) 2025 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// Tests for ProgressiveContainer (EIP-7495) and ProgressiveList /
+// ProgressiveBitlist (EIP-7916). All expected roots and gindices were
+// generated with the reference implementation ethereum/remerkleable.
+
+#include "bytes.h"
+#include "c4_assert.h"
+#include "json.h"
+#include "ssz.h"
+#include "state.h"
+#include "unity.h"
+#include <string.h>
+
+void setUp(void) {
+}
+
+void tearDown(void) {
+}
+
+// ProgressiveList[uint64]
+static const ssz_def_t UINT64_PROG_LIST = SSZ_PROG_LIST("uint64_list", ssz_uint64_def);
+
+// ProgressiveList[Bytes32]
+static const ssz_def_t BYTES32_PROG_LIST = SSZ_PROG_LIST("bytes32_list", ssz_bytes32);
+
+// ProgressiveBitlist
+static const ssz_def_t PROG_BIT_LIST = SSZ_PROG_BIT_LIST("bits");
+
+// ProgressiveList[ByteList[64]] (dynamic / variable-size element type)
+static const ssz_def_t BYTE_LIST_64       = SSZ_BYTES("data", 64);
+static const ssz_def_t BYTELIST_PROG_LIST = SSZ_PROG_LIST("byte_lists", BYTE_LIST_64);
+
+// EIP-7495 example: class Square(ProgressiveContainer(active_fields=[1, 0, 1]))
+static const ssz_def_t SQUARE[] = {
+    SSZ_UINT16("side"),
+    SSZ_NONE,
+    SSZ_UINT8("color"),
+};
+static const ssz_def_t SQUARE_CONTAINER = SSZ_PROG_CONTAINER("Square", SQUARE);
+
+// EIP-7495 example: class Circle(ProgressiveContainer(active_fields=[0, 1, 1]))
+static const ssz_def_t CIRCLE[] = {
+    SSZ_NONE,
+    SSZ_UINT16("radius"),
+    SSZ_UINT8("color"),
+};
+static const ssz_def_t CIRCLE_CONTAINER = SSZ_PROG_CONTAINER("Circle", CIRCLE);
+
+// class Nested(ProgressiveContainer(active_fields=[1, 1, 0, 0, 1])):
+//   slot: uint64, root: Bytes32, values: ProgressiveList[uint64]
+static const ssz_def_t NESTED[] = {
+    SSZ_UINT64("slot"),
+    SSZ_BYTES32("root"),
+    SSZ_NONE,
+    SSZ_NONE,
+    SSZ_PROG_LIST("values", ssz_uint64_def),
+};
+static const ssz_def_t NESTED_CONTAINER = SSZ_PROG_CONTAINER("Nested", NESTED);
+
+// serialization of Nested(slot=12345, root=0x11*32, values=[1..7]) created with remerkleable
+static const char* NESTED_SER_HEX = "0x39300000000000001111111111111111111111111111111111111111111111111111111111111111"
+                                    "2c000000"
+                                    "0100000000000000020000000000000003000000000000000400000000000000"
+                                    "050000000000000006000000000000000700000000000000";
+
+static void check_root(ssz_ob_t ob, const char* expected, const char* msg) {
+  bytes32_t root = {0};
+  ssz_hash_tree_root(ob, root);
+  ASSERT_HEX_STRING_EQUAL(expected, root, 32, msg);
+}
+
+static bytes_t from_hex(const char* hex, uint8_t* buf, size_t buf_size) {
+  int len = hex_to_bytes(hex, -1, bytes(buf, (uint32_t) buf_size));
+  TEST_ASSERT_GREATER_THAN_MESSAGE(0, len, "invalid hex string");
+  return bytes(buf, (uint32_t) len);
+}
+
+// builds the serialization of ProgressiveList[uint64] with values 1..n into buf
+static bytes_t uint64_list_data(buffer_t* buf, uint32_t n) {
+  buffer_reset(buf);
+  for (uint32_t i = 0; i < n; i++) {
+    uint8_t tmp[8] = {0};
+    uint64_to_le(tmp, i + 1);
+    buffer_append(buf, bytes(tmp, 8));
+  }
+  return buf->data;
+}
+
+void test_prog_list_uint64_roots(void) {
+  buffer_t buf = {0};
+  struct {
+    uint32_t    len;
+    const char* root;
+  } vectors[] = {
+      {0, "0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b"},
+      {1, "0x905efb51c2764c2c7a4efb0548e372569df06db82115c3b1896c186632f3fe5b"},
+      {4, "0x95a2f252ed2659ccf75e8821f05757c4663fce68e89d0290abf5c33d772935ae"},
+      {5, "0x29918e0447260511bc5be0f7dbb9817201e16e30c56af228b9cb931a16e8799d"},
+      {21, "0xed360c03ecbdfbb6f4b1cf5d9cbf6887038423e31121700797de968a9969aaed"},
+      {100, "0x3fea5b85e30e0416810839a91ea3767e65b04890709db74997109f50213b3375"},
+  };
+  for (size_t i = 0; i < sizeof(vectors) / sizeof(vectors[0]); i++) {
+    ssz_ob_t ob = ssz_ob(UINT64_PROG_LIST, uint64_list_data(&buf, vectors[i].len));
+    TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(ob, true, NULL), "progressive uint64 list must be valid");
+    TEST_ASSERT_EQUAL_UINT32(vectors[i].len, ssz_len(ob));
+    check_root(ob, vectors[i].root, "invalid root for ProgressiveList[uint64]");
+  }
+  buffer_free(&buf);
+}
+
+void test_prog_list_bytes32_roots(void) {
+  buffer_t buf = {0};
+  struct {
+    uint32_t    len;
+    const char* root;
+  } vectors[] = {
+      {0, "0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b"},
+      {1, "0x905efb51c2764c2c7a4efb0548e372569df06db82115c3b1896c186632f3fe5b"},
+      {3, "0x8b9e13c85c24b0073f9b226ee291c1ff181f3652f42d2bcaeb26b3c302ec6004"},
+      {6, "0x76d03915aa777c431f6534cbd136b8f185b5df884546f52a8caa5db69ab49845"},
+  };
+  for (size_t i = 0; i < sizeof(vectors) / sizeof(vectors[0]); i++) {
+    buffer_reset(&buf);
+    for (uint32_t n = 0; n < vectors[i].len; n++) {
+      uint8_t chunk[32] = {0};
+      chunk[0]          = (uint8_t) (n + 1);
+      buffer_append(&buf, bytes(chunk, 32));
+    }
+    ssz_ob_t ob = ssz_ob(BYTES32_PROG_LIST, buf.data);
+    TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(ob, true, NULL), "progressive bytes32 list must be valid");
+    TEST_ASSERT_EQUAL_UINT32(vectors[i].len, ssz_len(ob));
+    check_root(ob, vectors[i].root, "invalid root for ProgressiveList[Bytes32]");
+  }
+  buffer_free(&buf);
+}
+
+void test_prog_bitlist_roots(void) {
+  buffer_t buf = {0};
+  struct {
+    uint32_t    len;
+    const char* root;
+  } vectors[] = {
+      {0, "0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b"},
+      {3, "0x0a0a7cdb38b02d404eae74c9036e2727e4b9de617e77a4d6f3795a0777a034ab"},
+      {255, "0xc3362ae9ebd383368b0b2a19d830219a39c34a482f2975536c82e16b39128702"},
+      {256, "0x25f01ef233dd44d2615671507b9a90483b7823f384453d6be67e24f0f6bfb0c6"},
+      {999, "0xe17f86a4e4e5fb491efbb1071c9c4e92c86464ac4f1385b5c4bd7a4a02a2fb6d"},
+  };
+  for (size_t i = 0; i < sizeof(vectors) / sizeof(vectors[0]); i++) {
+    uint32_t len = vectors[i].len;
+    buffer_reset(&buf);
+    buffer_append(&buf, bytes(NULL, (len + 1 + 7) / 8)); // zeroed bytes incl. sentinel bit
+    for (uint32_t n = 0; n < len; n++) {
+      if (n % 3 == 0) buf.data.data[n >> 3] |= (uint8_t) (1 << (n & 7));
+    }
+    buf.data.data[len >> 3] |= (uint8_t) (1 << (len & 7)); // sentinel bit
+    ssz_ob_t ob = ssz_ob(PROG_BIT_LIST, buf.data);
+    TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(ob, true, NULL), "progressive bit list must be valid");
+    TEST_ASSERT_EQUAL_UINT32(len, ssz_len(ob));
+    check_root(ob, vectors[i].root, "invalid root for ProgressiveBitlist");
+  }
+  buffer_free(&buf);
+}
+
+void test_prog_container_eip7495_examples(void) {
+  // Square and Circle serialize identically (only active fields), but hash differently
+  uint8_t  data[] = {0x42, 0x00, 0x01};
+  ssz_ob_t square = ssz_ob(SQUARE_CONTAINER, bytes(data, sizeof(data)));
+  ssz_ob_t circle = ssz_ob(CIRCLE_CONTAINER, bytes(data, sizeof(data)));
+
+  c4_state_t state = {0};
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(square, true, &state), state.error);
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(circle, true, &state), state.error);
+
+  TEST_ASSERT_EQUAL_UINT64(0x42, ssz_get_uint64(&square, "side"));
+  TEST_ASSERT_EQUAL_UINT64(1, ssz_get_uint64(&square, "color"));
+  TEST_ASSERT_EQUAL_UINT64(0x42, ssz_get_uint64(&circle, "radius"));
+  TEST_ASSERT_EQUAL_UINT64(1, ssz_get_uint64(&circle, "color"));
+
+  check_root(square, "0x5d5c127e27e9862d9aacb13609cd9e936514fbe38e97dba278f0a83b553e57a0", "invalid Square root");
+  check_root(circle, "0xcba0f15b6779f3f88f268311ae29faf0ba2e021c9f4fa4c91208161f563b1554", "invalid Circle root");
+}
+
+void test_prog_container_nested(void) {
+  uint8_t  raw[128] = {0};
+  bytes_t  data     = from_hex(NESTED_SER_HEX, raw, sizeof(raw));
+  ssz_ob_t ob       = ssz_ob(NESTED_CONTAINER, data);
+
+  c4_state_t state = {0};
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(ob, true, &state), state.error);
+
+  TEST_ASSERT_EQUAL_UINT64(12345, ssz_get_uint64(&ob, "slot"));
+  ssz_ob_t values = ssz_get(&ob, "values");
+  TEST_ASSERT_EQUAL_UINT32(7, ssz_len(values));
+  TEST_ASSERT_EQUAL_UINT64(7, ssz_uint64(ssz_at(values, 6)));
+
+  check_root(values, "0xc1fbaac1b247e8871eb128eadd040aafbc9ef97ffaa1a7e68e75b376817b0072", "invalid values root");
+  check_root(ob, "0x7db6e5f1c5c575348b6d520336dcfa85f02753f8c3e410140045f5bbaa11941b", "invalid Nested root");
+}
+
+void test_prog_container_from_json(void) {
+  json_t json = json_parse("{\"slot\": 12345,"
+                           "\"root\": \"0x1111111111111111111111111111111111111111111111111111111111111111\","
+                           "\"values\": [1,2,3,4,5,6,7]}");
+
+  c4_state_t state = {0};
+  ssz_ob_t   ob    = ssz_from_json(json, &NESTED_CONTAINER, &state);
+  TEST_ASSERT_NULL_MESSAGE(state.error, state.error);
+
+  uint8_t raw[128] = {0};
+  bytes_t expected = from_hex(NESTED_SER_HEX, raw, sizeof(raw));
+  TEST_ASSERT_EQUAL_UINT32(expected.len, ob.bytes.len);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expected.data, ob.bytes.data, expected.len, "serialization must match remerkleable");
+
+  check_root(ob, "0x7db6e5f1c5c575348b6d520336dcfa85f02753f8c3e410140045f5bbaa11941b", "invalid Nested root from json");
+  safe_free(ob.bytes.data);
+}
+
+void test_prog_gindex(void) {
+  // chunk gindices of a progressive list (element index == chunk index for Bytes32),
+  // expected values from remerkleable to_gindex_progressive
+  struct {
+    int      idx;
+    gindex_t gindex;
+  } vectors[] = {{0, 4}, {1, 40}, {2, 41}, {4, 43}, {5, 352}, {20, 367}, {21, 2944}, {84, 3007}, {85, 24064}, {100, 24079}};
+  for (size_t i = 0; i < sizeof(vectors) / sizeof(vectors[0]); i++)
+    TEST_ASSERT_EQUAL_UINT64(vectors[i].gindex, ssz_gindex(&BYTES32_PROG_LIST, 1, vectors[i].idx));
+
+  // field gindices of a progressive container (chunk index == field position incl. SSZ_NONE slots)
+  TEST_ASSERT_EQUAL_UINT64(4, ssz_gindex(&NESTED_CONTAINER, 1, "slot"));    // chunk 0
+  TEST_ASSERT_EQUAL_UINT64(40, ssz_gindex(&NESTED_CONTAINER, 1, "root"));   // chunk 1
+  TEST_ASSERT_EQUAL_UINT64(43, ssz_gindex(&NESTED_CONTAINER, 1, "values")); // chunk 4
+
+  // combined path into the nested progressive list (values[0..3] are packed in chunk 0)
+  TEST_ASSERT_EQUAL_UINT64(172, ssz_gindex(&NESTED_CONTAINER, 2, "values", 0));
+
+  // unknown fields and inactive slots must not resolve
+  TEST_ASSERT_EQUAL_UINT64(0, ssz_gindex(&NESTED_CONTAINER, 1, "unknown"));
+  TEST_ASSERT_EQUAL_UINT64(0, ssz_gindex(&NESTED_CONTAINER, 1, "NONE"));
+}
+
+void test_prog_proof_roundtrip(void) {
+  uint8_t  raw[128] = {0};
+  bytes_t  data     = from_hex(NESTED_SER_HEX, raw, sizeof(raw));
+  ssz_ob_t ob       = ssz_ob(NESTED_CONTAINER, data);
+
+  bytes32_t expected_root = {0};
+  ssz_hash_tree_root(ob, expected_root);
+
+  // single proof for the "root" field (gindex 40)
+  gindex_t  gindex     = ssz_gindex(&NESTED_CONTAINER, 1, "root");
+  bytes32_t root_hash  = {0};
+  bytes_t   proof      = ssz_create_proof(ob, root_hash, gindex);
+  bytes32_t leaf       = {0};
+  bytes32_t proof_root = {0};
+  memset(leaf, 0x11, 32);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expected_root, root_hash, 32, "root of proof creation must match hash_tree_root");
+  ssz_verify_single_merkle_proof(proof, leaf, gindex, proof_root);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expected_root, proof_root, 32, "verified single proof must match the root");
+  safe_free(proof.data);
+
+  // multi proof for slot, root and values[0] (packed chunk with values 1..4)
+  gindex_t gindexes[] = {
+      ssz_gindex(&NESTED_CONTAINER, 1, "slot"),
+      ssz_gindex(&NESTED_CONTAINER, 1, "root"),
+      ssz_gindex(&NESTED_CONTAINER, 2, "values", 0)};
+  bytes_t multi_proof = ssz_create_multi_proof(ob, root_hash, 3, gindexes[0], gindexes[1], gindexes[2]);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expected_root, root_hash, 32, "root of multi proof creation must match hash_tree_root");
+
+  uint8_t leafes[96] = {0};
+  uint64_to_le(leafes, 12345);            // slot
+  memset(leafes + 32, 0x11, 32);          // root
+  for (uint64_t i = 0; i < 4; i++)        // first chunk of values: 1..4 packed
+    uint64_to_le(leafes + 64 + i * 8, i + 1);
+
+  memset(proof_root, 0, 32);
+  TEST_ASSERT_TRUE_MESSAGE(ssz_verify_multi_merkle_proof(multi_proof, bytes(leafes, sizeof(leafes)), gindexes, proof_root), "multi proof verification failed");
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expected_root, proof_root, 32, "verified multi proof must match the root");
+  safe_free(multi_proof.data);
+}
+
+// ProgressiveList with dynamic elements: serialization uses an offset table,
+// roots generated with remerkleable ProgressiveList[ByteList[64]]
+void test_prog_list_dynamic_elements(void) {
+  uint8_t    raw[128] = {0};
+  c4_state_t state    = {0};
+
+  // empty list
+  ssz_ob_t empty = ssz_ob(BYTELIST_PROG_LIST, bytes(NULL, 0));
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(empty, true, &state), state.error);
+  TEST_ASSERT_EQUAL_UINT32(0, ssz_len(empty));
+  check_root(empty, "0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b", "invalid root for empty ProgressiveList[ByteList]");
+
+  // one empty element: just the offset table [4]
+  ssz_ob_t one = ssz_ob(BYTELIST_PROG_LIST, from_hex("0x04000000", raw, sizeof(raw)));
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(one, true, &state), state.error);
+  TEST_ASSERT_EQUAL_UINT32(1, ssz_len(one));
+  TEST_ASSERT_EQUAL_UINT32(0, ssz_at(one, 0).bytes.len);
+  check_root(one, "0xd5786f98b33ca4dc786bee109fcfa06b1488babf60ee5de52c9009f3a363c062", "invalid root for [b\"\"]");
+
+  // trailing empty element: last offset equals the total length
+  ssz_ob_t trailing = ssz_ob(BYTELIST_PROG_LIST, from_hex("0x0800000009000000ab", raw, sizeof(raw)));
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(trailing, true, &state), state.error);
+  TEST_ASSERT_EQUAL_UINT32(2, ssz_len(trailing));
+  TEST_ASSERT_EQUAL_UINT32(1, ssz_at(trailing, 0).bytes.len);
+  TEST_ASSERT_EQUAL_UINT32(0, ssz_at(trailing, 1).bytes.len);
+  check_root(trailing, "0x4451a6c8b543058ab9423502ac72034676d33fbc2954841fcdc07d5b9e6c336b", "invalid root for [b\"\\xab\", b\"\"]");
+
+  // three elements with lengths 0, 3 and 40
+  ssz_ob_t three = ssz_ob(BYTELIST_PROG_LIST,
+                          from_hex("0x0c0000000c0000000f00000001020342424242424242424242424242424242"
+                                   "424242424242424242424242424242424242424242424242",
+                                   raw, sizeof(raw)));
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(three, true, &state), state.error);
+  TEST_ASSERT_EQUAL_UINT32(3, ssz_len(three));
+  TEST_ASSERT_EQUAL_UINT32(0, ssz_at(three, 0).bytes.len);
+  uint8_t  expected_el1[] = {1, 2, 3};
+  ssz_ob_t el1            = ssz_at(three, 1);
+  TEST_ASSERT_EQUAL_UINT32(3, el1.bytes.len);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected_el1, el1.bytes.data, 3);
+  ssz_ob_t el2 = ssz_at(three, 2);
+  TEST_ASSERT_EQUAL_UINT32(40, el2.bytes.len);
+  for (int i = 0; i < 40; i++) TEST_ASSERT_EQUAL_UINT8(0x42, el2.bytes.data[i]);
+  TEST_ASSERT_EQUAL_UINT32(0, ssz_at(three, 3).bytes.len); // out of range
+  check_root(three, "0x0756182e42abfe2c2e07f28a4e8b5c86036aac706ec1c45c30cb200180dce43b", "invalid root for three byte lists");
+
+  // six elements with lengths 0..5 (offset table of 24 bytes)
+  ssz_ob_t six = ssz_ob(BYTELIST_PROG_LIST,
+                        from_hex("0x1800000018000000190000001b0000001e00000022000000010202030303040404040505050505",
+                                 raw, sizeof(raw)));
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(six, true, &state), state.error);
+  TEST_ASSERT_EQUAL_UINT32(6, ssz_len(six));
+  TEST_ASSERT_EQUAL_UINT32(5, ssz_at(six, 5).bytes.len);
+  TEST_ASSERT_EQUAL_UINT8(5, ssz_at(six, 5).bytes.data[0]);
+  check_root(six, "0x181fdcf5d4587082e43ca6e5649a5e9920d794b5f316e5ee84521475e6fede14", "invalid root for six byte lists");
+}
+
+void test_prog_list_dynamic_from_json(void) {
+  json_t json = json_parse("[\"0x\",\"0x010203\","
+                           "\"0x42424242424242424242424242424242424242424242424242424242424242424242424242424242\"]");
+
+  c4_state_t state = {0};
+  ssz_ob_t   ob    = ssz_from_json(json, &BYTELIST_PROG_LIST, &state);
+  TEST_ASSERT_NULL_MESSAGE(state.error, state.error);
+
+  uint8_t raw[128] = {0};
+  bytes_t expected = from_hex("0x0c0000000c0000000f00000001020342424242424242424242424242424242"
+                              "424242424242424242424242424242424242424242424242",
+                              raw, sizeof(raw));
+  TEST_ASSERT_EQUAL_UINT32(expected.len, ob.bytes.len);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expected.data, ob.bytes.data, expected.len, "serialization must match remerkleable");
+  check_root(ob, "0x0756182e42abfe2c2e07f28a4e8b5c86036aac706ec1c45c30cb200180dce43b", "invalid root from json");
+  safe_free(ob.bytes.data);
+}
+
+// hostile / malformed bytes must be rejected by ssz_is_valid
+void test_prog_list_invalid_bytes(void) {
+  uint8_t    raw[16] = {0};
+  c4_state_t state   = {0};
+
+  struct {
+    const char* hex;
+    const char* msg;
+  } vectors[] = {
+      {"0x040000", "offset table shorter than one offset must be invalid"},
+      {"0x05000000aabbccdd", "misaligned first offset must be invalid"},
+      {"0x08000000", "first offset beyond total length must be invalid"},
+      {"0x00000000aabbccdd", "first offset inside the offset table must be invalid"},
+      {"0x0800000005000000aabb", "decreasing offsets must be invalid"},
+  };
+  for (size_t i = 0; i < sizeof(vectors) / sizeof(vectors[0]); i++) {
+    ssz_ob_t ob = ssz_ob(BYTELIST_PROG_LIST, from_hex(vectors[i].hex, raw, sizeof(raw)));
+    TEST_ASSERT_FALSE_MESSAGE(ssz_is_valid(ob, true, &state), vectors[i].msg);
+    c4_state_free(&state);
+    state = (c4_state_t) {0};
+  }
+
+  // fixed-size elements: total length must be a multiple of the element size
+  ssz_ob_t truncated = ssz_ob(UINT64_PROG_LIST, from_hex("0x01000000000000", raw, sizeof(raw)));
+  TEST_ASSERT_FALSE_MESSAGE(ssz_is_valid(truncated, true, &state), "length not a multiple of the element size must be invalid");
+  c4_state_free(&state);
+}
+
+void test_prog_bitlist_invalid_bytes(void) {
+  c4_state_t state = {0};
+
+  // empty bytes: even an empty progressive bit list requires the sentinel byte 0x01
+  ssz_ob_t empty = ssz_ob(PROG_BIT_LIST, bytes(NULL, 0));
+  TEST_ASSERT_FALSE_MESSAGE(ssz_is_valid(empty, true, &state), "empty bytes must be invalid for a progressive bit list");
+  c4_state_free(&state);
+  state = (c4_state_t) {0};
+
+  // last byte zero: the sentinel bit is missing
+  uint8_t  no_sentinel[2] = {0x05, 0x00};
+  ssz_ob_t ob             = ssz_ob(PROG_BIT_LIST, bytes(no_sentinel, sizeof(no_sentinel)));
+  TEST_ASSERT_FALSE_MESSAGE(ssz_is_valid(ob, true, &state), "missing sentinel bit must be invalid");
+  c4_state_free(&state);
+  TEST_ASSERT_EQUAL_UINT32(0, ssz_len(empty)); // ssz_len must not read out of bounds for empty bytes
+}
+
+void test_prog_container_invalid_bytes(void) {
+  uint8_t    raw[128] = {0};
+  bytes_t    data     = from_hex(NESTED_SER_HEX, raw, sizeof(raw));
+  c4_state_t state    = {0};
+
+  // truncated fixed part (fixed length of Nested is 8 + 32 + 4 = 44 bytes)
+  ssz_ob_t truncated = ssz_ob(NESTED_CONTAINER, bytes(data.data, 43));
+  TEST_ASSERT_FALSE_MESSAGE(ssz_is_valid(truncated, true, &state), "truncated progressive container must be invalid");
+  c4_state_free(&state);
+  state = (c4_state_t) {0};
+
+  // offset of the dynamic "values" field pointing beyond the total length
+  uint8_t bad_offset[44];
+  memcpy(bad_offset, data.data, 44);
+  bad_offset[40] = 0xff; // offset = 0xff > 44
+  TEST_ASSERT_FALSE_MESSAGE(ssz_is_valid(ssz_ob(NESTED_CONTAINER, bytes(bad_offset, sizeof(bad_offset))), true, &state), "offset beyond total length must be invalid");
+  c4_state_free(&state);
+  state = (c4_state_t) {0};
+
+  // offset pointing into the fixed part
+  memcpy(bad_offset, data.data, 44);
+  bad_offset[40] = 8; // offset = 8 < 44 (end of fixed part)
+  TEST_ASSERT_FALSE_MESSAGE(ssz_is_valid(ssz_ob(NESTED_CONTAINER, bytes(bad_offset, sizeof(bad_offset))), true, &state), "offset into the fixed part must be invalid");
+  c4_state_free(&state);
+  state = (c4_state_t) {0};
+
+  // fully fixed progressive container (Square, 3 bytes): wrong lengths must be rejected
+  uint8_t square_data[4] = {0x42, 0x00, 0x01, 0x00};
+  TEST_ASSERT_FALSE_MESSAGE(ssz_is_valid(ssz_ob(SQUARE_CONTAINER, bytes(square_data, 2)), true, &state), "too short fixed progressive container must be invalid");
+  c4_state_free(&state);
+  state = (c4_state_t) {0};
+  TEST_ASSERT_FALSE_MESSAGE(ssz_is_valid(ssz_ob(SQUARE_CONTAINER, bytes(square_data, 4)), true, &state), "too long fixed progressive container must be invalid");
+  c4_state_free(&state);
+}
+
+// JSON dump of a progressive container must skip inactive SSZ_NONE slots
+void test_prog_container_dump(void) {
+  uint8_t  raw[128] = {0};
+  bytes_t  data     = from_hex(NESTED_SER_HEX, raw, sizeof(raw));
+  ssz_ob_t ob       = ssz_ob(NESTED_CONTAINER, data);
+
+  char* json_str = ssz_dump_to_str(ob, false, false);
+  TEST_ASSERT_NOT_NULL(json_str);
+  TEST_ASSERT_NULL_MESSAGE(strstr(json_str, "NONE"), "inactive slots must not appear in the JSON dump");
+  TEST_ASSERT_NOT_NULL_MESSAGE(strstr(json_str, "\"slot\""), "active field slot missing in dump");
+  TEST_ASSERT_NOT_NULL_MESSAGE(strstr(json_str, "\"root\""), "active field root missing in dump");
+  TEST_ASSERT_NOT_NULL_MESSAGE(strstr(json_str, "\"values\""), "active field values missing in dump");
+
+  // the dump must be valid JSON with the expected values
+  json_t parsed = json_parse(json_str);
+  TEST_ASSERT_EQUAL_INT_MESSAGE(JSON_TYPE_OBJECT, parsed.type, "dump must be a valid JSON object");
+  TEST_ASSERT_EQUAL_UINT64(12345, json_get_uint64(parsed, "slot"));
+  TEST_ASSERT_EQUAL_INT(JSON_TYPE_ARRAY, json_get(parsed, "values").type);
+  safe_free(json_str);
+}
+
+// single and multi proofs for chunks in a higher progressive subtree
+// (chunk 5 is the first chunk of the 16-leaf subtree after the 1+4 chunks)
+void test_prog_proof_subtree_boundary(void) {
+  // ProgressiveList[Bytes32] with 6 elements (chunk i holds first byte i+1)
+  buffer_t buf = {0};
+  for (uint32_t n = 0; n < 6; n++) {
+    uint8_t chunk[32] = {0};
+    chunk[0]          = (uint8_t) (n + 1);
+    buffer_append(&buf, bytes(chunk, 32));
+  }
+  ssz_ob_t ob = ssz_ob(BYTES32_PROG_LIST, buf.data);
+
+  bytes32_t expected_root = {0};
+  ssz_hash_tree_root(ob, expected_root);
+
+  // single proof for element 5 (gindex 352, crossing the 4->16 subtree boundary)
+  gindex_t  gindex = ssz_gindex(&BYTES32_PROG_LIST, 1, 5);
+  bytes32_t root_hash, leaf = {0}, proof_root = {0};
+  TEST_ASSERT_EQUAL_UINT64(352, gindex);
+  bytes_t proof = ssz_create_proof(ob, root_hash, gindex);
+  leaf[0]       = 6;
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expected_root, root_hash, 32, "root of proof creation must match hash_tree_root");
+  ssz_verify_single_merkle_proof(proof, leaf, gindex, proof_root);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expected_root, proof_root, 32, "verified single proof for chunk 5 must match the root");
+  safe_free(proof.data);
+
+  // multi proof spanning both subtrees: element 0 (gindex 4), element 4 (gindex 43) and element 5 (gindex 352)
+  gindex_t gindexes[]  = {4, 43, 352};
+  bytes_t  multi_proof = ssz_create_multi_proof(ob, root_hash, 3, gindexes[0], gindexes[1], gindexes[2]);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expected_root, root_hash, 32, "root of multi proof creation must match hash_tree_root");
+
+  uint8_t leafes[96] = {0};
+  leafes[0]          = 1; // element 0
+  leafes[32]         = 5; // element 4
+  leafes[64]         = 6; // element 5
+  memset(proof_root, 0, 32);
+  TEST_ASSERT_TRUE_MESSAGE(ssz_verify_multi_merkle_proof(multi_proof, bytes(leafes, sizeof(leafes)), gindexes, proof_root), "multi proof verification failed");
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expected_root, proof_root, 32, "verified multi proof across subtrees must match the root");
+  safe_free(multi_proof.data);
+  buffer_free(&buf);
+}
+
+// proof for a dynamic element of a progressive list: the leaf is the
+// hash_tree_root of the element (from remerkleable)
+void test_prog_proof_dynamic_element(void) {
+  uint8_t  raw[128] = {0};
+  ssz_ob_t ob       = ssz_ob(BYTELIST_PROG_LIST,
+                             from_hex("0x0c0000000c0000000f00000001020342424242424242424242424242424242"
+                                      "424242424242424242424242424242424242424242424242",
+                                      raw, sizeof(raw)));
+
+  bytes32_t expected_root = {0};
+  ssz_hash_tree_root(ob, expected_root);
+
+  gindex_t gindex = ssz_gindex(&BYTELIST_PROG_LIST, 1, 2);
+  TEST_ASSERT_EQUAL_UINT64(41, gindex);
+
+  bytes32_t root_hash, leaf = {0}, proof_root = {0};
+  bytes_t   proof = ssz_create_proof(ob, root_hash, gindex);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expected_root, root_hash, 32, "root of proof creation must match hash_tree_root");
+
+  // leaf = hash_tree_root of the ByteList[64] element (incl. its own length mix-in)
+  uint8_t leaf_raw[32] = {0};
+  memcpy(leaf, from_hex("0x00adc194d6762a8691a5f37e44f3a2bd6ed7a66b5fb9d096f8fa23d6694f667e", leaf_raw, sizeof(leaf_raw)).data, 32);
+  ssz_verify_single_merkle_proof(proof, leaf, gindex, proof_root);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expected_root, proof_root, 32, "verified proof for a dynamic element must match the root");
+  safe_free(proof.data);
+}
+
+void test_prog_container_invalid_defs(void) {
+  // active_fields must not end in 0 -> last element must not be SSZ_NONE
+  static const ssz_def_t TRAILING_NONE[] = {
+      SSZ_UINT64("value"),
+      SSZ_NONE,
+  };
+  static const ssz_def_t TRAILING_NONE_CONTAINER = SSZ_PROG_CONTAINER("TrailingNone", TRAILING_NONE);
+
+  uint8_t    data[8] = {0};
+  c4_state_t state   = {0};
+  TEST_ASSERT_FALSE_MESSAGE(ssz_is_valid(ssz_ob(TRAILING_NONE_CONTAINER, bytes(data, sizeof(data))), false, &state), "trailing SSZ_NONE must be invalid");
+  c4_state_free(&state);
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_prog_list_uint64_roots);
+  RUN_TEST(test_prog_list_bytes32_roots);
+  RUN_TEST(test_prog_bitlist_roots);
+  RUN_TEST(test_prog_container_eip7495_examples);
+  RUN_TEST(test_prog_container_nested);
+  RUN_TEST(test_prog_container_from_json);
+  RUN_TEST(test_prog_gindex);
+  RUN_TEST(test_prog_proof_roundtrip);
+  RUN_TEST(test_prog_container_invalid_defs);
+  RUN_TEST(test_prog_list_dynamic_elements);
+  RUN_TEST(test_prog_list_dynamic_from_json);
+  RUN_TEST(test_prog_list_invalid_bytes);
+  RUN_TEST(test_prog_bitlist_invalid_bytes);
+  RUN_TEST(test_prog_container_invalid_bytes);
+  RUN_TEST(test_prog_container_dump);
+  RUN_TEST(test_prog_proof_subtree_boundary);
+  RUN_TEST(test_prog_proof_dynamic_element);
+  return UNITY_END();
+}

--- a/test/unittests/test_ssz_progressive.c
+++ b/test/unittests/test_ssz_progressive.c
@@ -855,6 +855,42 @@ void test_prog_container_mask_edge_cases(void) {
              "invalid root for 64-field prog container with only f63 active");
 }
 
+// ---------- Serialization semantics: inactive positions carry no bytes ----------
+
+// EIP-7495: "Serialization is identical to Container" refers to the container
+// formed by the ACTIVE fields only. In remerkleable a ProgressiveContainer only
+// declares its active fields (popcount(active_fields) must equal the field
+// count), so the fixed/dynamic decision and the offset table depend exclusively
+// on active fields. A dynamic type at an inactive base position (e.g. a field
+// used by a different container version) must neither add bytes nor turn the
+// container into a variable-size one; the merkle gap it leaves is a plain zero
+// chunk, independent of the field's type.
+static const ssz_def_t DYN_SHAPE_FIELDS[] = {
+    SSZ_UINT16("side"),     // position 0 (active)
+    SSZ_BYTES("extra", 64), // position 1 (inactive here, dynamic in another version)
+    SSZ_UINT8("color"),     // position 2 (active)
+};
+static const ssz_def_t DYN_SHAPE_BASE = SSZ_CONTAINER("DynShapeBase", DYN_SHAPE_FIELDS);
+static const ssz_def_t DYN_SHAPE_PROG = SSZ_PROG_CONTAINER("DynShape", DYN_SHAPE_BASE, 0b101);
+
+void test_prog_container_inactive_dynamic_field(void) {
+  TEST_ASSERT_FALSE_MESSAGE(ssz_is_dynamic(&DYN_SHAPE_PROG),
+                            "dynamic type at an inactive position must not make the container dynamic");
+  TEST_ASSERT_EQUAL_size_t_MESSAGE(3, ssz_fixed_length(&DYN_SHAPE_PROG),
+                                   "fixed length must cover active fields only (uint16 + uint8)");
+
+  // same bytes as Square: side=0x42, color=1 - no offset table, no bytes for "extra"
+  uint8_t    data[] = {0x42, 0x00, 0x01};
+  ssz_ob_t   ob     = ssz_ob(DYN_SHAPE_PROG, bytes(data, sizeof(data)));
+  c4_state_t state  = {0};
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(ob, true, &state), state.error);
+
+  // The root equals the remerkleable Square root: the zero-gap at position 1 is
+  // independent of the type the base container declares there.
+  check_root(ob, "0x5d5c127e27e9862d9aacb13609cd9e936514fbe38e97dba278f0a83b553e57a0",
+             "root must match remerkleable Square regardless of the inactive field type");
+}
+
 // ---------- Nested progressive container ----------
 
 // Inner progressive container (identical to SQUARE_CONTAINER shape).
@@ -924,6 +960,7 @@ int main(void) {
   RUN_TEST(test_prog_container_inactive_field_unreachable);
   RUN_TEST(test_prog_container_field_order);
   RUN_TEST(test_prog_container_mask_edge_cases);
+  RUN_TEST(test_prog_container_inactive_dynamic_field);
   RUN_TEST(test_prog_container_nested_prog);
   RUN_TEST(test_prog_list_dynamic_elements);
   RUN_TEST(test_prog_list_dynamic_from_json);

--- a/test/unittests/test_ssz_progressive.c
+++ b/test/unittests/test_ssz_progressive.c
@@ -28,6 +28,7 @@
 #include "bytes.h"
 #include "c4_assert.h"
 #include "json.h"
+#include "logger.h"
 #include "ssz.h"
 #include "state.h"
 #include "unity.h"
@@ -52,32 +53,28 @@ static const ssz_def_t PROG_BIT_LIST = SSZ_PROG_BIT_LIST("bits");
 static const ssz_def_t BYTE_LIST_64       = SSZ_BYTES("data", 64);
 static const ssz_def_t BYTELIST_PROG_LIST = SSZ_PROG_LIST("byte_lists", BYTE_LIST_64);
 
-// EIP-7495 example: class Square(ProgressiveContainer(active_fields=[1, 0, 1]))
-static const ssz_def_t SQUARE[] = {
-    SSZ_UINT16("side"),
-    SSZ_NONE,
-    SSZ_UINT8("color"),
+// EIP-7495 example: Shape base container with all fields at their canonical positions
+// (Square uses active_fields=[1, 0, 1], Circle uses [0, 1, 1] over the same base)
+static const ssz_def_t SHAPE_FIELDS[] = {
+    SSZ_UINT16("side"),   // field position 0
+    SSZ_UINT16("radius"), // field position 1
+    SSZ_UINT8("color"),   // field position 2
 };
-static const ssz_def_t SQUARE_CONTAINER = SSZ_PROG_CONTAINER("Square", SQUARE);
-
-// EIP-7495 example: class Circle(ProgressiveContainer(active_fields=[0, 1, 1]))
-static const ssz_def_t CIRCLE[] = {
-    SSZ_NONE,
-    SSZ_UINT16("radius"),
-    SSZ_UINT8("color"),
-};
-static const ssz_def_t CIRCLE_CONTAINER = SSZ_PROG_CONTAINER("Circle", CIRCLE);
+static const ssz_def_t SHAPE_CONTAINER  = SSZ_CONTAINER("Shape", SHAPE_FIELDS);
+static const ssz_def_t SQUARE_CONTAINER = SSZ_PROG_CONTAINER("Square", SHAPE_CONTAINER, 0b101);
+static const ssz_def_t CIRCLE_CONTAINER = SSZ_PROG_CONTAINER("Circle", SHAPE_CONTAINER, 0b110);
 
 // class Nested(ProgressiveContainer(active_fields=[1, 1, 0, 0, 1])):
 //   slot: uint64, root: Bytes32, values: ProgressiveList[uint64]
-static const ssz_def_t NESTED[] = {
-    SSZ_UINT64("slot"),
-    SSZ_BYTES32("root"),
-    SSZ_NONE,
-    SSZ_NONE,
-    SSZ_PROG_LIST("values", ssz_uint64_def),
+static const ssz_def_t NESTED_FIELDS[] = {
+    SSZ_UINT64("slot"),                     // field position 0
+    SSZ_BYTES32("root"),                    // field position 1
+    SSZ_UINT8("reserved_1"),                // field position 2 (inactive in Nested)
+    SSZ_UINT8("reserved_2"),                // field position 3 (inactive in Nested)
+    SSZ_PROG_LIST("values", ssz_uint64_def) // field position 4
 };
-static const ssz_def_t NESTED_CONTAINER = SSZ_PROG_CONTAINER("Nested", NESTED);
+static const ssz_def_t NESTED_BASE_CONTAINER = SSZ_CONTAINER("NestedBase", NESTED_FIELDS);
+static const ssz_def_t NESTED_CONTAINER      = SSZ_PROG_CONTAINER("Nested", NESTED_BASE_CONTAINER, 0b10011);
 
 // serialization of Nested(slot=12345, root=0x11*32, values=[1..7]) created with remerkleable
 static const char* NESTED_SER_HEX = "0x39300000000000001111111111111111111111111111111111111111111111111111111111111111"
@@ -248,7 +245,7 @@ void test_prog_gindex(void) {
   for (size_t i = 0; i < sizeof(vectors) / sizeof(vectors[0]); i++)
     TEST_ASSERT_EQUAL_UINT64(vectors[i].gindex, ssz_gindex(&BYTES32_PROG_LIST, 1, vectors[i].idx));
 
-  // field gindices of a progressive container (chunk index == field position incl. SSZ_NONE slots)
+  // field gindices of a progressive container (chunk index == base-container field position)
   TEST_ASSERT_EQUAL_UINT64(4, ssz_gindex(&NESTED_CONTAINER, 1, "slot"));    // chunk 0
   TEST_ASSERT_EQUAL_UINT64(40, ssz_gindex(&NESTED_CONTAINER, 1, "root"));   // chunk 1
   TEST_ASSERT_EQUAL_UINT64(43, ssz_gindex(&NESTED_CONTAINER, 1, "values")); // chunk 4
@@ -256,9 +253,10 @@ void test_prog_gindex(void) {
   // combined path into the nested progressive list (values[0..3] are packed in chunk 0)
   TEST_ASSERT_EQUAL_UINT64(172, ssz_gindex(&NESTED_CONTAINER, 2, "values", 0));
 
-  // unknown fields and inactive slots must not resolve
+  // unknown fields and inactive positions must not resolve
   TEST_ASSERT_EQUAL_UINT64(0, ssz_gindex(&NESTED_CONTAINER, 1, "unknown"));
-  TEST_ASSERT_EQUAL_UINT64(0, ssz_gindex(&NESTED_CONTAINER, 1, "NONE"));
+  TEST_ASSERT_EQUAL_UINT64(0, ssz_gindex(&NESTED_CONTAINER, 1, "reserved_1"));
+  TEST_ASSERT_EQUAL_UINT64(0, ssz_gindex(&NESTED_CONTAINER, 1, "reserved_2"));
 }
 
 void test_prog_proof_roundtrip(void) {
@@ -455,7 +453,7 @@ void test_prog_container_invalid_bytes(void) {
   c4_state_free(&state);
 }
 
-// JSON dump of a progressive container must skip inactive SSZ_NONE slots
+// JSON dump of a progressive container must skip inactive positions
 void test_prog_container_dump(void) {
   uint8_t  raw[128] = {0};
   bytes_t  data     = from_hex(NESTED_SER_HEX, raw, sizeof(raw));
@@ -463,7 +461,8 @@ void test_prog_container_dump(void) {
 
   char* json_str = ssz_dump_to_str(ob, false, false);
   TEST_ASSERT_NOT_NULL(json_str);
-  TEST_ASSERT_NULL_MESSAGE(strstr(json_str, "NONE"), "inactive slots must not appear in the JSON dump");
+  TEST_ASSERT_NULL_MESSAGE(strstr(json_str, "reserved_1"), "inactive positions must not appear in the JSON dump");
+  TEST_ASSERT_NULL_MESSAGE(strstr(json_str, "reserved_2"), "inactive positions must not appear in the JSON dump");
   TEST_ASSERT_NOT_NULL_MESSAGE(strstr(json_str, "\"slot\""), "active field slot missing in dump");
   TEST_ASSERT_NOT_NULL_MESSAGE(strstr(json_str, "\"root\""), "active field root missing in dump");
   TEST_ASSERT_NOT_NULL_MESSAGE(strstr(json_str, "\"values\""), "active field values missing in dump");
@@ -546,17 +545,365 @@ void test_prog_proof_dynamic_element(void) {
 }
 
 void test_prog_container_invalid_defs(void) {
-  // active_fields must not end in 0 -> last element must not be SSZ_NONE
-  static const ssz_def_t TRAILING_NONE[] = {
+  // active_fields must not end in 0 -> highest set bit must be < base_len
+  static const ssz_def_t SINGLE_FIELD[] = {
       SSZ_UINT64("value"),
-      SSZ_NONE,
   };
-  static const ssz_def_t TRAILING_NONE_CONTAINER = SSZ_PROG_CONTAINER("TrailingNone", TRAILING_NONE);
+  static const ssz_def_t SINGLE_FIELD_CONTAINER    = SSZ_CONTAINER("SingleField", SINGLE_FIELD);
+  static const ssz_def_t TRAILING_ZERO_CONTAINER   = SSZ_PROG_CONTAINER("TrailingZero", SINGLE_FIELD_CONTAINER, 0b10);
+  static const ssz_def_t EMPTY_MASK_CONTAINER      = SSZ_PROG_CONTAINER("EmptyMask", SINGLE_FIELD_CONTAINER, 0);
 
   uint8_t    data[8] = {0};
   c4_state_t state   = {0};
-  TEST_ASSERT_FALSE_MESSAGE(ssz_is_valid(ssz_ob(TRAILING_NONE_CONTAINER, bytes(data, sizeof(data))), false, &state), "trailing SSZ_NONE must be invalid");
+  TEST_ASSERT_FALSE_MESSAGE(ssz_is_valid(ssz_ob(TRAILING_ZERO_CONTAINER, bytes(data, sizeof(data))), false, &state), "bit outside base_len must be invalid");
   c4_state_free(&state);
+  state = (c4_state_t) {0};
+  TEST_ASSERT_FALSE_MESSAGE(ssz_is_valid(ssz_ob(EMPTY_MASK_CONTAINER, bytes(data, sizeof(data))), false, &state), "empty active_fields mask must be invalid");
+  c4_state_free(&state);
+}
+
+// Two variants of the same base container are only equal when their active_fields match
+void test_prog_container_is_type(void) {
+  static const ssz_def_t SHAPE_A = SSZ_PROG_CONTAINER("A", SHAPE_CONTAINER, 0b101);
+  static const ssz_def_t SHAPE_B = SSZ_PROG_CONTAINER("B", SHAPE_CONTAINER, 0b110);
+
+  // Square uses the same base and mask as SHAPE_A, so they must compare equal
+  uint8_t  square_data[3] = {0x2a, 0x00, 0x07}; // side=42, color=7
+  ssz_ob_t sq             = ssz_ob(SHAPE_A, bytes(square_data, sizeof(square_data)));
+  TEST_ASSERT_TRUE(ssz_is_type(&sq, &SQUARE_CONTAINER));
+
+  // Different mask -> different type, even with the same base container
+  TEST_ASSERT_FALSE(ssz_is_type(&sq, &SHAPE_B));
+  TEST_ASSERT_FALSE(ssz_is_type(&sq, &CIRCLE_CONTAINER));
+}
+
+// Direct unit tests for the new public helpers ssz_container_elements,
+// ssz_container_len, ssz_field_active and ssz_active_fields
+void test_prog_container_helpers(void) {
+  // Regular container: helpers must reflect the raw definition
+  TEST_ASSERT_EQUAL_PTR(SHAPE_FIELDS, ssz_container_elements(&SHAPE_CONTAINER));
+  TEST_ASSERT_EQUAL_UINT32(3, ssz_container_len(&SHAPE_CONTAINER));
+  TEST_ASSERT_TRUE(ssz_field_active(&SHAPE_CONTAINER, 0));
+  TEST_ASSERT_TRUE(ssz_field_active(&SHAPE_CONTAINER, 1));
+  TEST_ASSERT_TRUE(ssz_field_active(&SHAPE_CONTAINER, 2));
+  TEST_ASSERT_TRUE_MESSAGE(ssz_field_active(&SHAPE_CONTAINER, 63), "regular containers report all positions active");
+  TEST_ASSERT_EQUAL_UINT64_MESSAGE(0, ssz_active_fields(&SHAPE_CONTAINER), "regular containers have no active_fields mask");
+
+  // Progressive container SQUARE (mask 0b101): resolves to base fields
+  TEST_ASSERT_EQUAL_PTR(SHAPE_FIELDS, ssz_container_elements(&SQUARE_CONTAINER));
+  TEST_ASSERT_EQUAL_UINT32(3, ssz_container_len(&SQUARE_CONTAINER));
+  TEST_ASSERT_EQUAL_UINT64(0x5ULL, ssz_active_fields(&SQUARE_CONTAINER));
+  TEST_ASSERT_TRUE(ssz_field_active(&SQUARE_CONTAINER, 0));
+  TEST_ASSERT_FALSE(ssz_field_active(&SQUARE_CONTAINER, 1));
+  TEST_ASSERT_TRUE(ssz_field_active(&SQUARE_CONTAINER, 2));
+  // Positions beyond the mask must not report as active and must not overflow the uint64 shift
+  TEST_ASSERT_FALSE(ssz_field_active(&SQUARE_CONTAINER, 3));
+  TEST_ASSERT_FALSE(ssz_field_active(&SQUARE_CONTAINER, 63));
+  TEST_ASSERT_FALSE_MESSAGE(ssz_field_active(&SQUARE_CONTAINER, 64), "field_active must guard against 64-bit shift overflow");
+  TEST_ASSERT_FALSE(ssz_field_active(&SQUARE_CONTAINER, 1000));
+
+  // Different mask over the same base
+  TEST_ASSERT_EQUAL_PTR(SHAPE_FIELDS, ssz_container_elements(&CIRCLE_CONTAINER));
+  TEST_ASSERT_EQUAL_UINT64(0x6ULL, ssz_active_fields(&CIRCLE_CONTAINER));
+  TEST_ASSERT_FALSE(ssz_field_active(&CIRCLE_CONTAINER, 0));
+  TEST_ASSERT_TRUE(ssz_field_active(&CIRCLE_CONTAINER, 1));
+  TEST_ASSERT_TRUE(ssz_field_active(&CIRCLE_CONTAINER, 2));
+
+  // Confirm the base container is really referenced (not copied) so that any change
+  // to the base propagates to every variant that shares it.
+  TEST_ASSERT_EQUAL_PTR(&SHAPE_CONTAINER, SQUARE_CONTAINER.def.progressive_container.container);
+  TEST_ASSERT_EQUAL_PTR(&SHAPE_CONTAINER, CIRCLE_CONTAINER.def.progressive_container.container);
+}
+
+// Regression: two variants that share the exact same base container must produce
+// different hash tree roots when their active_fields differ, even if the serialized
+// bytes happen to be identical.
+void test_prog_container_base_sharing_regression(void) {
+  // Both Square and Circle keep only two of the three positions active, both fields
+  // have the same total fixed length (uint16 + uint8 = 3 bytes), so serialized bytes
+  // are identical for the values [0x42, 0x00, 0x01].
+  uint8_t  raw[3] = {0x42, 0x00, 0x01};
+  ssz_ob_t sq     = ssz_ob(SQUARE_CONTAINER, bytes(raw, sizeof(raw)));
+  ssz_ob_t ci     = ssz_ob(CIRCLE_CONTAINER, bytes(raw, sizeof(raw)));
+
+  TEST_ASSERT_EQUAL_UINT32(sq.bytes.len, ci.bytes.len);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(sq.bytes.data, ci.bytes.data, sq.bytes.len,
+                                        "shared base container: serialized bytes must be identical");
+
+  // But the merkle roots must differ because active_fields is mixed into the root.
+  bytes32_t sq_root = {0};
+  bytes32_t ci_root = {0};
+  ssz_hash_tree_root(sq, sq_root);
+  ssz_hash_tree_root(ci, ci_root);
+  TEST_ASSERT_FALSE_MESSAGE(memcmp(sq_root, ci_root, 32) == 0,
+                            "different masks over identical bytes must produce different roots");
+
+  // The same byte value maps to a different named field depending on the mask
+  TEST_ASSERT_EQUAL_UINT64(0x42, ssz_get_uint64(&sq, "side"));
+  TEST_ASSERT_EQUAL_UINT64(0x42, ssz_get_uint64(&ci, "radius"));
+
+  // Inactive positions are addressed by base-container field names but must not
+  // be reachable; silence log_error noise from ssz_get() while probing them.
+  log_level_t old_level = c4_get_log_level();
+  c4_set_log_level(LOG_SILENT);
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_error(ssz_get(&sq, "radius")), "radius is inactive in Square");
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_error(ssz_get(&ci, "side")), "side is inactive in Circle");
+  c4_set_log_level(old_level);
+}
+
+// Base container with camelCase field names, used to test JSON name mapping
+static const ssz_def_t CAMEL_FIELDS[] = {
+    SSZ_UINT64("blockNumber"),
+    SSZ_UINT32("gasLimit"),
+};
+static const ssz_def_t CAMEL_BASE_CONTAINER = SSZ_CONTAINER("CamelBase", CAMEL_FIELDS);
+static const ssz_def_t CAMEL_PROG_CONTAINER = SSZ_PROG_CONTAINER("CamelProg", CAMEL_BASE_CONTAINER, 0b11);
+
+// ssz_from_json must map snake_case JSON keys to camelCase DEF field names for
+// progressive containers as well (already covered for regular containers).
+void test_prog_container_camel_case_from_json(void) {
+  uint8_t expected[12] = {0};
+  uint64_to_le(expected, 12345);
+  uint32_to_le(expected + 8, 1000000);
+
+  // 1) snake_case JSON matches camelCase DEF via the built-in conversion
+  json_t     json_snake = json_parse("{\"block_number\": 12345, \"gas_limit\": 1000000}");
+  c4_state_t state      = {0};
+  ssz_ob_t   ob         = ssz_from_json(json_snake, &CAMEL_PROG_CONTAINER, &state);
+  TEST_ASSERT_NULL_MESSAGE(state.error, state.error);
+  TEST_ASSERT_EQUAL_UINT32(sizeof(expected), ob.bytes.len);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expected, ob.bytes.data, sizeof(expected),
+                                        "snake_case JSON must map to camelCase DEF fields");
+  check_root(ob, "0x71c4a192e55369c7d2c11b137106dad2e1d84f1a308a1ffee20c04ede9455a5e",
+             "invalid CamelProg root from snake_case JSON");
+  safe_free(ob.bytes.data);
+
+  // 2) exact camelCase JSON must also be accepted (direct name lookup)
+  json_t     json_camel = json_parse("{\"blockNumber\": 12345, \"gasLimit\": 1000000}");
+  c4_state_t state2     = {0};
+  ssz_ob_t   ob2        = ssz_from_json(json_camel, &CAMEL_PROG_CONTAINER, &state2);
+  TEST_ASSERT_NULL_MESSAGE(state2.error, state2.error);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expected, ob2.bytes.data, sizeof(expected),
+                                        "camelCase JSON must also match the DEF field name directly");
+  safe_free(ob2.bytes.data);
+
+  // 3) ssz_get on a progressive container also resolves camelCase field names
+  ssz_ob_t stored = ssz_ob(CAMEL_PROG_CONTAINER, bytes(expected, sizeof(expected)));
+  TEST_ASSERT_EQUAL_UINT64(12345, ssz_get_uint64(&stored, "blockNumber"));
+  TEST_ASSERT_EQUAL_UINT32(1000000, ssz_get_uint32(&stored, "gasLimit"));
+}
+
+// Inactive positions of a progressive container must not be reachable via any
+// public accessor. Also verifies that unknown field names return an error object.
+void test_prog_container_inactive_field_unreachable(void) {
+  uint8_t  raw[128] = {0};
+  bytes_t  data     = from_hex(NESTED_SER_HEX, raw, sizeof(raw));
+  ssz_ob_t ob       = ssz_ob(NESTED_CONTAINER, data);
+
+  // active fields are reachable and produce non-zero gindices
+  TEST_ASSERT_FALSE(ssz_is_error(ssz_get(&ob, "slot")));
+  TEST_ASSERT_NOT_NULL(ssz_get_def(&NESTED_CONTAINER, "slot"));
+  TEST_ASSERT_NOT_EQUAL(0, ssz_gindex(&NESTED_CONTAINER, 1, "slot"));
+
+  // silence the log_error() spam from ssz_get() for unreachable names
+  log_level_t old_level = c4_get_log_level();
+  c4_set_log_level(LOG_SILENT);
+
+  // inactive positions defined in the base container must be unreachable
+  ssz_ob_t r1 = ssz_get(&ob, "reserved_1");
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_error(r1), "ssz_get on inactive position must return an error object");
+  TEST_ASSERT_NULL_MESSAGE(ssz_get_def(&NESTED_CONTAINER, "reserved_1"), "ssz_get_def must return NULL for inactive position");
+  TEST_ASSERT_EQUAL_UINT64(0, ssz_gindex(&NESTED_CONTAINER, 1, "reserved_1"));
+
+  ssz_ob_t r2 = ssz_get(&ob, "reserved_2");
+  TEST_ASSERT_TRUE(ssz_is_error(r2));
+  TEST_ASSERT_NULL(ssz_get_def(&NESTED_CONTAINER, "reserved_2"));
+  TEST_ASSERT_EQUAL_UINT64(0, ssz_gindex(&NESTED_CONTAINER, 1, "reserved_2"));
+
+  // fully unknown field name behaves the same
+  TEST_ASSERT_TRUE(ssz_is_error(ssz_get(&ob, "does_not_exist")));
+  TEST_ASSERT_NULL(ssz_get_def(&NESTED_CONTAINER, "does_not_exist"));
+
+  c4_set_log_level(old_level);
+}
+
+// Serialization order test: field positions in the base container determine byte order,
+// not the order in which values are provided via JSON.
+void test_prog_container_field_order(void) {
+  // Base SHAPE_CONTAINER positions: side(0), radius(1), color(2)
+  // Square mask 0b101 -> active positions [0, 2] -> serialized as [side, color] = [uint16, uint8] (3 bytes)
+  const uint8_t expected[3] = {0x42, 0x00, 0x01}; // side=0x42, color=0x01
+
+  // JSON with keys in reversed order must still produce the canonical position-order encoding
+  json_t json = json_parse("{\"color\": 1, \"side\": 66}"); // 66 == 0x42
+  c4_state_t state = {0};
+  ssz_ob_t   ob    = ssz_from_json(json, &SQUARE_CONTAINER, &state);
+  TEST_ASSERT_NULL_MESSAGE(state.error, state.error);
+  TEST_ASSERT_EQUAL_UINT32(sizeof(expected), ob.bytes.len);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(expected, ob.bytes.data, sizeof(expected),
+                                        "serialization must follow base-container position order, not JSON key order");
+
+  // The resulting object hashes to the well-known Square root (identical to
+  // test_prog_container_eip7495_examples), confirming the byte layout is canonical.
+  check_root(ob, "0x5d5c127e27e9862d9aacb13609cd9e936514fbe38e97dba278f0a83b553e57a0",
+             "Square root from reversed-key JSON must match canonical root");
+  safe_free(ob.bytes.data);
+}
+
+// ---------- Mask edge-case fixtures ----------
+
+// Single-field base container (base_len=1). Only valid mask per EIP-7495 is 0b1.
+static const ssz_def_t SINGLE_UINT64_FIELDS[] = {
+    SSZ_UINT64("only"),
+};
+static const ssz_def_t SINGLE_UINT64_BASE = SSZ_CONTAINER("SingleUint64Base", SINGLE_UINT64_FIELDS);
+static const ssz_def_t SINGLE_UINT64_PROG = SSZ_PROG_CONTAINER("SingleUint64Prog", SINGLE_UINT64_BASE, 0x1ULL);
+
+// 5-field base container. Variants: only last active (0x10) and all active (0x1F).
+static const ssz_def_t FIVE_UINT64_FIELDS[] = {
+    SSZ_UINT64("a"),
+    SSZ_UINT64("b"),
+    SSZ_UINT64("c"),
+    SSZ_UINT64("d"),
+    SSZ_UINT64("e"),
+};
+static const ssz_def_t FIVE_UINT64_BASE      = SSZ_CONTAINER("FiveUint64Base", FIVE_UINT64_FIELDS);
+static const ssz_def_t FIVE_LAST_ONLY_PROG   = SSZ_PROG_CONTAINER("FiveLast", FIVE_UINT64_BASE, 0x10ULL); // 1 << 4
+static const ssz_def_t FIVE_ALL_ACTIVE_PROG  = SSZ_PROG_CONTAINER("FiveAll", FIVE_UINT64_BASE, 0x1FULL);  // 5 bits set
+
+// 64-field base container: exercises the boundary where mask_bound would wrap.
+static const ssz_def_t BASE64_UINT8_FIELDS[64] = {
+    SSZ_UINT8("f00"), SSZ_UINT8("f01"), SSZ_UINT8("f02"), SSZ_UINT8("f03"),
+    SSZ_UINT8("f04"), SSZ_UINT8("f05"), SSZ_UINT8("f06"), SSZ_UINT8("f07"),
+    SSZ_UINT8("f08"), SSZ_UINT8("f09"), SSZ_UINT8("f10"), SSZ_UINT8("f11"),
+    SSZ_UINT8("f12"), SSZ_UINT8("f13"), SSZ_UINT8("f14"), SSZ_UINT8("f15"),
+    SSZ_UINT8("f16"), SSZ_UINT8("f17"), SSZ_UINT8("f18"), SSZ_UINT8("f19"),
+    SSZ_UINT8("f20"), SSZ_UINT8("f21"), SSZ_UINT8("f22"), SSZ_UINT8("f23"),
+    SSZ_UINT8("f24"), SSZ_UINT8("f25"), SSZ_UINT8("f26"), SSZ_UINT8("f27"),
+    SSZ_UINT8("f28"), SSZ_UINT8("f29"), SSZ_UINT8("f30"), SSZ_UINT8("f31"),
+    SSZ_UINT8("f32"), SSZ_UINT8("f33"), SSZ_UINT8("f34"), SSZ_UINT8("f35"),
+    SSZ_UINT8("f36"), SSZ_UINT8("f37"), SSZ_UINT8("f38"), SSZ_UINT8("f39"),
+    SSZ_UINT8("f40"), SSZ_UINT8("f41"), SSZ_UINT8("f42"), SSZ_UINT8("f43"),
+    SSZ_UINT8("f44"), SSZ_UINT8("f45"), SSZ_UINT8("f46"), SSZ_UINT8("f47"),
+    SSZ_UINT8("f48"), SSZ_UINT8("f49"), SSZ_UINT8("f50"), SSZ_UINT8("f51"),
+    SSZ_UINT8("f52"), SSZ_UINT8("f53"), SSZ_UINT8("f54"), SSZ_UINT8("f55"),
+    SSZ_UINT8("f56"), SSZ_UINT8("f57"), SSZ_UINT8("f58"), SSZ_UINT8("f59"),
+    SSZ_UINT8("f60"), SSZ_UINT8("f61"), SSZ_UINT8("f62"), SSZ_UINT8("f63"),
+};
+static const ssz_def_t BASE64_UINT8_BASE          = SSZ_CONTAINER("Base64", BASE64_UINT8_FIELDS);
+static const ssz_def_t BASE64_ALL_ACTIVE_PROG     = SSZ_PROG_CONTAINER("Base64All", BASE64_UINT8_BASE, 0xFFFFFFFFFFFFFFFFULL);
+static const ssz_def_t BASE64_LAST_ONLY_PROG      = SSZ_PROG_CONTAINER("Base64Last", BASE64_UINT8_BASE, 0x8000000000000000ULL); // 1 << 63
+
+// Verifies the mask edge cases: only first, only last, all active, base_len=64.
+// Expected roots were produced with remerkleable.
+void test_prog_container_mask_edge_cases(void) {
+  c4_state_t state = {0};
+
+  // 1) base_len=1, mask=0b1 (only valid mask for a single-field base)
+  uint8_t single_data[8] = {0};
+  uint64_to_le(single_data, 0xdead);
+  ssz_ob_t single_ob = ssz_ob(SINGLE_UINT64_PROG, bytes(single_data, sizeof(single_data)));
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(single_ob, true, &state), state.error);
+  TEST_ASSERT_EQUAL_UINT64(0xdead, ssz_get_uint64(&single_ob, "only"));
+  check_root(single_ob, "0x0af7681c73c2c78bda41c2e0f3e7535fe3057cbeae454c948f86e84353e4292f",
+             "invalid root for single-field prog container (mask=1)");
+
+  // 2) base_len=5, mask=1<<4 (only the last position active)
+  //    serialization is just the uint64 value of "e"
+  uint8_t last_data[8] = {0};
+  uint64_to_le(last_data, 0xbeef);
+  ssz_ob_t last_ob = ssz_ob(FIVE_LAST_ONLY_PROG, bytes(last_data, sizeof(last_data)));
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(last_ob, true, &state), state.error);
+  TEST_ASSERT_EQUAL_UINT64(0xbeef, ssz_get_uint64(&last_ob, "e"));
+  // Inactive positions (0..3) are unreachable via ssz_get
+  log_level_t old_level = c4_get_log_level();
+  c4_set_log_level(LOG_SILENT);
+  TEST_ASSERT_TRUE(ssz_is_error(ssz_get(&last_ob, "a")));
+  TEST_ASSERT_TRUE(ssz_is_error(ssz_get(&last_ob, "b")));
+  TEST_ASSERT_TRUE(ssz_is_error(ssz_get(&last_ob, "c")));
+  TEST_ASSERT_TRUE(ssz_is_error(ssz_get(&last_ob, "d")));
+  c4_set_log_level(old_level);
+  check_root(last_ob, "0x922f69e3c97ba64d887c42b8bd28f38ac568c49408903e88a539fdcc24d85669",
+             "invalid root for 5-field prog container with only last position active");
+
+  // 3) base_len=5, mask=0x1F (all 5 positions active)
+  uint8_t all5_data[40] = {0};
+  for (uint32_t i = 0; i < 5; i++) uint64_to_le(all5_data + i * 8, (uint64_t) (i + 1));
+  ssz_ob_t all5_ob = ssz_ob(FIVE_ALL_ACTIVE_PROG, bytes(all5_data, sizeof(all5_data)));
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(all5_ob, true, &state), state.error);
+  TEST_ASSERT_EQUAL_UINT64(1, ssz_get_uint64(&all5_ob, "a"));
+  TEST_ASSERT_EQUAL_UINT64(5, ssz_get_uint64(&all5_ob, "e"));
+  check_root(all5_ob, "0x5a167eafdb77037933df6b87009c5d116ef0b6e6800d37b2e70693875b64318d",
+             "invalid root for 5-field prog container with all positions active");
+
+  // 4) base_len=64, mask=all 64 bits set - stresses the special-case branch
+  //    in ssz_is_valid where the bound check is skipped.
+  uint8_t base64_data[64] = {0};
+  for (uint32_t i = 0; i < 64; i++) base64_data[i] = (uint8_t) i;
+  ssz_ob_t base64_all_ob = ssz_ob(BASE64_ALL_ACTIVE_PROG, bytes(base64_data, sizeof(base64_data)));
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(base64_all_ob, true, &state), state.error);
+  TEST_ASSERT_EQUAL_UINT32(63, ssz_uint32(ssz_get(&base64_all_ob, "f63")));
+  check_root(base64_all_ob, "0x4b042d887794442c1af2513e6eef8418f17fd4b1f3fe06904e8a5a48ed486bc6",
+             "invalid root for 64-field prog container with all bits set");
+
+  // 5) base_len=64, mask=1<<63 (only the very last position active)
+  uint8_t base64_last_byte[1] = {0xcd};
+  ssz_ob_t base64_last_ob     = ssz_ob(BASE64_LAST_ONLY_PROG, bytes(base64_last_byte, sizeof(base64_last_byte)));
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(base64_last_ob, true, &state), state.error);
+  TEST_ASSERT_EQUAL_UINT32(0xcd, ssz_uint32(ssz_get(&base64_last_ob, "f63")));
+  check_root(base64_last_ob, "0x0fe6af3b3a37b46aa0ff135554dadc84a5f789db81834572d951f109069cbf85",
+             "invalid root for 64-field prog container with only f63 active");
+}
+
+// ---------- Nested progressive container ----------
+
+// Inner progressive container (identical to SQUARE_CONTAINER shape).
+static const ssz_def_t NESTED_INNER_FIELDS[] = {
+    SSZ_UINT16("side"),
+    SSZ_UINT16("radius"),
+    SSZ_UINT8("color"),
+};
+static const ssz_def_t NESTED_INNER_BASE = SSZ_CONTAINER("InnerBase", NESTED_INNER_FIELDS);
+static const ssz_def_t NESTED_INNER_PROG = SSZ_PROG_CONTAINER("Inner", NESTED_INNER_BASE, 0b101);
+
+// Outer container has 2 positions, both active. Position 1 is itself a prog container.
+static const ssz_def_t NESTED_OUTER_FIELDS[] = {
+    SSZ_UINT64("tag"),
+    {.name = "shape", .type = SSZ_TYPE_PROG_CONTAINER,
+     .def.progressive_container = {.container = &NESTED_INNER_BASE, .active_fields = 0x5ULL}},
+};
+static const ssz_def_t NESTED_OUTER_BASE = SSZ_CONTAINER("OuterBase", NESTED_OUTER_FIELDS);
+static const ssz_def_t NESTED_OUTER_PROG = SSZ_PROG_CONTAINER("Outer", NESTED_OUTER_BASE, 0b11);
+
+// A progressive container nested inside another progressive container must
+// merkleize correctly through both mix-ins. Expected root generated with remerkleable.
+void test_prog_container_nested_prog(void) {
+  // Outer(tag=0xaabbccdd, shape=Inner(side=0x1234, color=0x77))
+  // Serialization: tag (8 bytes, LE) + inner (3 bytes: side=uint16 LE, color=uint8)
+  uint8_t data[11] = {0};
+  uint64_to_le(data, 0xaabbccddULL);
+  data[8]  = 0x34; // side lo
+  data[9]  = 0x12; // side hi
+  data[10] = 0x77; // color
+
+  c4_state_t state = {0};
+  ssz_ob_t   ob    = ssz_ob(NESTED_OUTER_PROG, bytes(data, sizeof(data)));
+  TEST_ASSERT_TRUE_MESSAGE(ssz_is_valid(ob, true, &state), state.error);
+
+  TEST_ASSERT_EQUAL_UINT64(0xaabbccddULL, ssz_get_uint64(&ob, "tag"));
+
+  ssz_ob_t shape = ssz_get(&ob, "shape");
+  TEST_ASSERT_FALSE(ssz_is_error(shape));
+  TEST_ASSERT_EQUAL_INT(SSZ_TYPE_PROG_CONTAINER, shape.def->type);
+  TEST_ASSERT_EQUAL_UINT64(0x5ULL, ssz_active_fields(shape.def));
+  TEST_ASSERT_EQUAL_UINT32(0x1234, ssz_uint32(ssz_get(&shape, "side")));
+  TEST_ASSERT_EQUAL_UINT32(0x77, ssz_uint32(ssz_get(&shape, "color")));
+
+  // Reference root from remerkleable for the same nested value
+  check_root(shape, "0x018504225a478a26465b81b335fe94f2a725642a717d4c109c5f9bb43d5382f5",
+             "invalid inner prog container root");
+  check_root(ob, "0x37e9c1d8796717fa296eb3541104f3cfc14c1c827411255db7c54395f11846b7",
+             "invalid outer prog container root with nested prog container");
 }
 
 int main(void) {
@@ -570,6 +917,14 @@ int main(void) {
   RUN_TEST(test_prog_gindex);
   RUN_TEST(test_prog_proof_roundtrip);
   RUN_TEST(test_prog_container_invalid_defs);
+  RUN_TEST(test_prog_container_is_type);
+  RUN_TEST(test_prog_container_helpers);
+  RUN_TEST(test_prog_container_base_sharing_regression);
+  RUN_TEST(test_prog_container_camel_case_from_json);
+  RUN_TEST(test_prog_container_inactive_field_unreachable);
+  RUN_TEST(test_prog_container_field_order);
+  RUN_TEST(test_prog_container_mask_edge_cases);
+  RUN_TEST(test_prog_container_nested_prog);
   RUN_TEST(test_prog_list_dynamic_elements);
   RUN_TEST(test_prog_list_dynamic_from_json);
   RUN_TEST(test_prog_list_invalid_bytes);


### PR DESCRIPTION
## Summary

- Adds three new SSZ types to the core library: `SSZ_PROG_CONTAINER` (EIP-7495) with `active_fields` mix-in and `SSZ_NONE` placeholders for inactive field positions, plus the capacity-less `SSZ_PROG_LIST` / `SSZ_PROG_BIT_LIST` (EIP-7916) with progressive merkleization (recursive subtrees of 1, 4, 16, ... leaves) and length mix-in.
- Extends serialization, validation, JSON conversion (`ssz_from_json` / dump), merkleization with proof-witness recording, and `ssz_gindex` with the progressive chunk-to-gindex formula; `ssz_add_gindex` is now 64-bit safe with an overflow guard.
- Hardening from the review round: size cap for progressive bitlists (prevents 32-bit bit-length overflow and hash collisions), 64-bit chunk index arithmetic in `set_leaf`, mix-in witnesses are no longer dropped when they are the only witness, and offset validation no longer rejects valid lists whose last dynamic element is empty (pre-existing bug).
- New test suite `test_ssz_progressive.c` with 17 tests: reference roots and serializations generated with remerkleable, gindex edge cases, single/multi proof roundtrips across subtree boundaries, dynamic elements, hostile-input validation.

Migration of existing structures to the new types is intentionally out of scope for this PR.

## Test plan

- [x] `ctest --test-dir build/default`: 54/54 passed
- [x] `test_ssz_progressive`: 17/17 passed (reference vectors from remerkleable)
- [x] Separate build with `PRECOMPILE_ZERO_HASHES=ON` passed
- [x] Reviewed by security, QA and code-review agents; all HIGH/MEDIUM findings addressed