### PR TITLE
feat(eth): Phase 1 request validation

### DIFF
--- a/bindings/emscripten/test/rpc_suite.mjs
+++ b/bindings/emscripten/test/rpc_suite.mjs
@@ -3,11 +3,86 @@
 
 import assert from 'node:assert';
 import * as fs from 'node:fs';
+import { inspect } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 export const testdir = join(__dirname, '../../../test/data');
+
+// node:assert inspects AssertionError.actual/expected with depth 2, so nested
+// RPC fields collapse to `[Object]`. Compare ourselves and report only the
+// differing paths, with color, and without attaching the full trees.
+const MISSING = Symbol('missing');
+const useColor = !process.env.NO_COLOR && process.env.FORCE_COLOR !== '0';
+const paint = (code, text) => useColor ? `\x1b[${code}m${text}\x1b[0m` : text;
+
+function inspectVal(value) {
+    if (value === MISSING) return paint('2', '(missing)');
+    return inspect(value, {
+        depth: Infinity,
+        colors: useColor,
+        compact: true,
+        breakLength: 100,
+        maxStringLength: 200,
+        maxArrayLength: 20,
+    });
+}
+
+function isPlainObject(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value) && !ArrayBuffer.isView(value);
+}
+
+function collectDiffs(actual, expected, path, diffs) {
+    if (Object.is(actual, expected)) return;
+
+    if (isPlainObject(actual) && isPlainObject(expected)) {
+        const keys = new Set([...Object.keys(actual), ...Object.keys(expected)]);
+        for (const key of keys) {
+            const next = path ? `${path}.${key}` : key;
+            const aHas = Object.hasOwn(actual, key);
+            const eHas = Object.hasOwn(expected, key);
+            if (!aHas) diffs.push({ path: next, actual: MISSING, expected: expected[key] });
+            else if (!eHas) diffs.push({ path: next, actual: actual[key], expected: MISSING });
+            else collectDiffs(actual[key], expected[key], next, diffs);
+        }
+        return;
+    }
+
+    if (Array.isArray(actual) && Array.isArray(expected)) {
+        const n = Math.max(actual.length, expected.length);
+        for (let i = 0; i < n; i++) {
+            const next = path ? `${path}[${i}]` : `[${i}]`;
+            if (i >= actual.length) diffs.push({ path: next, actual: MISSING, expected: expected[i] });
+            else if (i >= expected.length) diffs.push({ path: next, actual: actual[i], expected: MISSING });
+            else collectDiffs(actual[i], expected[i], next, diffs);
+        }
+        return;
+    }
+
+    diffs.push({ path: path || '(root)', actual, expected });
+}
+
+function assertDeepEqual(actual, expected, message) {
+    const diffs = [];
+    collectDiffs(actual, expected, '', diffs);
+    if (diffs.length === 0) return;
+
+    const lines = [`${message} (${diffs.length} difference${diffs.length === 1 ? '' : 's'})`, ''];
+    for (const diff of diffs) {
+        lines.push(`  ${paint('1;36', diff.path)}`);
+        lines.push(`    ${paint('31', 'actual:  ')} ${inspectVal(diff.actual)}`);
+        lines.push(`    ${paint('32', 'expected:')} ${inspectVal(diff.expected)}`);
+        lines.push('');
+    }
+
+    // A plain Error keeps node:test from re-inspecting the full trees (depth 2
+    // -> `[Object]`) and from appending a `+ undefined / - undefined` assert diff.
+    const err = new Error(lines.join('\n'));
+    err.name = 'AssertionError';
+    Error.captureStackTrace(err, assertDeepEqual);
+    throw err;
+}
 
 function create_cache(dir) {
     return {
@@ -164,7 +239,7 @@ export async function run_rpc_suite(t, Colibri, decode_proof) {
             // rpc() fetches the recorded proof from the mock prover and verifies it.
             if (conf.privacy_mode == "basic" || test_conf.remote_prover) {
                 const result = await c4.rpc(test_conf.method, test_conf.params);
-                assert.deepStrictEqual(result, test_conf.expected_result, 'Proof should be valid');
+                assertDeepEqual(result, test_conf.expected_result, 'Proof should be valid');
                 return;
             }
 
@@ -196,7 +271,7 @@ export async function run_rpc_suite(t, Colibri, decode_proof) {
                 console.log(`Total: ${totalDuration.toFixed(2)}ms`);
                 console.log(`================================\n`);
             }
-            assert.deepEqual(result, test_conf.expected_result, 'Proof should be valid');
+            assertDeepEqual(result, test_conf.expected_result, 'Proof should be valid');
         });
     }
 }

--- a/src/chains/eth/AGENTS.md
+++ b/src/chains/eth/AGENTS.md
@@ -64,8 +64,9 @@ Each prover module generates proofs for a category of RPC methods. The main disp
 | `proof_witness.c` | Witness data generation (for L2) |
 | `historic_proof.c` | Historical block proof (older than 8192 slots) |
 | `historic_proof_zk.c` | ZK-based historical proofs |
-| `beacon.c/h` | Beacon API integration (bootstrap, updates, block roots) |
-| `eth_req.c/h` | Request parsing and validation |
+| `beacon.c/h` | Beacon block resolution (parent scan, Gloas hop, EL/CL fill) |
+| `cl_req.c/h` | Consensus-layer request wrappers (Beacon API + validation) |
+| `eth_req.c/h` | Execution-layer RPC wrappers and validation |
 | `eth_tools.c/h` | Ethereum utility functions |
 
 ## SSZ Type Definitions (`ssz/`)

--- a/src/chains/eth/CMakeLists.txt
+++ b/src/chains/eth/CMakeLists.txt
@@ -194,6 +194,7 @@ add_prover(
     prover/proof_logs_completeness.c
     prover/proof_call.c
     prover/beacon.c
+    prover/cl_req.c
     prover/beacon_header.c
     prover/proof_receipt.c
     prover/proof_block_receipts.c

--- a/src/chains/eth/prover/beacon.c
+++ b/src/chains/eth/prover/beacon.c
@@ -173,17 +173,6 @@ void c4_beacon_cache_update_blockdata(prover_ctx_t* ctx, eth_block_t* beacon_blo
 
 #endif
 
-static c4_status_t get_finality_check_points(prover_ctx_t* ctx, json_t* result) {
-  data_request_t* req = NULL;
-  TRY_ASYNC(c4_send_beacon_json(ctx, "eth/v1/beacon/states/head/finality_checkpoints", NULL, 0, result, &req));
-  if (req && !req->validated) {
-    CHECK_JSON(*result, JSON_BEACON_FINALITY, "Invalid finality checkpoints: ");
-    req->validated = true;
-  }
-  *result = json_get(*result, "data");
-  return C4_SUCCESS;
-}
-
 // Child-header lookup:
 // - Default: GET /eth/v1/beacon/headers?parent_root= (Beacon API, Lodestar).
 // - C4_PROVER_FLAG_NIMBUS: Nimbus does not implement that query
@@ -193,7 +182,6 @@ static c4_status_t get_finality_check_points(prover_ctx_t* ctx, json_t* result) 
 //   Nimbus 404 ("Block header/data has not been found"); both skip to the
 //   next slot. Other request errors abort.
 #define PARENT_CHILD_SCAN_MAX 32u
-#define PARENT_CHILD_SLOT_TTL 6u // empty ?slot= and empty ?parent_root= must not stick for DEFAULT_TTL
 
 static bool json_uint64_field(json_t obj, const char* key, uint64_t* out) {
   json_t v = json_get(obj, key);
@@ -261,46 +249,10 @@ static c4_status_t beacon_header_extract(prover_ctx_t* ctx, json_t entry, json_t
   return C4_SUCCESS;
 }
 
-static bool beacon_slot_missing_error(const char* error) {
-  if (!error) return false;
-  // Nimbus: HTTP 404 {"code":404,"message":"Block header/data has not been found"}
-  return strstr(error, "404") != NULL || strstr(error, "not been found") != NULL;
-}
-
-static c4_status_t fetch_headers_at_slot(prover_ctx_t* ctx, uint64_t slot, json_t* result) {
-  char     path[200]   = {0};
-  buffer_t path_buffer = stack_buffer(path);
-
-  bprintf(&path_buffer, "eth/v1/beacon/headers?slot=%l", slot);
-  // Use the non-throwing variant so we can distinguish a real transport
-  // failure from Nimbus' "empty slot" (404 / "not been found") without
-  // clearing an already-set `ctx->state.error` after the fact.
-  data_request_t* req    = NULL;
-  c4_status_t     status = c4_send_beacon_json_no_throw(ctx, path, NULL, PARENT_CHILD_SLOT_TTL, &req);
-  if (status == C4_PENDING) return C4_PENDING;
-  if (status == C4_SUCCESS) {
-    json_t response = json_parse((char*) req->response.data);
-    if (response.type == JSON_TYPE_INVALID) THROW_ERROR("Invalid JSON response");
-    if (!req->validated) {
-      CHECK_JSON(response, JSON_BEACON_HEADER_LIST, "Invalid beacon headers: ");
-      req->validated = true;
-    }
-    *result = response;
-    return C4_SUCCESS;
-  }
-  // status == C4_ERROR: map the well-known "no header at that slot" errors
-  // (empty slot on Nimbus, 404 on Lodestar) to a domain-level empty result.
-  if (beacon_slot_missing_error(req ? req->error : NULL)) {
-    *result = (json_t) {.type = JSON_TYPE_NOT_FOUND};
-    return C4_SUCCESS;
-  }
-  THROW_ERROR(req && req->error ? req->error : "Data request failed");
-}
-
 static c4_status_t get_beacon_header_at_slot_with_parent(prover_ctx_t* ctx, uint64_t slot, bytes32_t expected_parent, json_t* header, bytes32_t root) {
   json_t result = {0};
 
-  TRY_ASYNC(fetch_headers_at_slot(ctx, slot, &result));
+  TRY_ASYNC(cl_get_headers_at_slot(ctx, slot, &result));
 
   json_t entry = beacon_header_child_in_result(result, expected_parent);
   if (entry.type != JSON_TYPE_OBJECT)
@@ -317,7 +269,7 @@ static c4_status_t scan_child_headers(prover_ctx_t* ctx, uint64_t parent_slot, b
 
   for (uint32_t off = 1; off <= PARENT_CHILD_SCAN_MAX; off++) {
     json_t result = {0};
-    TRY_ASYNC(fetch_headers_at_slot(ctx, parent_slot + off, &result));
+    TRY_ASYNC(cl_get_headers_at_slot(ctx, parent_slot + off, &result));
     json_t entry = beacon_header_child_in_result(result, parent_root);
     if (entry.type != JSON_TYPE_OBJECT) continue;
     return beacon_header_extract(ctx, entry, header, root);
@@ -328,17 +280,8 @@ static c4_status_t scan_child_headers(prover_ctx_t* ctx, uint64_t parent_slot, b
 }
 
 static c4_status_t get_beacon_header_by_parent_hash_scan(prover_ctx_t* ctx, bytes32_t parent_root, json_t* header, bytes32_t root) {
-  char     path[200]   = {0};
-  json_t   parent_res  = {0};
-  buffer_t path_buffer = stack_buffer(path);
-
-  bprintf(&path_buffer, "eth/v1/beacon/headers/0x%x", bytes(parent_root, 32));
-  data_request_t* req = NULL;
-  TRY_ASYNC(c4_send_beacon_json(ctx, path, NULL, DEFAULT_TTL, &parent_res, &req));
-  if (req && !req->validated) {
-    CHECK_JSON(parent_res, JSON_BEACON_HEADER_OBJECT, "Invalid parent beacon header: ");
-    req->validated = true;
-  }
+  json_t parent_res = {0};
+  TRY_ASYNC(cl_get_header_by_root(ctx, parent_root, &parent_res));
 
   json_t parent_entry = beacon_header_unwrap_data(parent_res);
   if (parent_entry.type != JSON_TYPE_OBJECT) THROW_ERROR("Parent beacon header not found!");
@@ -350,17 +293,8 @@ static c4_status_t get_beacon_header_by_parent_hash_scan(prover_ctx_t* ctx, byte
 }
 
 static c4_status_t get_beacon_header_by_parent_hash_query(prover_ctx_t* ctx, bytes32_t parent_root, json_t* header, bytes32_t root) {
-  char     path[200]   = {0};
-  json_t   result      = {0};
-  buffer_t path_buffer = stack_buffer(path);
-
-  bprintf(&path_buffer, "eth/v1/beacon/headers?parent_root=0x%x", bytes(parent_root, 32));
-  data_request_t* req = NULL;
-  TRY_ASYNC(c4_send_beacon_json_with_client_type(ctx, path, NULL, PARENT_CHILD_SLOT_TTL, &result, BEACON_SUPPORTS_PARENT_ROOT_HEADERS, &req));
-  if (req && !req->validated) {
-    CHECK_JSON(result, JSON_BEACON_HEADER_LIST, "Invalid beacon headers: ");
-    req->validated = true;
-  }
+  json_t result = {0};
+  TRY_ASYNC(cl_get_headers_by_parent_root(ctx, parent_root, &result));
 
   json_t entry = beacon_header_child_in_result(result, parent_root);
   if (entry.type != JSON_TYPE_OBJECT) {
@@ -387,44 +321,14 @@ static c4_status_t get_beacon_header_by_parent_hash(prover_ctx_t* ctx, bytes32_t
   return find_child_header(ctx, parent_root, NULL, header, root);
 }
 
-static c4_status_t determine_fork(prover_ctx_t* ctx, ssz_ob_t* block, data_request_t* req) {
-  if (!block || !block->bytes.data) THROW_ERROR("no block data!");
-  if (block->bytes.len < 108) THROW_ERROR_WITH("Invalid block data len=%d !", block->bytes.len);
-  bytes_t  data   = block->bytes;
-  uint32_t offset = uint32_from_le(data.data);
-  if (offset > data.len - 8) THROW_ERROR_WITH("Invalid block data offset[%d] > data_len[%d] - 8 : %b !", offset, data.len, bytes(data.data, data.len < 200 ? data.len : 200));
-  uint64_t            slot  = uint64_from_le(data.data + offset);
-  const chain_spec_t* chain = c4_eth_get_chain_spec(ctx->chain_id);
-  if (chain == NULL) THROW_ERROR("unsupported chain id!");
-  fork_id_t fork = c4_chain_fork_id(ctx->chain_id, epoch_for_slot(slot, chain));
-  block->def     = eth_ssz_type_for_fork(ETH_SSZ_SIGNED_BEACON_BLOCK_CONTAINER, fork, ctx->chain_id);
-  if (!block->def) THROW_ERROR("Invalid fork id!");
-  if (req && req->validated) return C4_SUCCESS;
-  if (!ssz_is_valid(*block, true, &ctx->state)) return C4_ERROR;
-  if (req) req->validated = true;
-  return C4_SUCCESS;
-}
-
 static c4_status_t get_block(prover_ctx_t* ctx, beacon_head_t* b, ssz_ob_t* block) {
-  if (!block) THROW_ERROR("Invalid block data!");
-  bytes_t  block_data;
-  char     path[200];
-  buffer_t buffer   = stack_buffer(path);
-  bool     has_hash = b && !bytes_all_zero(bytes(b->root, 32));
-  uint32_t ttl      = 6; // 6s for head-requests
-  if (!b || (b->slot == 0 && !has_hash))
-    buffer_add_chars(&buffer, "eth/v2/beacon/blocks/head");
-  else if (has_hash) {
-    bprintf(&buffer, "eth/v2/beacon/blocks/0x%x", bytes(b->root, 32));
-    ttl = DEFAULT_TTL;
+  const uint8_t* root = NULL;
+  uint64_t       slot = 0;
+  if (b) {
+    root = b->root;
+    slot = b->slot;
   }
-  else
-    bprintf(&buffer, "eth/v2/beacon/blocks/%l", b->slot);
-
-  data_request_t* req = NULL;
-  TRY_ASYNC(c4_send_beacon_ssz(ctx, path, NULL, NULL, ttl, block, &req));
-  TRY_ASYNC(determine_fork(ctx, block, req));
-
+  TRY_ASYNC(cl_fetch_signed_beacon_block(ctx, root, slot, block));
   *block = ssz_get(block, "message");
   return C4_SUCCESS;
 }
@@ -581,7 +485,7 @@ static inline c4_status_t eth_get_final_hash(prover_ctx_t* ctx, bool safe, bytes
   buffer_t      buf_finalized = {.allocated = -32, .data = {.data = hashes[1].root, .len = 0}};
 
   //  uint8_t* root = safe ? blockroot : blockroot + 32;
-  TRY_ASYNC(get_finality_check_points(ctx, &result));
+  TRY_ASYNC(cl_get_finality_checkpoints(ctx, &result));
   json_get_bytes(json_get(result, "current_justified"), "root", &buf_justified);
   json_get_bytes(json_get(result, "finalized"), "root", &buf_finalized);
   if (slot) {
@@ -653,21 +557,14 @@ static c4_status_t get_el_header_and_branch(prover_ctx_t* ctx, el_header_and_bra
     ssz_ob_t      body              = ssz_get(&data_block, "body");
     ssz_ob_t      bid               = ssz_get(&body, "signedExecutionPayloadBid");
     ssz_ob_t      message           = ssz_get(&bid, "message");
-    uint8_t*      parent_block_hash = ssz_get(&message, "parentBlockHash").bytes.data;
+    bytes_t       parent_block_hash = ssz_get(&message, "parentBlockHash").bytes;
     ssz_builder_t body_builder      = ssz_builder_for_type(ETH_SSZ_EL_BLOCK_CONTENT);
-    json_t        result            = {0};
-    buffer_t      buffer            = {0};
-    char          tmp[100]          = {0};
-    sbprintf(tmp, "[\"0x%x\"]", bytes(parent_block_hash, 32));
+    bytes_t       raw_block         = {0};
 
-    data_request_t* req = NULL;
-    TRY_ASYNC(c4_send_eth_rpc(ctx, "debug_getRawBlock", tmp, DEFAULT_TTL, &result, &req));
-    if (req && !req->validated) {
-      CHECK_JSON(result, "bytes", "Invalid results for debug_getRawBlock: ");
-      req->validated = true;
-    }
-    buffer_grow(&buffer, result.len / 2 + 1);
-    TRY_ASYNC_FINAL(eth_el_header_get_from_raw_block(&ctx->state, json_as_bytes(result, &buffer), &generated_header, &body_builder), buffer_free(&buffer));
+    if (!parent_block_hash.data || parent_block_hash.len != 32)
+      THROW_ERROR("Invalid parentBlockHash in execution payload bid");
+    TRY_ASYNC(eth_debug_get_raw_block(ctx, parent_block_hash.data, &raw_block));
+    TRY_ASYNC(eth_el_header_get_from_raw_block(&ctx->state, raw_block, &generated_header, &body_builder));
 
     generated_branch_gindex = c4_execution_block_hash_gindex(ctx->chain_id, ssz_get_uint64(&data_block, "slot"));
     generated_branch        = ssz_create_proof(body, body_root, generated_branch_gindex);
@@ -805,201 +702,4 @@ ssz_builder_t c4_proof_add_header(ssz_ob_t block, bytes32_t body_root) {
   ssz_add_bytes(&beacon_header, "stateRoot", ssz_get(&block, "stateRoot").bytes);
   ssz_add_bytes(&beacon_header, "bodyRoot", bytes(body_root, 32));
   return beacon_header;
-}
-c4_status_t c4_send_beacon_json(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, json_t* result, data_request_t** req) {
-  return c4_send_beacon_json_with_client_type(ctx, path, query, ttl, result, 0, req);
-}
-
-/**
- * Shared enqueue-and-probe routine for all request variants.
- *
- * Computes the request-id from `(path, query)`, looks up the request in
- * `ctx->state`, and either creates it (returning `C4_PENDING`) or reports
- * the current status. Never touches `ctx->state.error`; error reporting is
- * the caller's responsibility (either by threading the error through the
- * returned `data_request_t.error`, or by wrapping into a `THROW_ERROR`).
- *
- * Ownership: on the "new request" path, the URL buffer is transferred to
- * `data_request_t.url` (must NOT be freed here). On the "existing request"
- * path, the local buffer is freed.
- *
- * Compute-unit accounting: `cu_cost` is added to `ctx` only when a new
- * `data_request_t` is enqueued -- looking up an already-completed request
- * (success or sticky error) is free. That keeps CU accounting tied to
- * network work, not to sticky-error re-probes on async re-entries.
- *
- * @param ctx           prover context
- * @param path          request path
- * @param query         optional query string (appended after `?`); may be NULL
- * @param ttl           cache TTL in seconds
- * @param data_type     request source type (`data_request_type_t`)
- * @param data_encoding wire encoding for the response (`data_request_encoding_t`)
- * @param client_type   preferred client type bitmask
- * @param cu_cost       compute units to charge when a new request is enqueued
- * @param out_req       receives the underlying `data_request_t*` on all
- *                      return statuses; may be NULL if the caller does not
- *                      care about the returned handle
- */
-static c4_status_t send_request_impl(prover_ctx_t*           ctx,
-                                     char*                   path,
-                                     char*                   query,
-                                     uint32_t                ttl,
-                                     data_request_type_t     data_type,
-                                     data_request_encoding_t data_encoding,
-                                     uint32_t                client_type,
-                                     uint32_t                cu_cost,
-                                     data_request_t**        out_req) {
-  bytes32_t id     = {0};
-  buffer_t  buffer = {0};
-  buffer_add_chars(&buffer, path);
-  if (query) {
-    buffer_add_chars(&buffer, "?");
-    buffer_add_chars(&buffer, query);
-  }
-  sha256(buffer.data, id);
-  data_request_t* data_request = c4_state_get_data_request_by_id(&ctx->state, id);
-  if (data_request) {
-    buffer_free(&buffer);
-    if (out_req) *out_req = data_request;
-    if (c4_state_is_pending(data_request)) return C4_PENDING;
-    if (!data_request->error && data_request->response.data) return C4_SUCCESS;
-    return C4_ERROR;
-  }
-  // New request: charge CU exactly once (at enqueue). All subsequent
-  // lookups for the same id (success, error, or pending re-entries) are
-  // free -- they do no I/O.
-  eth_cu_add(ctx, cu_cost);
-  data_request = (data_request_t*) safe_calloc(1, sizeof(data_request_t));
-  memcpy(data_request->id, id, 32);
-  data_request->url                   = (char*) buffer.data.data;
-  data_request->encoding              = data_encoding;
-  data_request->method                = C4_DATA_METHOD_GET;
-  data_request->type                  = data_type;
-  data_request->ttl                   = ttl;
-  data_request->preferred_client_type = client_type;
-  c4_state_add_request(&ctx->state, data_request);
-  if (out_req) *out_req = data_request;
-  return C4_PENDING;
-}
-
-c4_status_t c4_send_beacon_json_no_throw(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, data_request_t** out_req) {
-#ifdef HTTP_SERVER
-  uint32_t client_type = ctx->client_type;
-#else
-  uint32_t client_type = 0;
-#endif
-  return send_request_impl(ctx, path, query, ttl,
-                           C4_DATA_TYPE_BEACON_API, C4_DATA_ENCODING_JSON,
-                           client_type, CU_BEACON_JSON, out_req);
-}
-
-c4_status_t c4_send_beacon_json_with_client_type(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, json_t* result, uint32_t client_type, data_request_t** out_req) {
-#ifdef HTTP_SERVER
-  client_type |= ctx->client_type;
-#endif
-  data_request_t* req    = NULL;
-  c4_status_t     status = send_request_impl(ctx, path, query, ttl,
-                                             C4_DATA_TYPE_BEACON_API, C4_DATA_ENCODING_JSON,
-                                             client_type, CU_BEACON_JSON, &req);
-  if (out_req) *out_req = req;
-  if (status == C4_ERROR) THROW_ERROR(req && req->error ? req->error : "Data request failed");
-  if (status == C4_SUCCESS) {
-    json_t response = json_parse((char*) req->response.data);
-    if (response.type == JSON_TYPE_INVALID) THROW_ERROR("Invalid JSON response");
-    *result = response;
-  }
-  return status;
-}
-
-static bool convert_to_ssz(prover_ctx_t* ctx, data_request_t* data_request, ssz_ob_t* result) {
-  json_t json_result = json_parse((const char*) result->bytes.data);
-  json_t data        = json_get(json_result, "data");
-
-  if (data.type != JSON_TYPE_OBJECT) {
-    c4_state_add_error(&ctx->state, "Invalid JSON response");
-    return false;
-  }
-
-  if (result->def == NULL) {
-    // so we are getting a block, but we need to figure out the definition
-    uint64_t            slot  = json_get_uint64(json_get(data, "message"), "slot");
-    const chain_spec_t* chain = c4_eth_get_chain_spec(ctx->chain_id);
-    if (chain == NULL) {
-      c4_state_add_error(&ctx->state, "unsupported chain id!");
-      return false;
-    }
-    fork_id_t fork = c4_chain_fork_id(ctx->chain_id, epoch_for_slot(slot, chain));
-    result->def    = eth_ssz_type_for_fork(ETH_SSZ_SIGNED_BEACON_BLOCK_CONTAINER, fork, ctx->chain_id);
-    if (!result->def) {
-      c4_state_add_error(&ctx->state, "no definition for ETH_SSZ_SIGNED_BEACON_BLOCK_CONTAINER!");
-      return false;
-    }
-  }
-  ssz_ob_t ssz_result = ssz_from_json(data, result->def, &ctx->state);
-  if (!ssz_result.bytes.data) {
-    c4_state_add_error(&ctx->state, "Invalid SSZ response");
-    return false;
-  }
-
-  //  buffer_t buffer = {0};
-  //  bprintf(&buffer, "%z", ssz_result);
-  //  bytes_write(result->bytes, fopen("block_src.json", "wb"), true);
-  //  bytes_write(buffer.data, fopen("block_ssz.json", "wb"), true);
-  //  buffer_free(&buffer);
-
-  safe_free(data_request->response.data);
-  data_request->response = ssz_result.bytes;
-  result->bytes          = ssz_result.bytes;
-  return true;
-}
-c4_status_t c4_send_beacon_ssz(prover_ctx_t* ctx, char* path, char* query, const ssz_def_t* def, uint32_t ttl, ssz_ob_t* result, data_request_t** req) {
-  return c4_send_beacon_ssz_with_client_type(ctx, path, query, def, ttl, result, 0, req);
-}
-
-c4_status_t c4_send_beacon_ssz_no_throw(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, data_request_t** out_req) {
-#ifdef HTTP_SERVER
-  uint32_t client_type = ctx->client_type;
-#else
-  uint32_t client_type = 0;
-#endif
-  return send_request_impl(ctx, path, query, ttl,
-                           C4_DATA_TYPE_BEACON_API, C4_DATA_ENCODING_SSZ,
-                           client_type, CU_BEACON_SSZ, out_req);
-}
-
-c4_status_t c4_send_beacon_ssz_with_client_type(prover_ctx_t* ctx, char* path, char* query, const ssz_def_t* def, uint32_t ttl, ssz_ob_t* result, uint32_t client_type, data_request_t** out_req) {
-#ifdef HTTP_SERVER
-  client_type |= ctx->client_type;
-#endif
-  data_request_t* req    = NULL;
-  c4_status_t     status = send_request_impl(ctx, path, query, ttl,
-                                             C4_DATA_TYPE_BEACON_API, C4_DATA_ENCODING_SSZ,
-                                             client_type, CU_BEACON_SSZ, &req);
-  if (out_req) *out_req = req;
-  if (status == C4_ERROR) THROW_ERROR(req && req->error ? req->error : "Data request failed");
-  if (status == C4_SUCCESS) {
-    *result = (ssz_ob_t) {.def = def, .bytes = req->response};
-    if (!req->validated) {
-      if (result->bytes.len > 20 && result->bytes.data[0] == '{' && result->bytes.data[1] == '"' && !convert_to_ssz(ctx, req, result)) return C4_ERROR;
-      if (def) {
-        if (!ssz_is_valid(*result, true, &ctx->state)) return C4_ERROR;
-        req->validated = true;
-      }
-    }
-  }
-  return status;
-}
-
-c4_status_t c4_send_internal_request_no_throw(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, data_request_t** out_req) {
-  return send_request_impl(ctx, path, query, ttl,
-                           C4_DATA_TYPE_INTERN, C4_DATA_ENCODING_SSZ,
-                           0, CU_INTERNAL_REQUEST, out_req);
-}
-
-c4_status_t c4_send_internal_request(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, bytes_t* result) {
-  data_request_t* req    = NULL;
-  c4_status_t     status = c4_send_internal_request_no_throw(ctx, path, query, ttl, &req);
-  if (status == C4_ERROR) THROW_ERROR(req && req->error ? req->error : "Data request failed");
-  if (status == C4_SUCCESS) *result = req->response;
-  return status;
 }

--- a/src/chains/eth/prover/beacon.c
+++ b/src/chains/eth/prover/beacon.c
@@ -174,7 +174,12 @@ void c4_beacon_cache_update_blockdata(prover_ctx_t* ctx, eth_block_t* beacon_blo
 #endif
 
 static c4_status_t get_finality_check_points(prover_ctx_t* ctx, json_t* result) {
-  TRY_ASYNC(c4_send_beacon_json(ctx, "eth/v1/beacon/states/head/finality_checkpoints", NULL, 0, result));
+  data_request_t* req = NULL;
+  TRY_ASYNC(c4_send_beacon_json(ctx, "eth/v1/beacon/states/head/finality_checkpoints", NULL, 0, result, &req));
+  if (req && !req->validated) {
+    CHECK_JSON(*result, JSON_BEACON_FINALITY, "Invalid finality checkpoints: ");
+    req->validated = true;
+  }
   *result = json_get(*result, "data");
   return C4_SUCCESS;
 }
@@ -276,6 +281,10 @@ static c4_status_t fetch_headers_at_slot(prover_ctx_t* ctx, uint64_t slot, json_
   if (status == C4_SUCCESS) {
     json_t response = json_parse((char*) req->response.data);
     if (response.type == JSON_TYPE_INVALID) THROW_ERROR("Invalid JSON response");
+    if (!req->validated) {
+      CHECK_JSON(response, JSON_BEACON_HEADER_LIST, "Invalid beacon headers: ");
+      req->validated = true;
+    }
     *result = response;
     return C4_SUCCESS;
   }
@@ -324,7 +333,12 @@ static c4_status_t get_beacon_header_by_parent_hash_scan(prover_ctx_t* ctx, byte
   buffer_t path_buffer = stack_buffer(path);
 
   bprintf(&path_buffer, "eth/v1/beacon/headers/0x%x", bytes(parent_root, 32));
-  TRY_ASYNC(c4_send_beacon_json(ctx, path, NULL, DEFAULT_TTL, &parent_res));
+  data_request_t* req = NULL;
+  TRY_ASYNC(c4_send_beacon_json(ctx, path, NULL, DEFAULT_TTL, &parent_res, &req));
+  if (req && !req->validated) {
+    CHECK_JSON(parent_res, JSON_BEACON_HEADER_OBJECT, "Invalid parent beacon header: ");
+    req->validated = true;
+  }
 
   json_t parent_entry = beacon_header_unwrap_data(parent_res);
   if (parent_entry.type != JSON_TYPE_OBJECT) THROW_ERROR("Parent beacon header not found!");
@@ -341,7 +355,12 @@ static c4_status_t get_beacon_header_by_parent_hash_query(prover_ctx_t* ctx, byt
   buffer_t path_buffer = stack_buffer(path);
 
   bprintf(&path_buffer, "eth/v1/beacon/headers?parent_root=0x%x", bytes(parent_root, 32));
-  TRY_ASYNC(c4_send_beacon_json_with_client_type(ctx, path, NULL, PARENT_CHILD_SLOT_TTL, &result, BEACON_SUPPORTS_PARENT_ROOT_HEADERS));
+  data_request_t* req = NULL;
+  TRY_ASYNC(c4_send_beacon_json_with_client_type(ctx, path, NULL, PARENT_CHILD_SLOT_TTL, &result, BEACON_SUPPORTS_PARENT_ROOT_HEADERS, &req));
+  if (req && !req->validated) {
+    CHECK_JSON(result, JSON_BEACON_HEADER_LIST, "Invalid beacon headers: ");
+    req->validated = true;
+  }
 
   json_t entry = beacon_header_child_in_result(result, parent_root);
   if (entry.type != JSON_TYPE_OBJECT) {
@@ -368,7 +387,7 @@ static c4_status_t get_beacon_header_by_parent_hash(prover_ctx_t* ctx, bytes32_t
   return find_child_header(ctx, parent_root, NULL, header, root);
 }
 
-static c4_status_t determine_fork(prover_ctx_t* ctx, ssz_ob_t* block) {
+static c4_status_t determine_fork(prover_ctx_t* ctx, ssz_ob_t* block, data_request_t* req) {
   if (!block || !block->bytes.data) THROW_ERROR("no block data!");
   if (block->bytes.len < 108) THROW_ERROR_WITH("Invalid block data len=%d !", block->bytes.len);
   bytes_t  data   = block->bytes;
@@ -380,7 +399,10 @@ static c4_status_t determine_fork(prover_ctx_t* ctx, ssz_ob_t* block) {
   fork_id_t fork = c4_chain_fork_id(ctx->chain_id, epoch_for_slot(slot, chain));
   block->def     = eth_ssz_type_for_fork(ETH_SSZ_SIGNED_BEACON_BLOCK_CONTAINER, fork, ctx->chain_id);
   if (!block->def) THROW_ERROR("Invalid fork id!");
-  return ssz_is_valid(*block, true, &ctx->state) ? C4_SUCCESS : C4_ERROR;
+  if (req && req->validated) return C4_SUCCESS;
+  if (!ssz_is_valid(*block, true, &ctx->state)) return C4_ERROR;
+  if (req) req->validated = true;
+  return C4_SUCCESS;
 }
 
 static c4_status_t get_block(prover_ctx_t* ctx, beacon_head_t* b, ssz_ob_t* block) {
@@ -399,8 +421,9 @@ static c4_status_t get_block(prover_ctx_t* ctx, beacon_head_t* b, ssz_ob_t* bloc
   else
     bprintf(&buffer, "eth/v2/beacon/blocks/%l", b->slot);
 
-  TRY_ASYNC(c4_send_beacon_ssz(ctx, path, NULL, NULL, ttl, block));
-  TRY_ASYNC(determine_fork(ctx, block));
+  data_request_t* req = NULL;
+  TRY_ASYNC(c4_send_beacon_ssz(ctx, path, NULL, NULL, ttl, block, &req));
+  TRY_ASYNC(determine_fork(ctx, block, req));
 
   *block = ssz_get(block, "message");
   return C4_SUCCESS;
@@ -637,7 +660,12 @@ static c4_status_t get_el_header_and_branch(prover_ctx_t* ctx, el_header_and_bra
     char          tmp[100]          = {0};
     sbprintf(tmp, "[\"0x%x\"]", bytes(parent_block_hash, 32));
 
-    TRY_ASYNC(c4_send_eth_rpc(ctx, "debug_getRawBlock", tmp, DEFAULT_TTL, &result, NULL));
+    data_request_t* req = NULL;
+    TRY_ASYNC(c4_send_eth_rpc(ctx, "debug_getRawBlock", tmp, DEFAULT_TTL, &result, &req));
+    if (req && !req->validated) {
+      CHECK_JSON(result, "bytes", "Invalid results for debug_getRawBlock: ");
+      req->validated = true;
+    }
     buffer_grow(&buffer, result.len / 2 + 1);
     TRY_ASYNC_FINAL(eth_el_header_get_from_raw_block(&ctx->state, json_as_bytes(result, &buffer), &generated_header, &body_builder), buffer_free(&buffer));
 
@@ -778,8 +806,8 @@ ssz_builder_t c4_proof_add_header(ssz_ob_t block, bytes32_t body_root) {
   ssz_add_bytes(&beacon_header, "bodyRoot", bytes(body_root, 32));
   return beacon_header;
 }
-c4_status_t c4_send_beacon_json(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, json_t* result) {
-  return c4_send_beacon_json_with_client_type(ctx, path, query, ttl, result, 0);
+c4_status_t c4_send_beacon_json(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, json_t* result, data_request_t** req) {
+  return c4_send_beacon_json_with_client_type(ctx, path, query, ttl, result, 0, req);
 }
 
 /**
@@ -865,7 +893,7 @@ c4_status_t c4_send_beacon_json_no_throw(prover_ctx_t* ctx, char* path, char* qu
                            client_type, CU_BEACON_JSON, out_req);
 }
 
-c4_status_t c4_send_beacon_json_with_client_type(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, json_t* result, uint32_t client_type) {
+c4_status_t c4_send_beacon_json_with_client_type(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, json_t* result, uint32_t client_type, data_request_t** out_req) {
 #ifdef HTTP_SERVER
   client_type |= ctx->client_type;
 #endif
@@ -873,6 +901,7 @@ c4_status_t c4_send_beacon_json_with_client_type(prover_ctx_t* ctx, char* path, 
   c4_status_t     status = send_request_impl(ctx, path, query, ttl,
                                              C4_DATA_TYPE_BEACON_API, C4_DATA_ENCODING_JSON,
                                              client_type, CU_BEACON_JSON, &req);
+  if (out_req) *out_req = req;
   if (status == C4_ERROR) THROW_ERROR(req && req->error ? req->error : "Data request failed");
   if (status == C4_SUCCESS) {
     json_t response = json_parse((char*) req->response.data);
@@ -923,8 +952,8 @@ static bool convert_to_ssz(prover_ctx_t* ctx, data_request_t* data_request, ssz_
   result->bytes          = ssz_result.bytes;
   return true;
 }
-c4_status_t c4_send_beacon_ssz(prover_ctx_t* ctx, char* path, char* query, const ssz_def_t* def, uint32_t ttl, ssz_ob_t* result) {
-  return c4_send_beacon_ssz_with_client_type(ctx, path, query, def, ttl, result, 0);
+c4_status_t c4_send_beacon_ssz(prover_ctx_t* ctx, char* path, char* query, const ssz_def_t* def, uint32_t ttl, ssz_ob_t* result, data_request_t** req) {
+  return c4_send_beacon_ssz_with_client_type(ctx, path, query, def, ttl, result, 0, req);
 }
 
 c4_status_t c4_send_beacon_ssz_no_throw(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, data_request_t** out_req) {
@@ -938,7 +967,7 @@ c4_status_t c4_send_beacon_ssz_no_throw(prover_ctx_t* ctx, char* path, char* que
                            client_type, CU_BEACON_SSZ, out_req);
 }
 
-c4_status_t c4_send_beacon_ssz_with_client_type(prover_ctx_t* ctx, char* path, char* query, const ssz_def_t* def, uint32_t ttl, ssz_ob_t* result, uint32_t client_type) {
+c4_status_t c4_send_beacon_ssz_with_client_type(prover_ctx_t* ctx, char* path, char* query, const ssz_def_t* def, uint32_t ttl, ssz_ob_t* result, uint32_t client_type, data_request_t** out_req) {
 #ifdef HTTP_SERVER
   client_type |= ctx->client_type;
 #endif
@@ -946,13 +975,16 @@ c4_status_t c4_send_beacon_ssz_with_client_type(prover_ctx_t* ctx, char* path, c
   c4_status_t     status = send_request_impl(ctx, path, query, ttl,
                                              C4_DATA_TYPE_BEACON_API, C4_DATA_ENCODING_SSZ,
                                              client_type, CU_BEACON_SSZ, &req);
+  if (out_req) *out_req = req;
   if (status == C4_ERROR) THROW_ERROR(req && req->error ? req->error : "Data request failed");
   if (status == C4_SUCCESS) {
     *result = (ssz_ob_t) {.def = def, .bytes = req->response};
     if (!req->validated) {
       if (result->bytes.len > 20 && result->bytes.data[0] == '{' && result->bytes.data[1] == '"' && !convert_to_ssz(ctx, req, result)) return C4_ERROR;
-      if (def && !ssz_is_valid(*result, true, &ctx->state)) return C4_ERROR;
-      req->validated = true;
+      if (def) {
+        if (!ssz_is_valid(*result, true, &ctx->state)) return C4_ERROR;
+        req->validated = true;
+      }
     }
   }
   return status;

--- a/src/chains/eth/prover/beacon.h
+++ b/src/chains/eth/prover/beacon.h
@@ -184,10 +184,17 @@ c4_status_t c4_hybrid_test_resolve_block_hash(prover_ctx_t* ctx, const uint8_t* 
 // creates a new header with the body_root passed and returns the ssz_builder_t, which must be freed
 ssz_builder_t c4_proof_add_header(ssz_ob_t header, bytes32_t body_root);
 
-c4_status_t c4_send_beacon_json(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, json_t* result);
-c4_status_t c4_send_beacon_ssz(prover_ctx_t* ctx, char* path, char* query, const ssz_def_t* def, uint32_t ttl, ssz_ob_t* result);
-c4_status_t c4_send_beacon_json_with_client_type(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, json_t* result, uint32_t client_type);
-c4_status_t c4_send_beacon_ssz_with_client_type(prover_ctx_t* ctx, char* path, char* query, const ssz_def_t* def, uint32_t ttl, ssz_ob_t* result, uint32_t client_type);
+#define JSON_BEACON_HEADER_MESSAGE     "{slot:suint,proposer_index:suint,parent_root:bytes32,state_root:bytes32,body_root:bytes32}"
+#define JSON_BEACON_HEADER_ENTRY       "{root:bytes32,canonical?:bool,header:{message:" JSON_BEACON_HEADER_MESSAGE "}}"
+#define JSON_BEACON_HEADER_OBJECT      "{data:" JSON_BEACON_HEADER_ENTRY "}"
+#define JSON_BEACON_HEADER_LIST        "{data:[" JSON_BEACON_HEADER_ENTRY "]}"
+#define JSON_BEACON_FINALITY           "{data:{current_justified:{epoch:suint,root:bytes32},finalized:{epoch:suint,root:bytes32}}}"
+#define JSON_BEACON_HISTORICAL_SUMMARIES "{data:{historical_summaries:[{block_summary_root:bytes32,state_summary_root:bytes32}],proof:[bytes32]}}"
+
+c4_status_t c4_send_beacon_json(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, json_t* result, data_request_t** req);
+c4_status_t c4_send_beacon_ssz(prover_ctx_t* ctx, char* path, char* query, const ssz_def_t* def, uint32_t ttl, ssz_ob_t* result, data_request_t** req);
+c4_status_t c4_send_beacon_json_with_client_type(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, json_t* result, uint32_t client_type, data_request_t** req);
+c4_status_t c4_send_beacon_ssz_with_client_type(prover_ctx_t* ctx, char* path, char* query, const ssz_def_t* def, uint32_t ttl, ssz_ob_t* result, uint32_t client_type, data_request_t** req);
 c4_status_t c4_send_internal_request(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, bytes_t* result);
 
 /**

--- a/src/chains/eth/prover/beacon.h
+++ b/src/chains/eth/prover/beacon.h
@@ -26,32 +26,15 @@
 
 #include "../util/json.h"
 #include "../util/ssz.h"
+#include "cl_req.h"
 #include "header_cache.h"
 #include "prover.h"
-
-// Bitmask-based beacon client types for feature detection
-#define BEACON_CLIENT_UNKNOWN    0x00000000 // No specific client requirement
-#define BEACON_CLIENT_NIMBUS     0x00000001 // (1 << 0)
-#define BEACON_CLIENT_LODESTAR   0x00000002 // (1 << 1)
-#define BEACON_CLIENT_PRYSM      0x00000004 // (1 << 2)
-#define BEACON_CLIENT_LIGHTHOUSE 0x00000008 // (1 << 3)
-#define BEACON_CLIENT_TEKU       0x00000010 // (1 << 4)
-#define BEACON_CLIENT_GRANDINE   0x00000020 // (1 << 5)
-// Add more clients as needed...
-
-// Feature-based client combinations
-#define BEACON_SUPPORTS_LIGHTCLIENT_UPDATE   (BEACON_CLIENT_NIMBUS | BEACON_CLIENT_LODESTAR)
-#define BEACON_SUPPORTS_HISTORICAL_SUMMARIES (BEACON_CLIENT_NIMBUS | BEACON_CLIENT_LODESTAR)
-#define BEACON_SUPPORTS_DEBUG_ENDPOINTS      (BEACON_CLIENT_NIMBUS | BEACON_CLIENT_LIGHTHOUSE)
-#define BEACON_SUPPORTS_PARENT_ROOT_HEADERS  (BEACON_CLIENT_LODESTAR) // Nimbus: status-im/nimbus-eth2#7305
-#define BEACON_SUPPORTS_STATE_PROOF          (BEACON_CLIENT_LODESTAR) // /eth/v0/beacon/proof/state/{state_id}
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #define FINALITY_KEY "FinalityRoots"
-#define DEFAULT_TTL  (3600 * 24) // 1 day
 // beacon block including the relevant parts for the proof
 
 typedef struct {
@@ -184,58 +167,6 @@ c4_status_t c4_hybrid_test_resolve_block_hash(prover_ctx_t* ctx, const uint8_t* 
 // creates a new header with the body_root passed and returns the ssz_builder_t, which must be freed
 ssz_builder_t c4_proof_add_header(ssz_ob_t header, bytes32_t body_root);
 
-#define JSON_BEACON_HEADER_MESSAGE     "{slot:suint,proposer_index:suint,parent_root:bytes32,state_root:bytes32,body_root:bytes32}"
-#define JSON_BEACON_HEADER_ENTRY       "{root:bytes32,canonical?:bool,header:{message:" JSON_BEACON_HEADER_MESSAGE "}}"
-#define JSON_BEACON_HEADER_OBJECT      "{data:" JSON_BEACON_HEADER_ENTRY "}"
-#define JSON_BEACON_HEADER_LIST        "{data:[" JSON_BEACON_HEADER_ENTRY "]}"
-#define JSON_BEACON_FINALITY           "{data:{current_justified:{epoch:suint,root:bytes32},finalized:{epoch:suint,root:bytes32}}}"
-#define JSON_BEACON_HISTORICAL_SUMMARIES "{data:{historical_summaries:[{block_summary_root:bytes32,state_summary_root:bytes32}],proof:[bytes32]}}"
-
-c4_status_t c4_send_beacon_json(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, json_t* result, data_request_t** req);
-c4_status_t c4_send_beacon_ssz(prover_ctx_t* ctx, char* path, char* query, const ssz_def_t* def, uint32_t ttl, ssz_ob_t* result, data_request_t** req);
-c4_status_t c4_send_beacon_json_with_client_type(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, json_t* result, uint32_t client_type, data_request_t** req);
-c4_status_t c4_send_beacon_ssz_with_client_type(prover_ctx_t* ctx, char* path, char* query, const ssz_def_t* def, uint32_t ttl, ssz_ob_t* result, uint32_t client_type, data_request_t** req);
-c4_status_t c4_send_internal_request(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, bytes_t* result);
-
-/**
- * Non-throwing variant of `c4_send_beacon_json`. Enqueues the request (or
- * reuses an existing one) and returns the underlying `data_request_t*`
- * without touching `ctx->state.error`. This lets callers handle transport
- * errors locally -- e.g. clearing them, falling back to another endpoint,
- * or mapping "404 / not found" to a domain-level empty result.
- *
- * @param ctx     prover context
- * @param path    beacon API path (e.g. `"eth/v1/beacon/headers?slot=..."`)
- * @param query   optional query string (appended after `?`); may be NULL
- * @param ttl     cache TTL in seconds (0 = default)
- * @param out_req receives the underlying `data_request_t*`; never NULL on
- *                any of the three returned statuses
- *
- * @return
- *   - `C4_PENDING`: request was enqueued or is still awaiting a response.
- *   - `C4_SUCCESS`: response is available. Read `(*out_req)->response`.
- *     The caller is responsible for JSON-parsing / validating the body.
- *   - `C4_ERROR`: request completed with an error. Read `(*out_req)->error`.
- *     `ctx->state.error` is NOT set; the caller decides whether to propagate
- *     via `THROW_ERROR(...)` or to recover.
- */
-c4_status_t c4_send_beacon_json_no_throw(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, data_request_t** out_req);
-
-/**
- * Non-throwing variant of `c4_send_beacon_ssz`. See
- * `c4_send_beacon_json_no_throw` for the general contract. On `C4_SUCCESS`
- * the caller receives raw response bytes via `(*out_req)->response`; no
- * SSZ definition is attached and no SSZ validation is performed.
- */
-c4_status_t c4_send_beacon_ssz_no_throw(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, data_request_t** out_req);
-
-/**
- * Non-throwing variant of `c4_send_internal_request`. See
- * `c4_send_beacon_json_no_throw` for the general contract. Used to talk to
- * in-process server handlers (`c4_handle_*`) via the same `data_request_t`
- * pipeline as external endpoints, but with local error handling.
- */
-c4_status_t c4_send_internal_request_no_throw(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, data_request_t** out_req);
 #ifdef PROVER_CACHE
 c4_status_t c4_set_latest_block(prover_ctx_t* ctx, uint64_t latest_block_number);
 c4_status_t c4_eth_update_finality(prover_ctx_t* ctx, bytes32_t checkpoint, uint64_t* slot);

--- a/src/chains/eth/prover/bootstrap_gloas.c
+++ b/src/chains/eth/prover/bootstrap_gloas.c
@@ -383,7 +383,8 @@ static c4_status_t fetch_block_by_root_for_bootstrap(prover_ctx_t* ctx,
   buffer_t path_buf     = stack_buffer(path);
   bprintf(&path_buf, "eth/v2/beacon/blocks/0x%x", bytes(header_root, 32));
 
-  TRY_ASYNC(c4_send_beacon_ssz(ctx, path, NULL, NULL, DEFAULT_TTL, &signed_block));
+  data_request_t* req = NULL;
+  TRY_ASYNC(c4_send_beacon_ssz(ctx, path, NULL, NULL, DEFAULT_TTL, &signed_block, &req));
 
   // The SSZ envelope arrived without a definition attached; determine the fork
   // from the on-wire slot and validate the SSZ layout before we descend into
@@ -403,8 +404,11 @@ static c4_status_t fetch_block_by_root_for_bootstrap(prover_ctx_t* ctx,
   signed_block.def = eth_ssz_type_for_fork(ETH_SSZ_SIGNED_BEACON_BLOCK_CONTAINER, fork, ctx->chain_id);
   if (!signed_block.def)
     THROW_ERROR("c4_create_gloas_bootstrap_by_root: no SSZ def for signed block");
-  if (!ssz_is_valid(signed_block, true, &ctx->state))
-    THROW_ERROR("c4_create_gloas_bootstrap_by_root: invalid signed block SSZ");
+  if (!(req && req->validated)) {
+    if (!ssz_is_valid(signed_block, true, &ctx->state))
+      THROW_ERROR("c4_create_gloas_bootstrap_by_root: invalid signed block SSZ");
+    if (req) req->validated = true;
+  }
 
   ssz_ob_t data_block = ssz_get(&signed_block, "message");
   if (!data_block.bytes.data)

--- a/src/chains/eth/prover/bootstrap_gloas.c
+++ b/src/chains/eth/prover/bootstrap_gloas.c
@@ -272,8 +272,8 @@ static c4_status_t build_gloas_bootstrap_from_block(prover_ctx_t* ctx,
   // ---------------------------------------------------------------------------
   ssz_ob_t    leaves_ob     = {0};
   ssz_ob_t    descriptor_ob = {0};
-  c4_status_t status        = c4_state_proofs_beacon_fetch(ctx, state_root, descriptor,
-                                                           &leaves_ob, &descriptor_ob);
+  c4_status_t status        = cl_get_state_proof(ctx, state_root, descriptor,
+                                                 &leaves_ob, &descriptor_ob);
   safe_free(descriptor.data);
   descriptor.data = NULL;
   descriptor.len  = 0;
@@ -347,7 +347,7 @@ static c4_status_t build_gloas_bootstrap_from_block(prover_ctx_t* ctx,
   safe_free(sync_committee_branch.data);
 
   // Account for the reconstruction cost. The per-request CU was already
-  // charged by c4_state_proofs_beacon_fetch -> c4_send_beacon_ssz_*.
+  // charged by cl_get_state_proof -> c4_send_beacon_ssz_*.
   eth_cu_add_proof(ctx);
 
   *out_bootstrap_ssz = bootstrap;
@@ -379,40 +379,17 @@ static c4_status_t fetch_block_by_root_for_bootstrap(prover_ctx_t* ctx,
                                                      bytes32_t     header_root,
                                                      eth_block_t*  block_out) {
   ssz_ob_t signed_block = {0};
-  char     path[128]    = {0};
-  buffer_t path_buf     = stack_buffer(path);
-  bprintf(&path_buf, "eth/v2/beacon/blocks/0x%x", bytes(header_root, 32));
-
-  data_request_t* req = NULL;
-  TRY_ASYNC(c4_send_beacon_ssz(ctx, path, NULL, NULL, DEFAULT_TTL, &signed_block, &req));
-
-  // The SSZ envelope arrived without a definition attached; determine the fork
-  // from the on-wire slot and validate the SSZ layout before we descend into
-  // container access.
-  if (signed_block.bytes.len < 108)
-    THROW_ERROR("c4_create_gloas_bootstrap_by_root: signed block too short");
-  const chain_spec_t* chain = c4_eth_get_chain_spec(ctx->chain_id);
-  if (!chain) THROW_ERROR("c4_create_gloas_bootstrap_by_root: unknown chain");
-  uint64_t block_slot_offset = uint32_from_le(signed_block.bytes.data);
-  if (block_slot_offset > signed_block.bytes.len - 8)
-    THROW_ERROR("c4_create_gloas_bootstrap_by_root: invalid signed block layout");
-  uint64_t  slot = uint64_from_le(signed_block.bytes.data + block_slot_offset);
-  fork_id_t fork = c4_chain_fork_id(ctx->chain_id, epoch_for_slot(slot, chain));
-  if (fork != C4_FORK_GLOAS)
-    THROW_ERROR("c4_create_gloas_bootstrap_by_root: block root does not resolve to a Gloas block");
-
-  signed_block.def = eth_ssz_type_for_fork(ETH_SSZ_SIGNED_BEACON_BLOCK_CONTAINER, fork, ctx->chain_id);
-  if (!signed_block.def)
-    THROW_ERROR("c4_create_gloas_bootstrap_by_root: no SSZ def for signed block");
-  if (!(req && req->validated)) {
-    if (!ssz_is_valid(signed_block, true, &ctx->state))
-      THROW_ERROR("c4_create_gloas_bootstrap_by_root: invalid signed block SSZ");
-    if (req) req->validated = true;
-  }
+  TRY_ASYNC(cl_fetch_signed_beacon_block(ctx, header_root, 0, &signed_block));
 
   ssz_ob_t data_block = ssz_get(&signed_block, "message");
   if (!data_block.bytes.data)
     THROW_ERROR("c4_create_gloas_bootstrap_by_root: message field missing");
+
+  const chain_spec_t* chain = c4_eth_get_chain_spec(ctx->chain_id);
+  if (!chain) THROW_ERROR("c4_create_gloas_bootstrap_by_root: unknown chain");
+  fork_id_t fork = c4_chain_fork_id(ctx->chain_id, epoch_for_slot(ssz_get_uint64(&data_block, "slot"), chain));
+  if (fork != C4_FORK_GLOAS)
+    THROW_ERROR("c4_create_gloas_bootstrap_by_root: block root does not resolve to a Gloas block");
 
   // Anchor the returned block to the caller-provided header_root: if
   // hash_tree_root(header) differs, we would silently build a bootstrap for

--- a/src/chains/eth/prover/cl_req.c
+++ b/src/chains/eth/prover/cl_req.c
@@ -1,0 +1,403 @@
+/*
+ * Copyright (c) 2025,2026 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "cl_req.h"
+#include "beacon_types.h"
+#include "crypto.h"
+#include "eth_compute_units.h"
+#include "json.h"
+#include "ssz.h"
+#include <string.h>
+
+/** Empty `?slot=` / `?parent_root=` answers must not stick for `DEFAULT_TTL`. */
+#define CL_HEADER_QUERY_TTL 6u
+
+#define JSON_BEACON_HEADER_MESSAGE       "{slot:suint,proposer_index:suint,parent_root:bytes32,state_root:bytes32,body_root:bytes32}"
+#define JSON_BEACON_HEADER_ENTRY         "{root:bytes32,canonical?:bool,header:{message:" JSON_BEACON_HEADER_MESSAGE "}}"
+#define JSON_BEACON_HEADER_OBJECT        "{data:" JSON_BEACON_HEADER_ENTRY "}"
+#define JSON_BEACON_HEADER_LIST          "{data:[" JSON_BEACON_HEADER_ENTRY "]}"
+#define JSON_BEACON_FINALITY             "{data:{current_justified:{epoch:suint,root:bytes32},finalized:{epoch:suint,root:bytes32}}}"
+#define JSON_BEACON_HISTORICAL_SUMMARIES "{data:{historical_summaries:[{block_summary_root:bytes32,state_summary_root:bytes32}],proof:[bytes32]}}"
+
+/**
+ * Shared enqueue-and-probe routine for all request variants.
+ *
+ * Computes the request-id from `(path, query)`, looks up the request in
+ * `ctx->state`, and either creates it (returning `C4_PENDING`) or reports
+ * the current status. Never touches `ctx->state.error`; error reporting is
+ * the caller's responsibility (either by threading the error through the
+ * returned `data_request_t.error`, or by wrapping into a `THROW_ERROR`).
+ *
+ * Ownership: on the "new request" path, the URL buffer is transferred to
+ * `data_request_t.url` (must NOT be freed here). On the "existing request"
+ * path, the local buffer is freed.
+ *
+ * Compute-unit accounting: `cu_cost` is added to `ctx` only when a new
+ * `data_request_t` is enqueued -- looking up an already-completed request
+ * (success or sticky error) is free. That keeps CU accounting tied to
+ * network work, not to sticky-error re-probes on async re-entries.
+ */
+static c4_status_t send_request_impl(prover_ctx_t*           ctx,
+                                     char*                   path,
+                                     char*                   query,
+                                     uint32_t                ttl,
+                                     data_request_type_t     data_type,
+                                     data_request_encoding_t data_encoding,
+                                     uint32_t                client_type,
+                                     uint32_t                cu_cost,
+                                     data_request_t**        out_req) {
+  bytes32_t id     = {0};
+  buffer_t  buffer = {0};
+  buffer_add_chars(&buffer, path);
+  if (query) {
+    buffer_add_chars(&buffer, "?");
+    buffer_add_chars(&buffer, query);
+  }
+  sha256(buffer.data, id);
+  data_request_t* data_request = c4_state_get_data_request_by_id(&ctx->state, id);
+  if (data_request) {
+    buffer_free(&buffer);
+    if (out_req) *out_req = data_request;
+    if (c4_state_is_pending(data_request)) return C4_PENDING;
+    if (!data_request->error && data_request->response.data) return C4_SUCCESS;
+    return C4_ERROR;
+  }
+  eth_cu_add(ctx, cu_cost);
+  data_request = (data_request_t*) safe_calloc(1, sizeof(data_request_t));
+  memcpy(data_request->id, id, 32);
+  data_request->url                   = (char*) buffer.data.data;
+  data_request->encoding              = data_encoding;
+  data_request->method                = C4_DATA_METHOD_GET;
+  data_request->type                  = data_type;
+  data_request->ttl                   = ttl;
+  data_request->preferred_client_type = client_type;
+  c4_state_add_request(&ctx->state, data_request);
+  if (out_req) *out_req = data_request;
+  return C4_PENDING;
+}
+
+static bool convert_to_ssz(prover_ctx_t* ctx, data_request_t* data_request, ssz_ob_t* result) {
+  json_t json_result = json_parse((const char*) result->bytes.data);
+  json_t data        = json_get(json_result, "data");
+
+  if (data.type != JSON_TYPE_OBJECT) {
+    c4_state_add_error(&ctx->state, "Invalid JSON response");
+    return false;
+  }
+
+  if (result->def == NULL) {
+    uint64_t            slot  = json_get_uint64(json_get(data, "message"), "slot");
+    const chain_spec_t* chain = c4_eth_get_chain_spec(ctx->chain_id);
+    if (chain == NULL) {
+      c4_state_add_error(&ctx->state, "unsupported chain id!");
+      return false;
+    }
+    fork_id_t fork = c4_chain_fork_id(ctx->chain_id, epoch_for_slot(slot, chain));
+    result->def    = eth_ssz_type_for_fork(ETH_SSZ_SIGNED_BEACON_BLOCK_CONTAINER, fork, ctx->chain_id);
+    if (!result->def) {
+      c4_state_add_error(&ctx->state, "no definition for ETH_SSZ_SIGNED_BEACON_BLOCK_CONTAINER!");
+      return false;
+    }
+  }
+  ssz_ob_t ssz_result = ssz_from_json(data, result->def, &ctx->state);
+  if (!ssz_result.bytes.data) {
+    c4_state_add_error(&ctx->state, "Invalid SSZ response");
+    return false;
+  }
+
+  safe_free(data_request->response.data);
+  data_request->response = ssz_result.bytes;
+  result->bytes          = ssz_result.bytes;
+  return true;
+}
+
+static bool beacon_slot_missing_error(const char* error) {
+  if (!error) return false;
+  return strstr(error, "404") != NULL || strstr(error, "not been found") != NULL;
+}
+
+static c4_status_t c4_send_beacon_json_with_client_type(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, json_t* result, uint32_t client_type, data_request_t** out_req);
+static c4_status_t c4_send_beacon_ssz_with_client_type(prover_ctx_t* ctx, char* path, char* query, const ssz_def_t* def, uint32_t ttl, ssz_ob_t* result, uint32_t client_type, data_request_t** out_req);
+static c4_status_t cl_validate_signed_beacon_block(prover_ctx_t* ctx, ssz_ob_t* signed_block, data_request_t* req);
+
+static c4_status_t c4_send_beacon_json(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, json_t* result, data_request_t** req) {
+  return c4_send_beacon_json_with_client_type(ctx, path, query, ttl, result, 0, req);
+}
+
+static c4_status_t c4_send_beacon_json_no_throw(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, data_request_t** out_req) {
+#ifdef HTTP_SERVER
+  uint32_t client_type = ctx->client_type;
+#else
+  uint32_t client_type = 0;
+#endif
+  return send_request_impl(ctx, path, query, ttl,
+                           C4_DATA_TYPE_BEACON_API, C4_DATA_ENCODING_JSON,
+                           client_type, CU_BEACON_JSON, out_req);
+}
+
+static c4_status_t c4_send_beacon_json_with_client_type(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, json_t* result, uint32_t client_type, data_request_t** out_req) {
+#ifdef HTTP_SERVER
+  client_type |= ctx->client_type;
+#endif
+  data_request_t* req    = NULL;
+  c4_status_t     status = send_request_impl(ctx, path, query, ttl,
+                                             C4_DATA_TYPE_BEACON_API, C4_DATA_ENCODING_JSON,
+                                             client_type, CU_BEACON_JSON, &req);
+  if (out_req) *out_req = req;
+  if (status == C4_ERROR) THROW_ERROR(req && req->error ? req->error : "Data request failed");
+  if (status == C4_SUCCESS) {
+    json_t response = json_parse((char*) req->response.data);
+    if (response.type == JSON_TYPE_INVALID) THROW_ERROR("Invalid JSON response");
+    *result = response;
+  }
+  return status;
+}
+
+c4_status_t c4_send_beacon_ssz(prover_ctx_t* ctx, char* path, char* query, const ssz_def_t* def, uint32_t ttl, ssz_ob_t* result, data_request_t** req) {
+  return c4_send_beacon_ssz_with_client_type(ctx, path, query, def, ttl, result, 0, req);
+}
+
+c4_status_t c4_send_beacon_ssz_no_throw(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, data_request_t** out_req) {
+#ifdef HTTP_SERVER
+  uint32_t client_type = ctx->client_type;
+#else
+  uint32_t client_type = 0;
+#endif
+  return send_request_impl(ctx, path, query, ttl,
+                           C4_DATA_TYPE_BEACON_API, C4_DATA_ENCODING_SSZ,
+                           client_type, CU_BEACON_SSZ, out_req);
+}
+
+static c4_status_t c4_send_beacon_ssz_with_client_type(prover_ctx_t* ctx, char* path, char* query, const ssz_def_t* def, uint32_t ttl, ssz_ob_t* result, uint32_t client_type, data_request_t** out_req) {
+#ifdef HTTP_SERVER
+  client_type |= ctx->client_type;
+#endif
+  data_request_t* req    = NULL;
+  c4_status_t     status = send_request_impl(ctx, path, query, ttl,
+                                             C4_DATA_TYPE_BEACON_API, C4_DATA_ENCODING_SSZ,
+                                             client_type, CU_BEACON_SSZ, &req);
+  if (out_req) *out_req = req;
+  if (status == C4_ERROR) THROW_ERROR(req && req->error ? req->error : "Data request failed");
+  if (status == C4_SUCCESS) {
+    *result = (ssz_ob_t) {.def = def, .bytes = req->response};
+    if (!req->validated) {
+      if (result->bytes.len > 20 && result->bytes.data[0] == '{' && result->bytes.data[1] == '"' && !convert_to_ssz(ctx, req, result)) return C4_ERROR;
+      if (def) {
+        if (!ssz_is_valid(*result, true, &ctx->state)) return C4_ERROR;
+        req->validated = true;
+      }
+    }
+  }
+  return status;
+}
+
+c4_status_t c4_send_internal_request_no_throw(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, data_request_t** out_req) {
+  return send_request_impl(ctx, path, query, ttl,
+                           C4_DATA_TYPE_INTERN, C4_DATA_ENCODING_SSZ,
+                           0, CU_INTERNAL_REQUEST, out_req);
+}
+
+c4_status_t c4_send_internal_request(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, bytes_t* result) {
+  data_request_t* req    = NULL;
+  c4_status_t     status = c4_send_internal_request_no_throw(ctx, path, query, ttl, &req);
+  if (status == C4_ERROR) THROW_ERROR(req && req->error ? req->error : "Data request failed");
+  if (status == C4_SUCCESS) *result = req->response;
+  return status;
+}
+
+c4_status_t cl_get_finality_checkpoints(prover_ctx_t* ctx, json_t* result) {
+  data_request_t* req = NULL;
+  TRY_ASYNC(c4_send_beacon_json(ctx, "eth/v1/beacon/states/head/finality_checkpoints", NULL, 0, result, &req));
+  if (req && !req->validated) {
+    CHECK_JSON(*result, JSON_BEACON_FINALITY, "Invalid finality checkpoints: ");
+    req->validated = true;
+  }
+  *result = json_get(*result, "data");
+  return C4_SUCCESS;
+}
+
+c4_status_t cl_get_headers_at_slot(prover_ctx_t* ctx, uint64_t slot, json_t* result) {
+  char     path[200]   = {0};
+  buffer_t path_buffer = stack_buffer(path);
+
+  bprintf(&path_buffer, "eth/v1/beacon/headers?slot=%l", slot);
+  data_request_t* req    = NULL;
+  c4_status_t     status = c4_send_beacon_json_no_throw(ctx, path, NULL, CL_HEADER_QUERY_TTL, &req);
+  if (status == C4_PENDING) return C4_PENDING;
+  if (status == C4_SUCCESS) {
+    json_t response = json_parse((char*) req->response.data);
+    if (response.type == JSON_TYPE_INVALID) THROW_ERROR("Invalid JSON response");
+    if (!req->validated) {
+      CHECK_JSON(response, JSON_BEACON_HEADER_LIST, "Invalid beacon headers: ");
+      req->validated = true;
+    }
+    *result = response;
+    return C4_SUCCESS;
+  }
+  if (beacon_slot_missing_error(req ? req->error : NULL)) {
+    *result = (json_t) {.type = JSON_TYPE_NOT_FOUND};
+    return C4_SUCCESS;
+  }
+  THROW_ERROR(req && req->error ? req->error : "Data request failed");
+}
+
+c4_status_t cl_get_header_by_root(prover_ctx_t* ctx, bytes32_t root, json_t* result) {
+  char     path[200]   = {0};
+  buffer_t path_buffer = stack_buffer(path);
+
+  bprintf(&path_buffer, "eth/v1/beacon/headers/0x%x", bytes(root, 32));
+  data_request_t* req = NULL;
+  TRY_ASYNC(c4_send_beacon_json(ctx, path, NULL, DEFAULT_TTL, result, &req));
+  if (req && !req->validated) {
+    CHECK_JSON(*result, JSON_BEACON_HEADER_OBJECT, "Invalid beacon header: ");
+    req->validated = true;
+  }
+  return C4_SUCCESS;
+}
+
+c4_status_t cl_get_headers_by_parent_root(prover_ctx_t* ctx, bytes32_t parent_root, json_t* result) {
+  char     path[200]   = {0};
+  buffer_t path_buffer = stack_buffer(path);
+
+  bprintf(&path_buffer, "eth/v1/beacon/headers?parent_root=0x%x", bytes(parent_root, 32));
+  data_request_t* req = NULL;
+  TRY_ASYNC(c4_send_beacon_json_with_client_type(ctx, path, NULL, CL_HEADER_QUERY_TTL, result, BEACON_SUPPORTS_PARENT_ROOT_HEADERS, &req));
+  if (req && !req->validated) {
+    CHECK_JSON(*result, JSON_BEACON_HEADER_LIST, "Invalid beacon headers: ");
+    req->validated = true;
+  }
+  return C4_SUCCESS;
+}
+
+c4_status_t cl_get_header_message_by_root(prover_ctx_t* ctx, bytes32_t root, json_t* message) {
+  json_t result = {0};
+  TRY_ASYNC(cl_get_header_by_root(ctx, root, &result));
+  json_t val = json_get(result, "data");
+  if (val.type != JSON_TYPE_OBJECT) THROW_ERROR("Invalid header!");
+  val      = json_get(val, "header");
+  *message = json_get(val, "message");
+  if (!message->start) THROW_ERROR("Invalid header!");
+  return C4_SUCCESS;
+}
+
+c4_status_t cl_get_historical_summaries(prover_ctx_t* ctx, bytes_t state_root, json_t* history_proof) {
+  if (ctx->state.error) return C4_ERROR;
+  uint8_t         tmp[200] = {0};
+  buffer_t        buf      = stack_buffer(tmp);
+  bool            nimbus   = (ctx->flags & C4_PROVER_FLAG_NIMBUS) != 0;
+  const char*     path     = nimbus ? "nimbus/v1/debug/beacon/states/0x%b/historical_summaries"
+                                    : "eth/v1/lodestar/states/0x%b/historical_summaries";
+  uint32_t        client   = nimbus ? BEACON_CLIENT_NIMBUS : BEACON_CLIENT_LODESTAR;
+  data_request_t* req      = NULL;
+  c4_status_t     status   = c4_send_beacon_json_with_client_type(ctx, bprintf(&buf, path, state_root), NULL, 120, history_proof, client, &req);
+  if (status == C4_SUCCESS && req && !req->validated) {
+    CHECK_JSON(*history_proof, JSON_BEACON_HISTORICAL_SUMMARIES, "Invalid historical summaries: ");
+    req->validated = true;
+  }
+  return status;
+}
+
+static c4_status_t cl_validate_signed_beacon_block(prover_ctx_t* ctx, ssz_ob_t* signed_block, data_request_t* req) {
+  if (!signed_block || !signed_block->bytes.data) THROW_ERROR("no block data!");
+  if (signed_block->bytes.len < 108) THROW_ERROR_WITH("Invalid block data len=%d !", signed_block->bytes.len);
+  bytes_t  data   = signed_block->bytes;
+  uint32_t offset = uint32_from_le(data.data);
+  if (offset > data.len - 8) THROW_ERROR_WITH("Invalid block data offset[%d] > data_len[%d] - 8 : %b !", offset, data.len, bytes(data.data, data.len < 200 ? data.len : 200));
+  uint64_t            slot  = uint64_from_le(data.data + offset);
+  const chain_spec_t* chain = c4_eth_get_chain_spec(ctx->chain_id);
+  if (chain == NULL) THROW_ERROR("unsupported chain id!");
+  fork_id_t fork    = c4_chain_fork_id(ctx->chain_id, epoch_for_slot(slot, chain));
+  signed_block->def = eth_ssz_type_for_fork(ETH_SSZ_SIGNED_BEACON_BLOCK_CONTAINER, fork, ctx->chain_id);
+  if (!signed_block->def) THROW_ERROR("Invalid fork id!");
+  if (req && req->validated) return C4_SUCCESS;
+  if (!ssz_is_valid(*signed_block, true, &ctx->state)) return C4_ERROR;
+  if (req) req->validated = true;
+  return C4_SUCCESS;
+}
+
+c4_status_t cl_fetch_signed_beacon_block(prover_ctx_t* ctx, const uint8_t* root, uint64_t slot, ssz_ob_t* signed_block) {
+  if (!signed_block) THROW_ERROR("Invalid block data!");
+  char     path[200];
+  buffer_t buffer   = stack_buffer(path);
+  bool     has_hash = root && !bytes_all_zero(bytes((uint8_t*) root, 32));
+  uint32_t ttl      = 6;
+  if (!has_hash && slot == 0)
+    buffer_add_chars(&buffer, "eth/v2/beacon/blocks/head");
+  else if (has_hash) {
+    bprintf(&buffer, "eth/v2/beacon/blocks/0x%x", bytes((uint8_t*) root, 32));
+    ttl = DEFAULT_TTL;
+  }
+  else
+    bprintf(&buffer, "eth/v2/beacon/blocks/%l", slot);
+
+  data_request_t* req = NULL;
+  TRY_ASYNC(c4_send_beacon_ssz(ctx, path, NULL, NULL, ttl, signed_block, &req));
+  return cl_validate_signed_beacon_block(ctx, signed_block, req);
+}
+
+// Lodestar `/eth/v0/beacon/proof/state/{state_id}` response. Kept local so it
+// does not leak into fork-agnostic beacon type dispatchers. Limits match
+// Lodestar `CompactMultiProofType` (packages/api/src/beacon/routes/proof.ts).
+static const ssz_def_t COMPACT_MULTI_PROOF_FIELDS[] = {
+    SSZ_LIST("leaves", ssz_bytes32, 10000),
+    SSZ_BYTES("descriptor", 2048)};
+static const ssz_def_t COMPACT_MULTI_PROOF_CONTAINER =
+    SSZ_CONTAINER("CompactMultiProof", COMPACT_MULTI_PROOF_FIELDS);
+
+#define CL_STATE_PROOF_MAX_DESCRIPTOR 2048u
+
+c4_status_t cl_get_state_proof(prover_ctx_t* ctx,
+                               bytes32_t     state_root,
+                               bytes_t       descriptor,
+                               ssz_ob_t*     leaves_out,
+                               ssz_ob_t*     descriptor_out) {
+  if (!ctx || !leaves_out || !descriptor_out) return C4_ERROR;
+  if (descriptor.len == 0 || descriptor.data == NULL)
+    THROW_ERROR("cl_get_state_proof: empty descriptor");
+  if (descriptor.len > CL_STATE_PROOF_MAX_DESCRIPTOR)
+    THROW_ERROR("cl_get_state_proof: descriptor exceeds max size");
+
+  char     path[128] = {0};
+  buffer_t query     = {0};
+  sbprintf(path, "eth/v0/beacon/proof/state/0x%x", bytes(state_root, 32));
+  bprintf(&query, "format=0x%x", descriptor);
+
+  ssz_ob_t    response = {0};
+  c4_status_t status   = c4_send_beacon_ssz_with_client_type(
+      ctx, path, (char*) query.data.data,
+      &COMPACT_MULTI_PROOF_CONTAINER, DEFAULT_TTL, &response,
+      BEACON_CLIENT_LODESTAR, NULL);
+  buffer_free(&query);
+  if (status != C4_SUCCESS) return status;
+
+  ssz_ob_t leaves_ob     = ssz_get(&response, "leaves");
+  ssz_ob_t descriptor_ob = ssz_get(&response, "descriptor");
+
+  if (descriptor_ob.bytes.len != descriptor.len ||
+      memcmp(descriptor_ob.bytes.data, descriptor.data, descriptor.len) != 0)
+    THROW_ERROR("cl_get_state_proof: response descriptor does not match request");
+
+  *leaves_out     = leaves_ob;
+  *descriptor_out = descriptor_ob;
+  return C4_SUCCESS;
+}

--- a/src/chains/eth/prover/cl_req.h
+++ b/src/chains/eth/prover/cl_req.h
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2025,2026 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef cl_req_h__
+#define cl_req_h__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "../util/bytes.h"
+#include "../util/json.h"
+#include "../util/ssz.h"
+#include "../util/state.h"
+#include "prover.h"
+
+// Bitmask-based beacon client types for feature detection
+#define BEACON_CLIENT_UNKNOWN    0x00000000
+#define BEACON_CLIENT_NIMBUS     0x00000001
+#define BEACON_CLIENT_LODESTAR   0x00000002
+#define BEACON_CLIENT_PRYSM      0x00000004
+#define BEACON_CLIENT_LIGHTHOUSE 0x00000008
+#define BEACON_CLIENT_TEKU       0x00000010
+#define BEACON_CLIENT_GRANDINE   0x00000020
+
+#define BEACON_SUPPORTS_LIGHTCLIENT_UPDATE   (BEACON_CLIENT_NIMBUS | BEACON_CLIENT_LODESTAR)
+#define BEACON_SUPPORTS_HISTORICAL_SUMMARIES (BEACON_CLIENT_NIMBUS | BEACON_CLIENT_LODESTAR)
+#define BEACON_SUPPORTS_DEBUG_ENDPOINTS      (BEACON_CLIENT_NIMBUS | BEACON_CLIENT_LIGHTHOUSE)
+#define BEACON_SUPPORTS_PARENT_ROOT_HEADERS  (BEACON_CLIENT_LODESTAR) // Nimbus: status-im/nimbus-eth2#7305
+#define BEACON_SUPPORTS_STATE_PROOF          (BEACON_CLIENT_LODESTAR) // /eth/v0/beacon/proof/state/{state_id}
+
+#ifndef DEFAULT_TTL
+#define DEFAULT_TTL (3600 * 24) // 1 day
+#endif
+
+/**
+ * `GET /eth/v1/beacon/states/head/finality_checkpoints`.
+ *
+ * On success `*result` is the inner `data` object (not the JSON-RPC envelope).
+ *
+ * @param ctx prover context
+ * @param result receives `data.{current_justified,finalized}`
+ * @return `C4_SUCCESS`, `C4_PENDING`, or `C4_ERROR`
+ */
+c4_status_t cl_get_finality_checkpoints(prover_ctx_t* ctx, json_t* result);
+
+/**
+ * `GET /eth/v1/beacon/headers?slot=`.
+ *
+ * A Nimbus/Lodestar empty-slot 404 becomes `JSON_TYPE_NOT_FOUND` instead of
+ * `C4_ERROR`.
+ *
+ * @param ctx prover context
+ * @param slot beacon slot to query
+ * @param result receives the list envelope, or `JSON_TYPE_NOT_FOUND`
+ * @return `C4_SUCCESS`, `C4_PENDING`, or `C4_ERROR`
+ */
+c4_status_t cl_get_headers_at_slot(prover_ctx_t* ctx, uint64_t slot, json_t* result);
+
+/**
+ * `GET /eth/v1/beacon/headers/{root}`.
+ *
+ * @param ctx prover context
+ * @param root 32-byte beacon block root
+ * @param result receives the full JSON envelope (`{data: {root, header, ...}}`)
+ * @return `C4_SUCCESS`, `C4_PENDING`, or `C4_ERROR`
+ */
+c4_status_t cl_get_header_by_root(prover_ctx_t* ctx, bytes32_t root, json_t* result);
+
+/**
+ * `GET /eth/v1/beacon/headers?parent_root=` (Lodestar).
+ *
+ * @param ctx prover context
+ * @param parent_root 32-byte parent block root
+ * @param result receives the list envelope
+ * @return `C4_SUCCESS`, `C4_PENDING`, or `C4_ERROR`
+ */
+c4_status_t cl_get_headers_by_parent_root(prover_ctx_t* ctx, bytes32_t parent_root, json_t* result);
+
+/**
+ * Header `message` from `GET /eth/v1/beacon/headers/{root}`.
+ *
+ * @param ctx prover context
+ * @param root 32-byte beacon block root
+ * @param message receives `data.header.message`
+ * @return `C4_SUCCESS`, `C4_PENDING`, or `C4_ERROR`
+ */
+c4_status_t cl_get_header_message_by_root(prover_ctx_t* ctx, bytes32_t root, json_t* message);
+
+/**
+ * Historical summaries for a beacon state root (Nimbus or Lodestar URL).
+ *
+ * @param ctx prover context
+ * @param state_root beacon state root
+ * @param history_proof receives the JSON envelope (`historical_summaries` + `proof`)
+ * @return `C4_SUCCESS`, `C4_PENDING`, or `C4_ERROR`
+ */
+c4_status_t cl_get_historical_summaries(prover_ctx_t* ctx, bytes_t state_root, json_t* history_proof);
+
+/**
+ * Fetch a `SignedBeaconBlock` as SSZ and validate it (`ssz_is_valid`).
+ *
+ * @param ctx prover context
+ * @param root 32-byte beacon block root, or NULL / all-zero to use `slot`
+ * @param slot used when `root` is missing; both missing fetches `head`
+ * @param signed_block output: validated signed container (not unwrapped)
+ * @return `C4_SUCCESS`, `C4_PENDING`, or `C4_ERROR`
+ */
+c4_status_t cl_fetch_signed_beacon_block(prover_ctx_t* ctx, const uint8_t* root, uint64_t slot, ssz_ob_t* signed_block);
+
+/**
+ * `GET /eth/v0/beacon/proof/state/{state_root}?format=0x...` (Lodestar).
+ *
+ * Fetches a `CompactMultiProof {leaves, descriptor}`. The echoed descriptor
+ * is compared to the request descriptor before return; reconstruction against
+ * `state_root` stays the caller's job (`c4_ssz_compact_to_branch` /
+ * `c4_ssz_compact_multi_extract`).
+ *
+ * `leaves_out` and `descriptor_out` point into the request response; do not free them.
+ *
+ * @param ctx prover context
+ * @param state_root 32-byte beacon state root
+ * @param descriptor compact-multi-proof descriptor (`format` query)
+ * @param leaves_out borrowed `leaves` list
+ * @param descriptor_out borrowed echoed descriptor
+ * @return `C4_SUCCESS`, `C4_PENDING`, or `C4_ERROR`
+ */
+c4_status_t cl_get_state_proof(prover_ctx_t* ctx,
+                               bytes32_t     state_root,
+                               bytes_t       descriptor,
+                               ssz_ob_t*     leaves_out,
+                               ssz_ob_t*     descriptor_out);
+
+/**
+ * Beacon SSZ GET without a validating wrapper.
+ *
+ * Prefer a `cl_*` helper. This remains public for light-client update lists
+ * (`def == NULL`, no list-level SSZ type yet; see #356). When `def` is set,
+ * `ssz_is_valid` runs once and `validated` is set.
+ *
+ * @param ctx prover context
+ * @param path beacon API path
+ * @param query optional query string; may be NULL
+ * @param def SSZ type for the body, or NULL to skip validation
+ * @param ttl cache TTL in seconds
+ * @param result receives `{.def, .bytes}` pointing at the request response
+ * @param req optional; receives the underlying `data_request_t*`
+ * @return `C4_SUCCESS`, `C4_PENDING`, or `C4_ERROR`
+ */
+c4_status_t c4_send_beacon_ssz(prover_ctx_t* ctx, char* path, char* query, const ssz_def_t* def, uint32_t ttl, ssz_ob_t* result, data_request_t** req);
+
+/**
+ * Non-throwing Beacon SSZ GET. Does not set `ctx->state.error`.
+ *
+ * On `C4_SUCCESS` read `(*out_req)->response`. No SSZ def is attached and no
+ * validation runs — the caller must validate (used for bootstrap 404 fallback).
+ *
+ * @param ctx prover context
+ * @param path beacon API path
+ * @param query optional query string; may be NULL
+ * @param ttl cache TTL in seconds
+ * @param out_req receives the `data_request_t*`; set on every return status
+ * @return `C4_SUCCESS`, `C4_PENDING`, or `C4_ERROR` (`out_req->error` on error)
+ */
+c4_status_t c4_send_beacon_ssz_no_throw(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, data_request_t** out_req);
+
+/**
+ * In-process server request (`C4_DATA_TYPE_INTERN`). No schema validation.
+ *
+ * Used for period-store / ZK / OP preconf bytes that are not untrusted RPC.
+ *
+ * @param ctx prover context
+ * @param path internal handler path
+ * @param query optional query string; may be NULL
+ * @param ttl cache TTL in seconds
+ * @param result receives a view of `req->response`; do not free
+ * @return `C4_SUCCESS`, `C4_PENDING`, or `C4_ERROR`
+ */
+c4_status_t c4_send_internal_request(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, bytes_t* result);
+
+/**
+ * Non-throwing variant of `c4_send_internal_request`. Does not set
+ * `ctx->state.error`. Used when a failed internal path should fall back
+ * (e.g. `lcu_updates` → beacon).
+ *
+ * @param ctx prover context
+ * @param path internal handler path
+ * @param query optional query string; may be NULL
+ * @param ttl cache TTL in seconds
+ * @param out_req receives the `data_request_t*`; set on every return status
+ * @return `C4_SUCCESS`, `C4_PENDING`, or `C4_ERROR` (`out_req->error` on error)
+ */
+c4_status_t c4_send_internal_request_no_throw(prover_ctx_t* ctx, char* path, char* query, uint32_t ttl, data_request_t** out_req);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/chains/eth/prover/eth_req.c
+++ b/src/chains/eth/prover/eth_req.c
@@ -22,7 +22,6 @@
  */
 
 #include "eth_req.h"
-#include "beacon.h"
 #include "beacon_types.h"
 #include "eth_compute_units.h"
 #include "eth_verify.h"
@@ -43,6 +42,14 @@
 
 static bool is_nullable_method(char* method) {
   return method && (strcmp(method, "eth_getTransactionByHash") == 0 || strcmp(method, "eth_getTransactionByBlockHashAndIndex") == 0 || strcmp(method, "eth_getTransactionByBlockNumberAndIndex") == 0 || strcmp(method, "eth_getTransactionReceipt") == 0);
+}
+
+/** Builds the JSON-RPC POST body and its request id. Caller owns `payload`. */
+static buffer_t eth_rpc_payload(char* method, char* params, bytes32_t id) {
+  buffer_t buffer = {0};
+  bprintf(&buffer, "{\"jsonrpc\":\"2.0\",\"method\":\"%s\",\"params\":%s,\"id\":1}", method, params);
+  sha256(buffer.data, id);
+  return buffer;
 }
 
 c4_status_t get_eth_tx(prover_ctx_t* ctx, json_t txhash, json_t* tx_data) {
@@ -94,6 +101,56 @@ c4_status_t eth_get_block(prover_ctx_t* ctx, json_t block, bool full_tx, json_t*
       CHECK_JSON(*result, JSON_BLOCK_HEADER_FIELDS, "Invalid results for Block: ");
     req->validated = true;
   }
+  return C4_SUCCESS;
+}
+
+c4_status_t eth_block_number(prover_ctx_t* ctx, uint64_t* number_out) {
+  data_request_t* req    = NULL;
+  json_t          result = {0};
+  c4_status_t     status = c4_send_eth_rpc(ctx, "eth_blockNumber", "[]", 0, &result, &req);
+  if (status != C4_SUCCESS) return status;
+  if (req && !req->validated) {
+    CHECK_JSON(result, "hexuint", "Invalid results for eth_blockNumber: ");
+    req->validated = true;
+  }
+  *number_out = json_as_uint64(result);
+  return C4_SUCCESS;
+}
+
+c4_status_t eth_debug_get_raw_block(prover_ctx_t* ctx, const uint8_t* block_hash, bytes_t* result) {
+  char            tmp[100] = {0};
+  data_request_t* req      = NULL;
+  json_t          json     = {0};
+  bytes32_t       id       = {0};
+  buffer_t        payload  = {0};
+
+  if (!block_hash) THROW_ERROR("debug_getRawBlock: missing block hash");
+  sbprintf(tmp, "[\"0x%x\"]", bytes((uint8_t*) block_hash, 32));
+  payload = eth_rpc_payload("debug_getRawBlock", tmp, id);
+  buffer_free(&payload);
+  req = c4_state_get_data_request_by_id(&ctx->state, id);
+  // After the first successful conversion `response` is raw RLP, not a JSON-RPC envelope.
+  if (req && req->validated) {
+    *result = req->response;
+    return C4_SUCCESS;
+  }
+
+  TRY_ASYNC(c4_send_eth_rpc(ctx, "debug_getRawBlock", tmp, DEFAULT_TTL, &json, &req));
+  if (req && !req->validated) {
+    CHECK_JSON(json, "bytes", "Invalid results for debug_getRawBlock: ");
+    uint32_t cap  = json.len / 2 + 1;
+    uint8_t* data = safe_malloc(cap);
+    uint32_t len  = json_to_bytes(json, bytes(data, cap));
+    if (!len) {
+      safe_free(data);
+      THROW_ERROR("Invalid results for debug_getRawBlock: empty block");
+    }
+    safe_free(req->response.data);
+    req->response  = bytes(data, len);
+    req->validated = true;
+  }
+  if (!req || !req->response.data) THROW_ERROR("debug_getRawBlock: missing response");
+  *result = req->response;
   return C4_SUCCESS;
 }
 
@@ -251,10 +308,8 @@ c4_status_t c4_send_eth_rpc(prover_ctx_t* ctx, char* method, char* params, uint3
   // the value reported by `eth_prover_execute` reflects the work the server had
   // to coordinate for this request, regardless of caching state.
   eth_cu_add(ctx, cu_for_eth_rpc_method(method));
-  bytes32_t id     = {0};
-  buffer_t  buffer = {0};
-  bprintf(&buffer, "{\"jsonrpc\":\"2.0\",\"method\":\"%s\",\"params\":%s,\"id\":1}", method, params);
-  sha256(buffer.data, id);
+  bytes32_t       id           = {0};
+  buffer_t        buffer       = eth_rpc_payload(method, params, id);
   data_request_t* data_request = c4_state_get_data_request_by_id(&ctx->state, id);
   if (data_request) {
     if (req) *req = data_request;

--- a/src/chains/eth/prover/eth_req.c
+++ b/src/chains/eth/prover/eth_req.c
@@ -85,10 +85,16 @@ c4_status_t eth_getBlockReceipts(prover_ctx_t* ctx, json_t block, json_t* receip
 }
 
 c4_status_t eth_get_block(prover_ctx_t* ctx, json_t block, bool full_tx, json_t* result) {
-  uint8_t  tmp[200] = {0};
-  buffer_t buffer   = stack_buffer(tmp);
-  return c4_send_eth_rpc(ctx, (char*) (block.len == 68 ? "eth_getBlockByHash" : "eth_getBlockByNumber"), bprintf(&buffer, "[%J,%s]", block, full_tx ? "true" : "false"), block.len == 68 ? DEFAULT_TTL : 12, result, NULL);
-  // TODO validate the json result
+  uint8_t         tmp[200] = {0};
+  buffer_t        buffer   = stack_buffer(tmp);
+  data_request_t* req      = NULL;
+  TRY_ASYNC(c4_send_eth_rpc(ctx, (char*) (block.len == 68 ? "eth_getBlockByHash" : "eth_getBlockByNumber"), bprintf(&buffer, "[%J,%s]", block, full_tx ? "true" : "false"), block.len == 68 ? DEFAULT_TTL : 12, result, &req));
+  if (req && !req->validated) {
+    if (result->type != JSON_TYPE_NULL)
+      CHECK_JSON(*result, JSON_BLOCK_HEADER_FIELDS, "Invalid results for Block: ");
+    req->validated = true;
+  }
+  return C4_SUCCESS;
 }
 
 c4_status_t eth_get_logs(prover_ctx_t* ctx, json_t params, json_t* logs) {

--- a/src/chains/eth/prover/eth_req.h
+++ b/src/chains/eth/prover/eth_req.h
@@ -32,6 +32,9 @@ extern "C" {
 #include "../verifier/eth_tx.h"
 #include "prover.h"
 
+/** Header fields read from `eth_getBlockBy*` results. Extra properties (e.g. `transactions`) are ignored. */
+#define JSON_BLOCK_HEADER_FIELDS "{number:hexuint,hash:bytes32,stateRoot:bytes32,receiptsRoot:bytes32,transactionsRoot:bytes32,logsBloom?:bytes,parentBeaconBlockRoot?:bytes32,slotNumber?:hexuint}"
+
 // get the eth transaction for the given hash
 c4_status_t get_eth_tx(prover_ctx_t* ctx, json_t txhash, json_t* tx_data);
 

--- a/src/chains/eth/prover/eth_req.h
+++ b/src/chains/eth/prover/eth_req.h
@@ -24,6 +24,10 @@
 #ifndef eth_req_h__
 #define eth_req_h__
 
+#ifndef DEFAULT_TTL
+#define DEFAULT_TTL (3600 * 24)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -49,6 +53,21 @@ c4_status_t eth_get_logs(prover_ctx_t* ctx, json_t params, json_t* logs);
 // get the block receipts for the given block
 c4_status_t eth_getBlockReceipts(prover_ctx_t* ctx, json_t block, json_t* receipts_array);
 c4_status_t eth_get_block(prover_ctx_t* ctx, json_t block, bool full_tx, json_t* result);
+c4_status_t eth_block_number(prover_ctx_t* ctx, uint64_t* number_out);
+/**
+ * Fetches a raw execution block via `debug_getRawBlock`.
+ *
+ * On first success the JSON-RPC hex result is decoded and stored in the request.
+ * `validated` on this request means `response` is already raw RLP (not a JSON
+ * envelope). Later calls reuse those bytes. The returned `bytes_t` is a view of
+ * that response; the prover state owns the memory.
+ *
+ * @param ctx prover context
+ * @param block_hash 32-byte execution block hash
+ * @param result receives the decoded raw block bytes
+ * @return `C4_SUCCESS`, `C4_PENDING`, or `C4_ERROR`
+ */
+c4_status_t eth_debug_get_raw_block(prover_ctx_t* ctx, const uint8_t* block_hash, bytes_t* result);
 // serialize the receipt for the given json using the buffer to allocate memory
 bytes_t c4_serialize_receipt(json_t r, buffer_t* buf);
 

--- a/src/chains/eth/prover/historic_proof.c
+++ b/src/chains/eth/prover/historic_proof.c
@@ -49,25 +49,7 @@ static const ssz_def_t SUMMARIES                    = SSZ_LIST("summaries", HIST
 static const ssz_def_t BLOCKS                       = SSZ_VECTOR("blocks", ssz_bytes32, 8192);
 
 static c4_status_t get_beacon_header(prover_ctx_t* ctx, bytes32_t block_hash, json_t* header) {
-
-  char     path[200]   = {0};
-  json_t   result      = {0};
-  buffer_t path_buffer = stack_buffer(path);
-  bprintf(&path_buffer, "eth/v1/beacon/headers/0x%x", bytes(block_hash, 32));
-
-  data_request_t* req = NULL;
-  TRY_ASYNC(c4_send_beacon_json(ctx, path, NULL, DEFAULT_TTL, &result, &req));
-  if (req && !req->validated) {
-    CHECK_JSON(result, JSON_BEACON_HEADER_OBJECT, "Invalid beacon header: ");
-    req->validated = true;
-  }
-
-  json_t val = json_get(result, "data");
-  if (val.type != JSON_TYPE_OBJECT) THROW_ERROR("Invalid header!");
-  val     = json_get(val, "header");
-  *header = json_get(val, "message");
-  if (!header->start) THROW_ERROR("Invalid header!");
-  return C4_SUCCESS;
+  return cl_get_header_message_by_root(ctx, block_hash, header);
 }
 
 static void verify_proof(char* name, bytes32_t leaf, bytes32_t root, bytes_t proof, gindex_t gindex) {
@@ -127,21 +109,7 @@ static c4_status_t check_historic_proof_header(prover_ctx_t* ctx, blockroot_proo
 }
 
 static c4_status_t get_historical_summaries(prover_ctx_t* ctx, eth_block_t* block, json_t* history_proof) {
-  if (ctx->state.error) return C4_ERROR;
-  uint8_t     tmp[200] = {0};
-  buffer_t    buf      = stack_buffer(tmp);
-  bytes_t     state    = ssz_get(&block->beacon.cl_header, "stateRoot").bytes;
-  bool        nimbus   = (ctx->flags & C4_PROVER_FLAG_NIMBUS) != 0;
-  const char* path     = nimbus ? "nimbus/v1/debug/beacon/states/0x%b/historical_summaries"
-                                : "eth/v1/lodestar/states/0x%b/historical_summaries";
-  uint32_t    client   = nimbus ? BEACON_CLIENT_NIMBUS : BEACON_CLIENT_LODESTAR;
-  data_request_t* req    = NULL;
-  c4_status_t     status = c4_send_beacon_json_with_client_type(ctx, bprintf(&buf, path, state), NULL, 120, history_proof, client, &req);
-  if (status == C4_SUCCESS && req && !req->validated) {
-    CHECK_JSON(*history_proof, JSON_BEACON_HISTORICAL_SUMMARIES, "Invalid historical summaries: ");
-    req->validated = true;
-  }
-  return status;
+  return cl_get_historical_summaries(ctx, ssz_get(&block->beacon.cl_header, "stateRoot").bytes, history_proof);
 }
 
 #ifdef TEST

--- a/src/chains/eth/prover/historic_proof.c
+++ b/src/chains/eth/prover/historic_proof.c
@@ -55,7 +55,12 @@ static c4_status_t get_beacon_header(prover_ctx_t* ctx, bytes32_t block_hash, js
   buffer_t path_buffer = stack_buffer(path);
   bprintf(&path_buffer, "eth/v1/beacon/headers/0x%x", bytes(block_hash, 32));
 
-  TRY_ASYNC(c4_send_beacon_json(ctx, path, NULL, DEFAULT_TTL, &result));
+  data_request_t* req = NULL;
+  TRY_ASYNC(c4_send_beacon_json(ctx, path, NULL, DEFAULT_TTL, &result, &req));
+  if (req && !req->validated) {
+    CHECK_JSON(result, JSON_BEACON_HEADER_OBJECT, "Invalid beacon header: ");
+    req->validated = true;
+  }
 
   json_t val = json_get(result, "data");
   if (val.type != JSON_TYPE_OBJECT) THROW_ERROR("Invalid header!");
@@ -130,7 +135,13 @@ static c4_status_t get_historical_summaries(prover_ctx_t* ctx, eth_block_t* bloc
   const char* path     = nimbus ? "nimbus/v1/debug/beacon/states/0x%b/historical_summaries"
                                 : "eth/v1/lodestar/states/0x%b/historical_summaries";
   uint32_t    client   = nimbus ? BEACON_CLIENT_NIMBUS : BEACON_CLIENT_LODESTAR;
-  return c4_send_beacon_json_with_client_type(ctx, bprintf(&buf, path, state), NULL, 120, history_proof, client);
+  data_request_t* req    = NULL;
+  c4_status_t     status = c4_send_beacon_json_with_client_type(ctx, bprintf(&buf, path, state), NULL, 120, history_proof, client, &req);
+  if (status == C4_SUCCESS && req && !req->validated) {
+    CHECK_JSON(*history_proof, JSON_BEACON_HISTORICAL_SUMMARIES, "Invalid historical summaries: ");
+    req->validated = true;
+  }
+  return status;
 }
 
 #ifdef TEST
@@ -279,14 +290,17 @@ void c4_free_block_proof(blockroot_proof_t* block_proof) {
 // Wraps a raw bootstrap SSZ blob in a typed ssz_ob_t after fork detection +
 // SSZ validation. Used for both the primary (beacon-served) and fallback
 // (self-built) paths so the two share exactly the same validation.
-static c4_status_t decode_bootstrap_bytes(prover_ctx_t* ctx, bytes_t raw, ssz_ob_t* out_bootstrap) {
+static c4_status_t decode_bootstrap_bytes(prover_ctx_t* ctx, bytes_t raw, ssz_ob_t* out_bootstrap, data_request_t* req) {
   ssz_ob_t  result = {.bytes = raw, .def = NULL};
   fork_id_t fork   = c4_eth_get_fork_for_lcu(ctx->chain_id, result.bytes);
   if (fork == 0) THROW_ERROR("Invalid bootstrap data: cannot determine fork!");
   // Single source of truth for fork -> bootstrap container mapping.
   result.def = eth_get_light_client_bootstrap(fork);
   if (!result.def) THROW_ERROR("Invalid bootstrap data: unsupported fork!");
-  if (!ssz_is_valid(result, true, &ctx->state)) THROW_ERROR("Invalid bootstrap data!");
+  if (!(req && req->validated)) {
+    if (!ssz_is_valid(result, true, &ctx->state)) THROW_ERROR("Invalid bootstrap data!");
+    if (req) req->validated = true;
+  }
   *out_bootstrap = result;
   return C4_SUCCESS;
 }
@@ -323,7 +337,7 @@ static c4_status_t fetch_bootstrap_by_root(prover_ctx_t* ctx, bytes32_t header_r
   //    "fallback marker" bookkeeping.
   bytes_t cached_fallback = c4_state_cache_get(&ctx->state, fallback_key);
   if (cached_fallback.data)
-    return decode_bootstrap_bytes(ctx, cached_fallback, out_bootstrap);
+    return decode_bootstrap_bytes(ctx, cached_fallback, out_bootstrap, NULL);
 
   // 2) Try the primary beacon endpoint. Use the non-throwing variant so a
   //    404 / regen error does not abort the whole prover run -- we want to
@@ -336,7 +350,7 @@ static c4_status_t fetch_bootstrap_by_root(prover_ctx_t* ctx, bytes32_t header_r
   data_request_t* primary_req = NULL;
   c4_status_t     st          = c4_send_beacon_ssz_no_throw(ctx, path, NULL, DEFAULT_TTL, &primary_req);
   if (st == C4_PENDING) return C4_PENDING;
-  if (st == C4_SUCCESS) return decode_bootstrap_bytes(ctx, primary_req->response, out_bootstrap);
+  if (st == C4_SUCCESS) return decode_bootstrap_bytes(ctx, primary_req->response, out_bootstrap, primary_req);
 
   // st == C4_ERROR: the request layer left `ctx->state.error` untouched, so
   // we can decide locally whether to fall back or to surface the error.
@@ -357,7 +371,7 @@ static c4_status_t fetch_bootstrap_by_root(prover_ctx_t* ctx, bytes32_t header_r
   //    the prover context. `c4_state_cache_set` takes ownership of
   //    `built_ssz.data`.
   bytes_t cached = c4_state_cache_set(&ctx->state, fallback_key, built_ssz);
-  return decode_bootstrap_bytes(ctx, cached, out_bootstrap);
+  return decode_bootstrap_bytes(ctx, cached, out_bootstrap, NULL);
 }
 
 static c4_status_t fetch_bootstrap_data(prover_ctx_t* ctx, syncdata_state_t* sync_data, ssz_ob_t* bootstrap) {
@@ -460,7 +474,7 @@ c4_status_t c4_fetch_client_updates(prover_ctx_t* ctx, uint64_t start_period, ui
   }
 
   ssz_ob_t result = {0};
-  TRY_ASYNC(c4_send_beacon_ssz(ctx, "eth/v1/beacon/light_client/updates", query, NULL, DEFAULT_TTL, &result));
+  TRY_ASYNC(c4_send_beacon_ssz(ctx, "eth/v1/beacon/light_client/updates", query, NULL, DEFAULT_TTL, &result, NULL));
   *out_data = result.bytes;
   return C4_SUCCESS;
 }

--- a/src/chains/eth/prover/lcu_gloas.c
+++ b/src/chains/eth/prover/lcu_gloas.c
@@ -303,7 +303,7 @@ c4_status_t c4_create_gloas_lcu(prover_ctx_t* ctx,
 
   ssz_ob_t    sc_leaves_ob     = {0};
   ssz_ob_t    sc_descriptor_ob = {0};
-  c4_status_t status           = c4_state_proofs_beacon_fetch(
+  c4_status_t status           = cl_get_state_proof(
       ctx, attested_state_root, sc_descriptor,
       &sc_leaves_ob, &sc_descriptor_ob);
   safe_free(sc_descriptor.data);
@@ -439,7 +439,7 @@ c4_status_t c4_create_gloas_lcu(prover_ctx_t* ctx,
     THROW_ERROR("c4_create_gloas_lcu: SSZ assembly failed");
 
   // Account for the reconstruction cost. Per-request CU was already charged
-  // by c4_state_proofs_beacon_fetch -> c4_send_beacon_ssz_*.
+  // by cl_get_state_proof -> c4_send_beacon_ssz_*.
   eth_cu_add_proof(ctx);
 
   *out_lcu_ssz = lcu;

--- a/src/chains/eth/prover/proof_witness.c
+++ b/src/chains/eth/prover/proof_witness.c
@@ -59,12 +59,8 @@ static c4_status_t c4_proof_witness_blockhash(prover_ctx_t* ctx, json_t block_nu
   buffer_t buffer   = stack_buffer(tmp);
   json_t   result   = {0};
 
-  data_request_t* req = NULL;
-  TRY_ASYNC(c4_send_eth_rpc(ctx, block_number.len == 68 ? "eth_getBlockByHash" : "eth_getBlockByNumber", bprintf(&buffer, "[%J,false]", block_number), block_number.len == 68 ? DEFAULT_TTL : 12, &result, &req));
-  if (req && !req->validated) {
-    CHECK_JSON(result, JSON_BLOCK_HEADER_FIELDS, "Invalid results for Block: ");
-    req->validated = true;
-  }
+  TRY_ASYNC(eth_get_block(ctx, block_number, false, &result));
+  if (result.type == JSON_TYPE_NULL) THROW_ERROR_WITH("Block not found: %j", block_number);
 
   ssz_builder_t witness = ssz_builder_for_def(c4_witness_get_def(C4_BLOCK_HASH_WITNESS_ID));
   ssz_add_uint64(&witness, ctx->chain_id);

--- a/src/chains/eth/prover/proof_witness.c
+++ b/src/chains/eth/prover/proof_witness.c
@@ -59,7 +59,12 @@ static c4_status_t c4_proof_witness_blockhash(prover_ctx_t* ctx, json_t block_nu
   buffer_t buffer   = stack_buffer(tmp);
   json_t   result   = {0};
 
-  TRY_ASYNC(c4_send_eth_rpc(ctx, block_number.len == 68 ? "eth_getBlockByHash" : "eth_getBlockByNumber", bprintf(&buffer, "[%J,false]", block_number), block_number.len == 68 ? DEFAULT_TTL : 12, &result, NULL));
+  data_request_t* req = NULL;
+  TRY_ASYNC(c4_send_eth_rpc(ctx, block_number.len == 68 ? "eth_getBlockByHash" : "eth_getBlockByNumber", bprintf(&buffer, "[%J,false]", block_number), block_number.len == 68 ? DEFAULT_TTL : 12, &result, &req));
+  if (req && !req->validated) {
+    CHECK_JSON(result, JSON_BLOCK_HEADER_FIELDS, "Invalid results for Block: ");
+    req->validated = true;
+  }
 
   ssz_builder_t witness = ssz_builder_for_def(c4_witness_get_def(C4_BLOCK_HASH_WITNESS_ID));
   ssz_add_uint64(&witness, ctx->chain_id);

--- a/src/chains/eth/prover/state_proofs.c
+++ b/src/chains/eth/prover/state_proofs.c
@@ -28,16 +28,6 @@
 #include <stddef.h>
 #include <string.h>
 
-// SSZ type of the response returned by Lodestar's
-// `/eth/v0/beacon/proof/state/{state_id}` endpoint. Kept local so it does not
-// leak into fork-agnostic beacon type dispatchers. Limits mirror Lodestar
-// (`CompactMultiProofType` in packages/api/src/beacon/routes/proof.ts).
-static const ssz_def_t COMPACT_MULTI_PROOF_FIELDS[] = {
-    SSZ_LIST("leaves", ssz_bytes32, 10000),
-    SSZ_BYTES("descriptor", 2048)};
-static const ssz_def_t COMPACT_MULTI_PROOF_CONTAINER =
-    SSZ_CONTAINER("CompactMultiProof", COMPACT_MULTI_PROOF_FIELDS);
-
 // :: Internal helpers
 
 typedef struct {
@@ -531,48 +521,6 @@ bool c4_ssz_compact_to_branch(bytes_t   leaves,
 
 // :: Public API
 
-c4_status_t c4_state_proofs_beacon_fetch(prover_ctx_t* ctx,
-                                         bytes32_t     state_root,
-                                         bytes_t       descriptor,
-                                         ssz_ob_t*     leaves_out,
-                                         ssz_ob_t*     descriptor_out) {
-  if (!ctx || !leaves_out || !descriptor_out) return C4_ERROR;
-  if (descriptor.len == 0 || descriptor.data == NULL)
-    THROW_ERROR("c4_state_proofs_beacon_fetch: empty descriptor");
-  // Bound the outbound descriptor to the same size limit we enforce on the
-  // response side. Prevents runaway `bprintf` growth if a future caller passes
-  // an unvalidated descriptor (defense-in-depth against DoS / memory bomb).
-  if (descriptor.len > MAX_DESCRIPTOR_BYTES)
-    THROW_ERROR("c4_state_proofs_beacon_fetch: descriptor exceeds max size");
-
-  char     path[128] = {0};
-  buffer_t query     = {0};
-  sbprintf(path, "eth/v0/beacon/proof/state/0x%x", bytes(state_root, 32));
-  bprintf(&query, "format=0x%x", descriptor);
-
-  ssz_ob_t    response = {0};
-  c4_status_t status   = c4_send_beacon_ssz_with_client_type(
-      ctx, path, (char*) query.data.data,
-      &COMPACT_MULTI_PROOF_CONTAINER, DEFAULT_TTL, &response,
-      BEACON_CLIENT_LODESTAR, NULL);
-  buffer_free(&query);
-  if (status != C4_SUCCESS) return status;
-
-  ssz_ob_t leaves_ob     = ssz_get(&response, "leaves");
-  ssz_ob_t descriptor_ob = ssz_get(&response, "descriptor");
-
-  // Defense-in-depth: the response descriptor must exactly match what we
-  // asked for. The root check downstream is still the primary anchor of trust,
-  // but bailing out early on a descriptor mismatch gives a clearer error path.
-  if (descriptor_ob.bytes.len != descriptor.len ||
-      memcmp(descriptor_ob.bytes.data, descriptor.data, descriptor.len) != 0)
-    THROW_ERROR("c4_state_proofs_beacon_fetch: response descriptor does not match request");
-
-  *leaves_out     = leaves_ob;
-  *descriptor_out = descriptor_ob;
-  return C4_SUCCESS;
-}
-
 c4_status_t c4_create_state_proof(prover_ctx_t* ctx,
                                   bytes32_t     state_root,
                                   gindex_t      gindex,
@@ -588,8 +536,8 @@ c4_status_t c4_create_state_proof(prover_ctx_t* ctx,
   ssz_ob_t leaves_ob     = {0};
   ssz_ob_t descriptor_ob = {0};
 
-  c4_status_t status = c4_state_proofs_beacon_fetch(ctx, state_root, descriptor,
-                                                    &leaves_ob, &descriptor_ob);
+  c4_status_t status = cl_get_state_proof(ctx, state_root, descriptor,
+                                          &leaves_ob, &descriptor_ob);
   safe_free(descriptor.data);
   if (status != C4_SUCCESS) return status;
 

--- a/src/chains/eth/prover/state_proofs.c
+++ b/src/chains/eth/prover/state_proofs.c
@@ -554,7 +554,7 @@ c4_status_t c4_state_proofs_beacon_fetch(prover_ctx_t* ctx,
   c4_status_t status   = c4_send_beacon_ssz_with_client_type(
       ctx, path, (char*) query.data.data,
       &COMPACT_MULTI_PROOF_CONTAINER, DEFAULT_TTL, &response,
-      BEACON_CLIENT_LODESTAR);
+      BEACON_CLIENT_LODESTAR, NULL);
   buffer_free(&query);
   if (status != C4_SUCCESS) return status;
 

--- a/src/chains/eth/prover/state_proofs.h
+++ b/src/chains/eth/prover/state_proofs.h
@@ -32,35 +32,6 @@ extern "C" {
 #include "ssz.h"
 
 /**
- * Issues a Lodestar `CompactMultiProof` state-proof request against
- * `state_root` with the given caller-supplied `descriptor`, and returns the
- * SSZ objects of the response's `leaves` list and its echoed `descriptor`.
- *
- * The echoed descriptor is byte-checked against the request descriptor as a
- * defense-in-depth guard before returning; the reconstruction root check is
- * still the primary anchor of trust.
- *
- * Async: may return `C4_PENDING`; the caller must retry after fulfilling the
- * pending data request. Requests are routed to Lodestar
- * (`BEACON_CLIENT_LODESTAR`).
- *
- * `leaves_out` and `descriptor_out` point into the response cache and must
- * not be freed by the caller.
- *
- * @param ctx prover context
- * @param state_root the anchor beacon-state root
- * @param descriptor caller-computed compact-multi-proof descriptor bitlist
- * @param leaves_out on success, borrowed `leaves` ssz_ob_t
- * @param descriptor_out on success, borrowed `descriptor` ssz_ob_t
- * @return `C4_SUCCESS`, `C4_PENDING`, or `C4_ERROR`
- */
-c4_status_t c4_state_proofs_beacon_fetch(prover_ctx_t* ctx,
-                                         bytes32_t     state_root,
-                                         bytes_t       descriptor,
-                                         ssz_ob_t*     leaves_out,
-                                         ssz_ob_t*     descriptor_out);
-
-/**
  * Fetches a classical Merkle branch for a `BeaconState` field via Lodestar's
  * unofficial `/eth/v0/beacon/proof/state/{state_id}` endpoint.
  *

--- a/src/chains/eth/server/head_update.c
+++ b/src/chains/eth/server/head_update.c
@@ -115,8 +115,13 @@ static c4_status_t handle_head(prover_ctx_t* ctx, beacon_head_t* b) {
 
   if (c4_watcher_check_block_number) {
     // run request to fetch the blocknumber from the execution node to make sure the execution node is cabable of handling the latest block.
-    c4_status_t latest_status = c4_send_eth_rpc(ctx, "eth_blockNumber", "[]", 0, &latest_block, NULL);
+    data_request_t* req           = NULL;
+    c4_status_t     latest_status = c4_send_eth_rpc(ctx, "eth_blockNumber", "[]", 0, &latest_block, &req);
     if (latest_status == C4_PENDING && ctx->state.requests->type == C4_DATA_TYPE_ETH_RPC) ctx->state.requests->node_exclude_mask = (uint16_t) (0xFFFF - 1); // exclude all, but the first node, because we always wnat to get the latest from the first.
+    if (latest_status == C4_SUCCESS && req && !req->validated) {
+      CHECK_JSON(latest_block, "hexuint", "Invalid results for eth_blockNumber: ");
+      req->validated = true;
+    }
     TRY_ADD_ASYNC(status, latest_status);
   }
   TRY_ASYNC(status);

--- a/src/chains/eth/server/head_update.c
+++ b/src/chains/eth/server/head_update.c
@@ -105,7 +105,7 @@ static c4_status_t handle_head(prover_ctx_t* ctx, beacon_head_t* b) {
   char        tmp2[300]    = {0};
   bytes_t     block_roots  = {0};
   bytes_t     lcu          = {0};
-  json_t      latest_block = {0};
+  uint64_t    latest_block = 0;
   ssz_ob_t    sig_block    = {0};
   ssz_ob_t    data_block   = {0};
   bytes32_t   data_root    = {0};
@@ -115,13 +115,8 @@ static c4_status_t handle_head(prover_ctx_t* ctx, beacon_head_t* b) {
 
   if (c4_watcher_check_block_number) {
     // run request to fetch the blocknumber from the execution node to make sure the execution node is cabable of handling the latest block.
-    data_request_t* req           = NULL;
-    c4_status_t     latest_status = c4_send_eth_rpc(ctx, "eth_blockNumber", "[]", 0, &latest_block, &req);
+    c4_status_t latest_status = eth_block_number(ctx, &latest_block);
     if (latest_status == C4_PENDING && ctx->state.requests->type == C4_DATA_TYPE_ETH_RPC) ctx->state.requests->node_exclude_mask = (uint16_t) (0xFFFF - 1); // exclude all, but the first node, because we always wnat to get the latest from the first.
-    if (latest_status == C4_SUCCESS && req && !req->validated) {
-      CHECK_JSON(latest_block, "hexuint", "Invalid results for eth_blockNumber: ");
-      req->validated = true;
-    }
     TRY_ADD_ASYNC(status, latest_status);
   }
   TRY_ASYNC(status);
@@ -134,7 +129,7 @@ static c4_status_t handle_head(prover_ctx_t* ctx, beacon_head_t* b) {
   c4_beacon_cache_update_blockdata(ctx, &beacon_block, c4_watcher_check_block_number ? 0 : timestamp, beacon_block.beacon.sign_parent_root);
 
   // now set the latest block number
-  uint64_t latest_block_number = min64(beacon_block_number, c4_watcher_check_block_number ? json_as_uint64(latest_block) : beacon_block_number);
+  uint64_t latest_block_number = min64(beacon_block_number, c4_watcher_check_block_number ? latest_block : beacon_block_number);
   if (latest_block_number && c4_watcher_check_block_number)
     TRY_ASYNC(c4_set_latest_block(ctx, latest_block_number));
 

--- a/src/chains/eth/verifier/call_ctx.c
+++ b/src/chains/eth/verifier/call_ctx.c
@@ -27,9 +27,12 @@
 #include "eth_account.h"
 #include "eth_verify.h"
 #include "plugin.h"
+#include "state.h"
 #include "state_overrides.h"
 #include <stdlib.h>
 #include <string.h>
+
+#define JSON_ETH_PROOF_FIELDS "{accountProof:[bytes],storageProof:[{key:hex32,value:hexuint,proof:[bytes]}],balance:hexuint,codeHash:bytes32,nonce:hexuint,storageHash:bytes32}"
 
 // :: Account lookup helpers (traverse parent chain)
 
@@ -153,7 +156,13 @@ void call_account_lazy_fetch_storage(evmone_context_t* ctx, const address_t addr
         c4_state_add_error(&ctx->ctx->state, "oblivious eth_getProof returned an error");
         return;
       }
-      json_t proof_item = json_get(json_at(json_get(json_get(response, "result"), "storageProof"), 0), "value");
+      json_t proof_result = json_get(response, "result");
+      if (!req->validated) {
+        if (c4_check_json_inline(&ctx->ctx->state, proof_result, JSON_ETH_PROOF_FIELDS, "Invalid results for eth_getProof: ") != C4_SUCCESS)
+          return;
+        req->validated = true;
+      }
+      json_t proof_item = json_get(json_at(json_get(proof_result, "storageProof"), 0), "value");
       if (proof_item.type == JSON_TYPE_STRING) {
         buffer_t val_buf = stack_buffer(val);
         bytes_t  b       = json_as_bytes(proof_item, &val_buf);
@@ -167,6 +176,11 @@ void call_account_lazy_fetch_storage(evmone_context_t* ctx, const address_t addr
     }
     else {
       json_t val_json = json_get(response, "result");
+      if (!req->validated) {
+        if (c4_check_json_inline(&ctx->ctx->state, val_json, "hex32", "Invalid results for eth_getStorageAt: ") != C4_SUCCESS)
+          return;
+        req->validated = true;
+      }
       if (val_json.type == JSON_TYPE_STRING) {
         buffer_t val_buf = stack_buffer(val);
         bytes_t  b       = json_as_bytes(val_json, &val_buf);

--- a/src/chains/eth/verifier/eth_account.c
+++ b/src/chains/eth/verifier/eth_account.c
@@ -144,7 +144,12 @@ INTERNAL c4_status_t eth_fetch_account_code(verify_ctx_t* ctx, call_account_t* a
   data_request_t* req = c4_state_get_data_request_by_id(&ctx->state, hash);
   if (req && req->response.data) {
     buffer_reset(&buf);
-    json_t result = json_get(json_parse((char*) req->response.data), "result");
+    json_t response = json_parse((char*) req->response.data);
+    json_t result   = json_get(response, "result");
+    if (!req->validated) {
+      CHECK_JSON(result, "bytes", "Invalid results for Code: ");
+      req->validated = true;
+    }
     if (result.type == JSON_TYPE_STRING) {
       buffer_t code_data = {0};
       ac->code           = json_as_bytes(result, &code_data);

--- a/src/chains/eth/verifier/sync_committee.c
+++ b/src/chains/eth/verifier/sync_committee.c
@@ -527,13 +527,13 @@ static bool detect_update_format(bytes_t data) {
  * @return true if all updates were processed successfully, false otherwise
  */
 INTERNAL bool c4_process_light_client_updates(verify_ctx_t* ctx, bytes_t light_client_updates, bool (*process_update)(verify_ctx_t*, ssz_ob_t*)) {
-  uint64_t        length     = 0;
-  bool            success    = true;
-  bool            lighthouse = detect_update_format(light_client_updates);
-  int             idx        = 0;
-  data_request_t* src_req    = c4_state_get_data_request_by_response(&ctx->state, light_client_updates);
-  bool            skip_ssz   = src_req && src_req->validated;
+  uint64_t length     = 0;
+  bool     success    = true;
+  bool     lighthouse = detect_update_format(light_client_updates);
+  int      idx        = 0;
 
+  // Per-update ssz_is_valid only. The enclosing list request stays
+  // unvalidated until a list-level check exists.
   for (uint32_t pos = 0; pos + UPDATE_PREFIX_SIZE < light_client_updates.len; pos += length + SSZ_LENGTH_SIZE, idx++) {
     uint32_t data_offset        = pos + SSZ_LENGTH_SIZE + SSZ_OFFSET_SIZE;
     uint32_t data_length_offset = SSZ_OFFSET_SIZE;
@@ -575,7 +575,7 @@ INTERNAL bool c4_process_light_client_updates(verify_ctx_t* ctx, bytes_t light_c
 
     ssz_ob_t light_client_update_ob = {.bytes = light_client_update_bytes, .def = light_client_update_def};
 
-    if (!skip_ssz && !ssz_is_valid(light_client_update_ob, true, &ctx->state)) {
+    if (!ssz_is_valid(light_client_update_ob, true, &ctx->state)) {
       success = false;
       c4_state_add_error(&ctx->state, "Invalid SSZ structure in light client update");
       break;
@@ -588,7 +588,6 @@ INTERNAL bool c4_process_light_client_updates(verify_ctx_t* ctx, bytes_t light_c
     }
   }
 
-  if (success && src_req) src_req->validated = true;
   return success;
 }
 

--- a/src/chains/eth/verifier/sync_committee.c
+++ b/src/chains/eth/verifier/sync_committee.c
@@ -527,10 +527,12 @@ static bool detect_update_format(bytes_t data) {
  * @return true if all updates were processed successfully, false otherwise
  */
 INTERNAL bool c4_process_light_client_updates(verify_ctx_t* ctx, bytes_t light_client_updates, bool (*process_update)(verify_ctx_t*, ssz_ob_t*)) {
-  uint64_t length     = 0;
-  bool     success    = true;
-  bool     lighthouse = detect_update_format(light_client_updates);
-  int      idx        = 0;
+  uint64_t        length     = 0;
+  bool            success    = true;
+  bool            lighthouse = detect_update_format(light_client_updates);
+  int             idx        = 0;
+  data_request_t* src_req    = c4_state_get_data_request_by_response(&ctx->state, light_client_updates);
+  bool            skip_ssz   = src_req && src_req->validated;
 
   for (uint32_t pos = 0; pos + UPDATE_PREFIX_SIZE < light_client_updates.len; pos += length + SSZ_LENGTH_SIZE, idx++) {
     uint32_t data_offset        = pos + SSZ_LENGTH_SIZE + SSZ_OFFSET_SIZE;
@@ -573,8 +575,7 @@ INTERNAL bool c4_process_light_client_updates(verify_ctx_t* ctx, bytes_t light_c
 
     ssz_ob_t light_client_update_ob = {.bytes = light_client_update_bytes, .def = light_client_update_def};
 
-    // Validate SSZ structure (checks offsets and ensures all properties exist)
-    if (!ssz_is_valid(light_client_update_ob, true, &ctx->state)) {
+    if (!skip_ssz && !ssz_is_valid(light_client_update_ob, true, &ctx->state)) {
       success = false;
       c4_state_add_error(&ctx->state, "Invalid SSZ structure in light client update");
       break;
@@ -587,6 +588,7 @@ INTERNAL bool c4_process_light_client_updates(verify_ctx_t* ctx, bytes_t light_c
     }
   }
 
+  if (success && src_req) src_req->validated = true;
   return success;
 }
 

--- a/src/chains/eth/verifier/sync_committee_state.c
+++ b/src/chains/eth/verifier/sync_committee_state.c
@@ -243,10 +243,13 @@ bool c4_req_checkpointz_status(c4_state_t* state, chain_id_t chain_id, uint64_t*
       // generic `string` (not `bytes32`) because some Beacon API providers emit block
       // roots WITHOUT the `0x` prefix; `json_as_bytes` -> `hex_to_bytes` accepts both,
       // we just enforce the 32-byte length after decoding.
-      const char* err = json_validate(res, "{data:{finalized:{epoch:suint,root:string}}}", "finality checkpoints");
-      if (err) {
-        c4_state_add_error(state, err);
-        return false;
+      if (!req->validated) {
+        const char* err = json_validate(res, "{data:{finalized:{epoch:suint,root:string}}}", "finality checkpoints");
+        if (err) {
+          c4_state_add_error(state, err);
+          return false;
+        }
+        req->validated = true;
       }
 
       json_t data      = json_get(res, "data");
@@ -327,9 +330,12 @@ c4_status_t c4_handle_bootstrap(verify_ctx_t* ctx, bytes_t bootstrap_data, bytes
   ssz_ob_t  bootstrap             = {.bytes = bootstrap_data, .def = bootstrap_def};
   bytes32_t previous_pubkeys_hash = {0}; // in case of a bootstrap, there is no previous pubkey hash, so we set it to 0
 
-  // Validate SSZ structure (checks offsets and ensures all properties exist)
-  if (!ssz_is_valid(bootstrap, true, &ctx->state))
-    THROW_ERROR("Invalid SSZ structure in bootstrap data");
+  data_request_t* src_req = c4_state_get_data_request_by_response(&ctx->state, bootstrap_data);
+  if (!(src_req && src_req->validated)) {
+    if (!ssz_is_valid(bootstrap, true, &ctx->state))
+      THROW_ERROR("Invalid SSZ structure in bootstrap data");
+    if (src_req) src_req->validated = true;
+  }
 
   // Extract components (no need for ssz_is_error checks after validation)
   ssz_ob_t header                 = ssz_get(&bootstrap, "header");
@@ -758,7 +764,10 @@ INTERNAL c4_status_t c4_verify_checkpointz_root(verify_ctx_t* ctx, uint64_t slot
   // `json_as_bytes`) accepts both variants, so we just need to enforce the 32-byte
   // length after decoding.
   json_t res = json_parse((char*) req->response.data);
-  CHECK_JSON(res, "{data:{root:string}}", "checkpointz response");
+  if (!req->validated) {
+    CHECK_JSON(res, "{data:{root:string}}", "checkpointz response");
+    req->validated = true;
+  }
 
   bytes32_t checkpointz_root = {0};
   buffer_t  root_buf         = stack_buffer(checkpointz_root);
@@ -857,10 +866,14 @@ static c4_status_t c4_check_weak_subjectivity(verify_ctx_t* ctx, c4_sync_validat
     clear_sync_state(ctx->chain_id);
     return c4_state_add_error(&ctx->state, "WSP bootstrap: unsupported fork");
   }
-  ssz_ob_t bootstrap = {.bytes = bootstrap_data, .def = bootstrap_def};
-  if (!ssz_is_valid(bootstrap, true, &ctx->state)) {
-    clear_sync_state(ctx->chain_id);
-    return c4_state_add_error(&ctx->state, "WSP bootstrap: invalid SSZ structure");
+  ssz_ob_t        bootstrap = {.bytes = bootstrap_data, .def = bootstrap_def};
+  data_request_t* src_req   = c4_state_get_data_request_by_response(&ctx->state, bootstrap_data);
+  if (!(src_req && src_req->validated)) {
+    if (!ssz_is_valid(bootstrap, true, &ctx->state)) {
+      clear_sync_state(ctx->chain_id);
+      return c4_state_add_error(&ctx->state, "WSP bootstrap: invalid SSZ structure");
+    }
+    if (src_req) src_req->validated = true;
   }
 
   ssz_ob_t header                 = ssz_get(&bootstrap, "header");
@@ -1029,7 +1042,13 @@ static c4_status_t c4_try_sync_from_next_period(verify_ctx_t* ctx, uint32_t peri
 
     uint64_t length                    = uint64_from_le(light_client_update.data + offset);
     bytes_t  light_client_update_bytes = bytes(light_client_update.data + offset + UPDATE_PREFIX_SIZE, length - SSZ_OFFSET_SIZE);
-    ssz_ob_t update_ob                 = {.bytes = light_client_update_bytes, .def = client_update_def};
+    ssz_ob_t        update_ob = {.bytes = light_client_update_bytes, .def = client_update_def};
+    data_request_t* src_req   = c4_state_get_data_request_by_response(&ctx->state, light_client_update);
+    if (!(src_req && src_req->validated)) {
+      if (!ssz_is_valid(update_ob, true, &ctx->state))
+        THROW_ERROR("Invalid SSZ structure in light client update");
+      if (src_req) src_req->validated = true;
+    }
 
     // Step 4: Extract nextSyncCommittee from the update (this is period N+1's committee in period N's update)
     ssz_ob_t next_sync_committee = ssz_get(&update_ob, "nextSyncCommittee");

--- a/src/chains/eth/verifier/sync_committee_state.c
+++ b/src/chains/eth/verifier/sync_committee_state.c
@@ -1042,13 +1042,11 @@ static c4_status_t c4_try_sync_from_next_period(verify_ctx_t* ctx, uint32_t peri
 
     uint64_t length                    = uint64_from_le(light_client_update.data + offset);
     bytes_t  light_client_update_bytes = bytes(light_client_update.data + offset + UPDATE_PREFIX_SIZE, length - SSZ_OFFSET_SIZE);
-    ssz_ob_t        update_ob = {.bytes = light_client_update_bytes, .def = client_update_def};
-    data_request_t* src_req   = c4_state_get_data_request_by_response(&ctx->state, light_client_update);
-    if (!(src_req && src_req->validated)) {
-      if (!ssz_is_valid(update_ob, true, &ctx->state))
-        THROW_ERROR("Invalid SSZ structure in light client update");
-      if (src_req) src_req->validated = true;
-    }
+    ssz_ob_t update_ob                 = {.bytes = light_client_update_bytes, .def = client_update_def};
+    // One item is not the enclosing list. Leave the list request unvalidated
+    // until a list-level SSZ check exists.
+    if (!ssz_is_valid(update_ob, true, &ctx->state))
+      THROW_ERROR("Invalid SSZ structure in light client update");
 
     // Step 4: Extract nextSyncCommittee from the update (this is period N+1's committee in period N's update)
     ssz_ob_t next_sync_committee = ssz_get(&update_ob, "nextSyncCommittee");

--- a/src/chains/eth/verifier/verify_call.c
+++ b/src/chains/eth/verifier/verify_call.c
@@ -642,6 +642,7 @@ static bool proof_call(verify_ctx_t* ctx, evm_call_ctx_t* evm) {
     buffer_free(&payload);
     bool result = pap_verify_proof_response(ctx, evm->accounts, req->response, &values_changed);
     if (!result) return false;
+    req->validated = true;
     if (values_changed) {
       evm->evm_done = false; // we need to repeat with the updates values
       return true;

--- a/src/chains/eth/verifier/verify_pap_tx.c
+++ b/src/chains/eth/verifier/verify_pap_tx.c
@@ -75,11 +75,13 @@ static c4_status_t fetch_tx_cache_from_server(verify_ctx_t* ctx) {
   if (response.len > PAP_TX_CACHE_MAX_SSZ_SIZE)
     THROW_ERROR("PAP: tx_cache response exceeds size limit");
 
-  if (response.len > 0) {
+  data_request_t* req = c4_state_get_data_request_by_response(&ctx->state, response);
+  if (response.len > 0 && !(req && req->validated)) {
     ssz_ob_t snapshot = {.bytes = response, .def = &PAP_TX_CACHE_SNAPSHOT};
     if (!ssz_is_valid(snapshot, true, &ctx->state))
       return C4_ERROR;
   }
+  if (req) req->validated = true;
 
   if (incremental)
     pap_tx_cache_merge_from_ssz(ctx->chain_id, response);

--- a/src/chains/eth/verifier/verify_pap_tx.c
+++ b/src/chains/eth/verifier/verify_pap_tx.c
@@ -80,8 +80,8 @@ static c4_status_t fetch_tx_cache_from_server(verify_ctx_t* ctx) {
     ssz_ob_t snapshot = {.bytes = response, .def = &PAP_TX_CACHE_SNAPSHOT};
     if (!ssz_is_valid(snapshot, true, &ctx->state))
       return C4_ERROR;
+    if (req) req->validated = true;
   }
-  if (req) req->validated = true;
 
   if (incremental)
     pap_tx_cache_merge_from_ssz(ctx->chain_id, response);

--- a/src/util/state.c
+++ b/src/util/state.c
@@ -128,6 +128,16 @@ data_request_t* c4_state_get_data_request_by_id(c4_state_t* state, bytes32_t id)
   return NULL;
 }
 
+data_request_t* c4_state_get_data_request_by_response(c4_state_t* state, bytes_t response) {
+  if (!state || !response.data) return NULL;
+  data_request_t* data_request = state->requests;
+  while (data_request) {
+    if (data_request->response.data == response.data) return data_request;
+    data_request = data_request->next;
+  }
+  return NULL;
+}
+
 data_request_t* c4_state_get_data_request_by_url(c4_state_t* state, char* url) {
   data_request_t* data_request = state->requests;
   while (data_request) {
@@ -157,6 +167,7 @@ bool c4_state_retry_after(data_request_t* req, uint32_t delay_ms, uint16_t max_r
   // try"). Unlike `RETRY_REQUEST`, we explicitly do NOT exclude the node.
   req->response_node_index = 0;
   req->node_exclude_mask   = 0;
+  req->validated           = false;
   req->delay               = delay_ms;
   req->retry_count++;
   return true;

--- a/src/util/state.h
+++ b/src/util/state.h
@@ -324,6 +324,18 @@ void c4_append_prover_request_props(buffer_t* payload, bytes_t client_state, cha
 data_request_t* c4_state_get_data_request_by_id(c4_state_t* state, bytes32_t id);
 
 /**
+ * Finds a data request whose `response` pointer matches the given bytes.
+ *
+ * Used to attach `validated` to the request that produced a consumed buffer
+ * without changing every consume-function signature.
+ *
+ * @param state Pointer to the state object
+ * @param response Response bytes (matched by `data` pointer, not contents)
+ * @return Pointer to the matching request, or NULL if not found
+ */
+data_request_t* c4_state_get_data_request_by_response(c4_state_t* state, bytes_t response);
+
+/**
  * Gets a `C4_DATA_TYPE_CACHE` snapshot from the request list.
  *
  * Walks the request list and matches only `C4_DATA_TYPE_CACHE` entries with a
@@ -740,7 +752,8 @@ static inline bool c4_check_json_verify_cached_inline(c4_state_t* state, bool* s
       req->node_exclude_mask |= (1 << req->response_node_index);                                                                                                                              \
     log_warn("   [retry] request (%s) returned invalid response (%r) from node index=%d, retrying", c4_req_info(req->type, req->url, req->payload), req->response, req->response_node_index); \
     safe_free(req->response.data);                                                                                                                                                            \
-    req->response = NULL_BYTES;                                                                                                                                                               \
+    req->response  = NULL_BYTES;                                                                                                                                                              \
+    req->validated = false;                                                                                                                                                                   \
     return C4_PENDING;                                                                                                                                                                        \
   } while (0)
 

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -79,7 +79,7 @@ foreach(test_source ${TEST_SOURCES})
         target_link_libraries(${test_name} PRIVATE eth_bn254 intx_wrapper eth_precompiles)
     endif()
 
-    if("${test_name}" MATCHES "^test_evmone_")
+    if("${test_name}" MATCHES "^test_evmone_" OR "${test_name}" STREQUAL "test_request_validation")
         if(EVMONE)
             target_compile_definitions(${test_name} PRIVATE EVMONE)
             target_link_libraries(${test_name} PRIVATE evmone_wrapper)

--- a/test/unittests/test_eth_beacon_parent_header.c
+++ b/test/unittests/test_eth_beacon_parent_header.c
@@ -273,7 +273,11 @@ void test_parent_lookup_parent_header_not_found(void) {
   st = c4_eth_get_signblock_and_parent(ctx, NULL, parent, &sig_block, &data_block, data_root_out);
   TEST_ASSERT_EQUAL(C4_ERROR, st);
   TEST_ASSERT_NOT_NULL(ctx->state.error);
-  TEST_ASSERT_NOT_NULL(strstr(ctx->state.error, "Parent beacon header not found"));
+  // `{"data":[]}` is the list-endpoint empty shape; the by-root endpoint
+  // expects `{data:{...}}`, so Phase-1 schema validation rejects it first.
+  TEST_ASSERT_TRUE_MESSAGE(strstr(ctx->state.error, "Parent beacon header not found") ||
+                               strstr(ctx->state.error, "Invalid parent beacon header"),
+                           ctx->state.error);
   c4_prover_free(ctx);
 }
 
@@ -582,7 +586,8 @@ void test_parent_lookup_parent_missing_slot(void) {
   st = c4_eth_get_signblock_and_parent(ctx, NULL, parent, &sig_block, &data_block, data_root_out);
   TEST_ASSERT_EQUAL(C4_ERROR, st);
   TEST_ASSERT_NOT_NULL(ctx->state.error);
-  TEST_ASSERT_NOT_NULL(strstr(ctx->state.error, "missing slot"));
+  TEST_ASSERT_TRUE_MESSAGE(strstr(ctx->state.error, "missing slot") || strstr(ctx->state.error, "missing property"),
+                           ctx->state.error);
   c4_prover_free(ctx);
 }
 
@@ -632,7 +637,8 @@ void test_parent_lookup_rejects_short_child_root(void) {
 
   TEST_ASSERT_EQUAL(C4_ERROR, st);
   TEST_ASSERT_NOT_NULL(ctx->state.error);
-  TEST_ASSERT_NOT_NULL(strstr(ctx->state.error, "Invalid beacon header root"));
+  TEST_ASSERT_TRUE_MESSAGE(strstr(ctx->state.error, "Invalid beacon header root") || strstr(ctx->state.error, "fixed size"),
+                           ctx->state.error);
   c4_prover_free(ctx);
 }
 
@@ -990,9 +996,10 @@ static char* gloas_el_rpc(const uint8_t* hash, const uint8_t* parent_cl, uint64_
   return bprintf(NULL,
                  "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{"
                  "\"number\":\"0x1\",\"hash\":\"0x%s\","
+                 "\"stateRoot\":\"0x%s\",\"receiptsRoot\":\"0x%s\",\"transactionsRoot\":\"0x%s\","
                  "\"parentBeaconBlockRoot\":\"0x%s\",\"slotNumber\":\"0x%lx\""
                  "}}",
-                 hh, ph, slot);
+                 hh, hh, hh, hh, ph, slot);
 }
 
 static int is_eth_get_block_number(data_request_t* req, const char* hex_num) {
@@ -1092,9 +1099,10 @@ static char* el_rpc_without_slot(const uint8_t* hash, const uint8_t* parent_cl) 
   return bprintf(NULL,
                  "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{"
                  "\"number\":\"0x1\",\"hash\":\"0x%s\","
+                 "\"stateRoot\":\"0x%s\",\"receiptsRoot\":\"0x%s\",\"transactionsRoot\":\"0x%s\","
                  "\"parentBeaconBlockRoot\":\"0x%s\""
                  "}}",
-                 hh, ph);
+                 hh, hh, hh, hh, ph);
 }
 
 static eth_block_t dummy_block_with_state_root(const uint8_t* state_root, ssz_def_t* header_def, uint8_t* header_bytes) {

--- a/test/unittests/test_eth_beacon_parent_header.c
+++ b/test/unittests/test_eth_beacon_parent_header.c
@@ -276,7 +276,7 @@ void test_parent_lookup_parent_header_not_found(void) {
   // `{"data":[]}` is the list-endpoint empty shape; the by-root endpoint
   // expects `{data:{...}}`, so Phase-1 schema validation rejects it first.
   TEST_ASSERT_TRUE_MESSAGE(strstr(ctx->state.error, "Parent beacon header not found") ||
-                               strstr(ctx->state.error, "Invalid parent beacon header"),
+                               strstr(ctx->state.error, "Invalid beacon header"),
                            ctx->state.error);
   c4_prover_free(ctx);
 }

--- a/test/unittests/test_oblivious_retry.c
+++ b/test/unittests/test_oblivious_retry.c
@@ -102,11 +102,13 @@ void test_retry_after_clears_response_and_error(void) {
   data_request_t req = {0};
   req.response       = bytes_dup(bytes((uint8_t*) "x", 1));
   req.error          = strdup("transient error");
+  req.validated      = true;
 
   TEST_ASSERT_TRUE(c4_state_retry_after(&req, 1500, 5));
   TEST_ASSERT_NULL(req.response.data);
   TEST_ASSERT_EQUAL_UINT32(0, req.response.len);
   TEST_ASSERT_NULL(req.error);
+  TEST_ASSERT_FALSE(req.validated);
   TEST_ASSERT_EQUAL_UINT32(1500, req.delay);
 }
 

--- a/test/unittests/test_request_validation.c
+++ b/test/unittests/test_request_validation.c
@@ -7,6 +7,7 @@
  */
 
 #include "unity.h"
+#include "beacon.h"
 #include "bytes.h"
 #include "chains.h"
 #include "eth_req.h"
@@ -94,6 +95,24 @@ void test_eth_get_block_validates_once(void) {
   c4_prover_free(ctx);
 }
 
+void test_send_beacon_ssz_null_def_does_not_validate(void) {
+  prover_ctx_t*   ctx    = c4_prover_create("eth_getBlockByNumber", "[\"0x1\",false]", C4_CHAIN_MAINNET, 0);
+  ssz_ob_t        result = {0};
+  data_request_t* req    = NULL;
+
+  TEST_ASSERT_EQUAL_INT(C4_PENDING, c4_send_beacon_ssz(ctx, "eth/v2/beacon/blocks/head", NULL, NULL, 0, &result, &req));
+  TEST_ASSERT_NOT_NULL(req);
+
+  uint8_t* body = safe_calloc(32, 1);
+  req->response = bytes(body, 32);
+
+  TEST_ASSERT_EQUAL_INT(C4_SUCCESS, c4_send_beacon_ssz(ctx, "eth/v2/beacon/blocks/head", NULL, NULL, 0, &result, &req));
+  TEST_ASSERT_FALSE(req->validated);
+  TEST_ASSERT_EQUAL_PTR(body, result.bytes.data);
+
+  c4_prover_free(ctx);
+}
+
 #ifdef EVMONE
 void test_eth_get_storage_at_rejects_invalid_result(void) {
   verify_ctx_t      vctx = {0};
@@ -127,6 +146,7 @@ int main(void) {
   RUN_TEST(test_get_data_request_by_response);
   RUN_TEST(test_eth_get_block_rejects_incomplete_json);
   RUN_TEST(test_eth_get_block_validates_once);
+  RUN_TEST(test_send_beacon_ssz_null_def_does_not_validate);
 #ifdef EVMONE
   RUN_TEST(test_eth_get_storage_at_rejects_invalid_result);
 #endif

--- a/test/unittests/test_request_validation.c
+++ b/test/unittests/test_request_validation.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 corpus.core
+ * SPDX-License-Identifier: MIT
+ *
+ * Phase-1 request validation: JSON/SSZ is checked once per data_request_t
+ * and `validated` is set so the same payload is not re-checked on re-entry.
+ */
+
+#include "unity.h"
+#include "bytes.h"
+#include "chains.h"
+#include "eth_req.h"
+#include "json.h"
+#include "prover.h"
+#include "state.h"
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef EVMONE
+#include "call_ctx.h"
+#endif
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_retry_after_clears_validated(void) {
+  data_request_t req = {0};
+  req.response       = bytes_dup(bytes((uint8_t*) "x", 1));
+  req.validated      = true;
+
+  TEST_ASSERT_TRUE(c4_state_retry_after(&req, 100, 3));
+  TEST_ASSERT_FALSE(req.validated);
+  TEST_ASSERT_NULL(req.response.data);
+}
+
+void test_get_data_request_by_response(void) {
+  c4_state_t      state = {0};
+  data_request_t* req   = safe_calloc(1, sizeof(data_request_t));
+  req->id[0]            = 1; // non-zero so add_request does not hash a NULL url
+  req->response         = bytes_dup(bytes((uint8_t*) "body", 4));
+  c4_state_add_request(&state, req);
+
+  TEST_ASSERT_EQUAL_PTR(req, c4_state_get_data_request_by_response(&state, req->response));
+  TEST_ASSERT_NULL(c4_state_get_data_request_by_response(&state, bytes((uint8_t*) "body", 4)));
+
+  c4_state_free(&state);
+}
+
+static const char* k_block_id = "\"0x1\"";
+
+void test_eth_get_block_rejects_incomplete_json(void) {
+  prover_ctx_t* ctx    = c4_prover_create("eth_getBlockByNumber", "[\"0x1\",false]", C4_CHAIN_MAINNET, 0);
+  json_t        block  = {.start = k_block_id, .len = 5, .type = JSON_TYPE_STRING};
+  json_t        result = {0};
+
+  TEST_ASSERT_EQUAL_INT(C4_PENDING, eth_get_block(ctx, block, false, &result));
+  data_request_t* req = c4_state_get_pending_request(&ctx->state);
+  TEST_ASSERT_NOT_NULL(req);
+
+  const char* body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"number\":\"0x1\"}}";
+  req->response    = bytes((uint8_t*) strdup(body), (uint32_t) strlen(body));
+
+  TEST_ASSERT_EQUAL_INT(C4_ERROR, eth_get_block(ctx, block, false, &result));
+  TEST_ASSERT_FALSE(req->validated);
+  TEST_ASSERT_NOT_NULL(ctx->state.error);
+
+  c4_prover_free(ctx);
+}
+
+void test_eth_get_block_validates_once(void) {
+  prover_ctx_t* ctx    = c4_prover_create("eth_getBlockByNumber", "[\"0x1\",false]", C4_CHAIN_MAINNET, 0);
+  json_t        block  = {.start = k_block_id, .len = 5, .type = JSON_TYPE_STRING};
+  json_t        result = {0};
+
+  TEST_ASSERT_EQUAL_INT(C4_PENDING, eth_get_block(ctx, block, false, &result));
+  data_request_t* req = c4_state_get_pending_request(&ctx->state);
+  TEST_ASSERT_NOT_NULL(req);
+
+  const char* body =
+      "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{"
+      "\"number\":\"0x1\","
+      "\"hash\":\"0x1111111111111111111111111111111111111111111111111111111111111111\","
+      "\"stateRoot\":\"0x2222222222222222222222222222222222222222222222222222222222222222\","
+      "\"receiptsRoot\":\"0x3333333333333333333333333333333333333333333333333333333333333333\","
+      "\"transactionsRoot\":\"0x4444444444444444444444444444444444444444444444444444444444444444\""
+      "}}";
+  req->response = bytes((uint8_t*) strdup(body), (uint32_t) strlen(body));
+
+  TEST_ASSERT_EQUAL_INT(C4_SUCCESS, eth_get_block(ctx, block, false, &result));
+  TEST_ASSERT_TRUE(req->validated);
+  TEST_ASSERT_EQUAL_INT(C4_SUCCESS, eth_get_block(ctx, block, false, &result));
+  TEST_ASSERT_TRUE(req->validated);
+
+  c4_prover_free(ctx);
+}
+
+#ifdef EVMONE
+void test_eth_get_storage_at_rejects_invalid_result(void) {
+  verify_ctx_t      vctx = {0};
+  evmone_context_t  ectx = {0};
+  address_t         addr = {0};
+  bytes32_t         key  = {0};
+  bytes32_t         out  = {0};
+  ectx.ctx               = &vctx;
+
+  call_account_lazy_fetch_storage(&ectx, addr, key, out);
+  data_request_t* req = c4_state_get_pending_request(&vctx.state);
+  TEST_ASSERT_NOT_NULL(req);
+
+  const char* body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}";
+  req->response    = bytes((uint8_t*) strdup(body), (uint32_t) strlen(body));
+  memset(out, 0xff, 32);
+
+  call_account_lazy_fetch_storage(&ectx, addr, key, out);
+  TEST_ASSERT_NOT_NULL(vctx.state.error);
+  TEST_ASSERT_FALSE(req->validated);
+  for (int i = 0; i < 32; i++)
+    TEST_ASSERT_EQUAL_UINT8(0xff, out[i]);
+
+  c4_state_free(&vctx.state);
+}
+#endif
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_retry_after_clears_validated);
+  RUN_TEST(test_get_data_request_by_response);
+  RUN_TEST(test_eth_get_block_rejects_incomplete_json);
+  RUN_TEST(test_eth_get_block_validates_once);
+#ifdef EVMONE
+  RUN_TEST(test_eth_get_storage_at_rejects_invalid_result);
+#endif
+  return UNITY_END();
+}

--- a/test/unittests/test_request_validation.c
+++ b/test/unittests/test_request_validation.c
@@ -6,7 +6,6 @@
  * and `validated` is set so the same payload is not re-checked on re-entry.
  */
 
-#include "unity.h"
 #include "beacon.h"
 #include "bytes.h"
 #include "chains.h"
@@ -14,6 +13,7 @@
 #include "json.h"
 #include "prover.h"
 #include "state.h"
+#include "unity.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -113,14 +113,120 @@ void test_send_beacon_ssz_null_def_does_not_validate(void) {
   c4_prover_free(ctx);
 }
 
+void test_eth_debug_get_raw_block_decodes_to_bytes(void) {
+  prover_ctx_t* ctx      = c4_prover_create("eth_getBlockByNumber", "[\"0x1\",false]", C4_CHAIN_MAINNET, 0);
+  uint8_t       hash[32] = {0};
+  bytes_t       result   = {0};
+
+  TEST_ASSERT_EQUAL_INT(C4_PENDING, eth_debug_get_raw_block(ctx, hash, &result));
+  data_request_t* req = c4_state_get_pending_request(&ctx->state);
+  TEST_ASSERT_NOT_NULL(req);
+
+  const char* body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"0xdeadbeef\"}";
+  req->response    = bytes((uint8_t*) strdup(body), (uint32_t) strlen(body));
+
+  TEST_ASSERT_EQUAL_INT(C4_SUCCESS, eth_debug_get_raw_block(ctx, hash, &result));
+  TEST_ASSERT_TRUE(req->validated);
+  TEST_ASSERT_EQUAL_UINT32(4, result.len);
+  TEST_ASSERT_EQUAL_UINT8(0xde, result.data[0]);
+  TEST_ASSERT_EQUAL_UINT8(0xad, result.data[1]);
+  TEST_ASSERT_EQUAL_UINT8(0xbe, result.data[2]);
+  TEST_ASSERT_EQUAL_UINT8(0xef, result.data[3]);
+  TEST_ASSERT_EQUAL_PTR(req->response.data, result.data);
+
+  bytes_t again = {0};
+  TEST_ASSERT_EQUAL_INT(C4_SUCCESS, eth_debug_get_raw_block(ctx, hash, &again));
+  TEST_ASSERT_EQUAL_PTR(result.data, again.data);
+  TEST_ASSERT_EQUAL_UINT32(4, again.len);
+  TEST_ASSERT_TRUE(req->validated);
+
+  c4_prover_free(ctx);
+}
+
+void test_eth_debug_get_raw_block_rejects_invalid_json(void) {
+  prover_ctx_t* ctx      = c4_prover_create("eth_getBlockByNumber", "[\"0x1\",false]", C4_CHAIN_MAINNET, 0);
+  uint8_t       hash[32] = {0};
+  bytes_t       result   = {0};
+
+  TEST_ASSERT_EQUAL_INT(C4_PENDING, eth_debug_get_raw_block(ctx, hash, &result));
+  data_request_t* req = c4_state_get_pending_request(&ctx->state);
+  TEST_ASSERT_NOT_NULL(req);
+
+  const char* body      = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}";
+  uint8_t*    json_body = (uint8_t*) strdup(body);
+  uint32_t    json_len  = (uint32_t) strlen(body);
+  req->response         = bytes(json_body, json_len);
+
+  TEST_ASSERT_EQUAL_INT(C4_ERROR, eth_debug_get_raw_block(ctx, hash, &result));
+  TEST_ASSERT_FALSE(req->validated);
+  TEST_ASSERT_NOT_NULL(ctx->state.error);
+  TEST_ASSERT_EQUAL_PTR(json_body, req->response.data);
+  TEST_ASSERT_EQUAL_UINT32(json_len, req->response.len);
+  TEST_ASSERT_EQUAL_MEMORY(body, req->response.data, json_len);
+
+  c4_prover_free(ctx);
+}
+
+void test_eth_debug_get_raw_block_rejects_empty_hex(void) {
+  prover_ctx_t* ctx      = c4_prover_create("eth_getBlockByNumber", "[\"0x1\",false]", C4_CHAIN_MAINNET, 0);
+  uint8_t       hash[32] = {0};
+  bytes_t       result   = {0};
+
+  TEST_ASSERT_EQUAL_INT(C4_PENDING, eth_debug_get_raw_block(ctx, hash, &result));
+  data_request_t* req = c4_state_get_pending_request(&ctx->state);
+  TEST_ASSERT_NOT_NULL(req);
+
+  const char* body      = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"0x\"}";
+  uint8_t*    json_body = (uint8_t*) strdup(body);
+  uint32_t    json_len  = (uint32_t) strlen(body);
+  req->response         = bytes(json_body, json_len);
+
+  TEST_ASSERT_EQUAL_INT(C4_ERROR, eth_debug_get_raw_block(ctx, hash, &result));
+  TEST_ASSERT_FALSE(req->validated);
+  TEST_ASSERT_NOT_NULL(ctx->state.error);
+  TEST_ASSERT_NOT_NULL(strstr(ctx->state.error, "empty"));
+  TEST_ASSERT_EQUAL_PTR(json_body, req->response.data);
+  TEST_ASSERT_EQUAL_UINT32(json_len, req->response.len);
+  TEST_ASSERT_EQUAL_MEMORY(body, req->response.data, json_len);
+
+  c4_prover_free(ctx);
+}
+
+void test_eth_debug_get_raw_block_decodes_long_hex(void) {
+  prover_ctx_t* ctx      = c4_prover_create("eth_getBlockByNumber", "[\"0x1\",false]", C4_CHAIN_MAINNET, 0);
+  uint8_t       hash[32] = {0};
+  bytes_t       result   = {0};
+
+  TEST_ASSERT_EQUAL_INT(C4_PENDING, eth_debug_get_raw_block(ctx, hash, &result));
+  data_request_t* req = c4_state_get_pending_request(&ctx->state);
+  TEST_ASSERT_NOT_NULL(req);
+
+  const char* body =
+      "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"0x"
+      "000102030405060708090a0b0c0d0e0f"
+      "101112131415161718191a1b1c1d1e1f"
+      "202122232425262728292a2b2c2d2e2f"
+      "303132333435363738393a3b3c3d3e3f\"}";
+  req->response = bytes((uint8_t*) strdup(body), (uint32_t) strlen(body));
+
+  TEST_ASSERT_EQUAL_INT(C4_SUCCESS, eth_debug_get_raw_block(ctx, hash, &result));
+  TEST_ASSERT_TRUE(req->validated);
+  TEST_ASSERT_EQUAL_UINT32(64, result.len);
+  TEST_ASSERT_EQUAL_PTR(req->response.data, result.data);
+  for (uint32_t i = 0; i < 64; i++)
+    TEST_ASSERT_EQUAL_UINT8((uint8_t) i, result.data[i]);
+
+  c4_prover_free(ctx);
+}
+
 #ifdef EVMONE
 void test_eth_get_storage_at_rejects_invalid_result(void) {
-  verify_ctx_t      vctx = {0};
-  evmone_context_t  ectx = {0};
-  address_t         addr = {0};
-  bytes32_t         key  = {0};
-  bytes32_t         out  = {0};
-  ectx.ctx               = &vctx;
+  verify_ctx_t     vctx = {0};
+  evmone_context_t ectx = {0};
+  address_t        addr = {0};
+  bytes32_t        key  = {0};
+  bytes32_t        out  = {0};
+  ectx.ctx              = &vctx;
 
   call_account_lazy_fetch_storage(&ectx, addr, key, out);
   data_request_t* req = c4_state_get_pending_request(&vctx.state);
@@ -147,6 +253,10 @@ int main(void) {
   RUN_TEST(test_eth_get_block_rejects_incomplete_json);
   RUN_TEST(test_eth_get_block_validates_once);
   RUN_TEST(test_send_beacon_ssz_null_def_does_not_validate);
+  RUN_TEST(test_eth_debug_get_raw_block_decodes_to_bytes);
+  RUN_TEST(test_eth_debug_get_raw_block_rejects_invalid_json);
+  RUN_TEST(test_eth_debug_get_raw_block_rejects_empty_hex);
+  RUN_TEST(test_eth_debug_get_raw_block_decodes_long_hex);
 #ifdef EVMONE
   RUN_TEST(test_eth_get_storage_at_rejects_invalid_result);
 #endif


### PR DESCRIPTION
## Summary

- Bind existing JSON-schema (`CHECK_JSON`) and `ssz_is_valid` checks to `data_request_t.validated`, so the same payload is not re-checked on async re-entry.
- Validation stays in the wrappers. `c4_send_beacon_ssz(..., def=NULL)` does **not** set the flag (caller validates after fork resolution). LCU lists and internal requests are intentionally out of scope.
- `RETRY_REQUEST` / `c4_state_retry_after` clear `validated`. Invalid `eth_getStorageAt` JSON is now an error, not a zero slot.

## Test plan

- [x] `cmake --build build/default`
- [x] `test_request_validation` (retry flag, pointer lookup, incomplete block JSON, validate-once, `def=NULL`, invalid storage)
- [x] `test_eth_beacon_parent_header`, `test_oblivious_retry`
- [x] ETH verify/sync/call/receipt/tx/storage/simulate + `test_state_proofs` / PAP / header-cache regressions
- [ ] CI on this PR

## Follow-ups (not this PR)

- Schema parameter on `c4_send_*`
- First-class fork-dependent SSZ (`def==NULL`)
- LCU list validator (prover + internal `lcu_updates`)
- Internal handler validation (`blocks.ssz`, ZK, sigs, OP preconf)
- Strip now-redundant downstream `ssz_is_valid` once every fetch sets the flag honestly