### PR TITLE
feat(eth): validate LCU list framing and derive fork from ForkDigest

### DIFF
--- a/src/chains/eth/CMakeLists.txt
+++ b/src/chains/eth/CMakeLists.txt
@@ -92,6 +92,7 @@ set(VERIFIER_SOURCES
   verifier/sync_committee.c
   verifier/sync_committee_state.c
   verifier/beacon_header.c
+  verifier/lcu_wire.c
   verifier/eth_tx.c
   verifier/eth_account.c
   verifier/eth_verify.c

--- a/src/chains/eth/prover/cl_req.h
+++ b/src/chains/eth/prover/cl_req.h
@@ -154,9 +154,11 @@ c4_status_t cl_get_state_proof(prover_ctx_t* ctx,
 /**
  * Beacon SSZ GET without a validating wrapper.
  *
- * Prefer a `cl_*` helper. This remains public for light-client update lists
- * (`def == NULL`, no list-level SSZ type yet; see #356). When `def` is set,
- * `ssz_is_valid` runs once and `validated` is set.
+ * Prefer a `cl_*` helper. This is used for light-client update lists
+ * (`def == NULL`, no single SSZ type covers the list). Callers must run
+ * `c4_eth_walk_lcu_list` on the response (see [lcu_wire.h](../verifier/lcu_wire.h))
+ * to mark the request `validated`. When `def` is set, `ssz_is_valid` runs
+ * once here and `validated` is set.
  *
  * @param ctx prover context
  * @param path beacon API path

--- a/src/chains/eth/prover/historic_proof.c
+++ b/src/chains/eth/prover/historic_proof.c
@@ -24,6 +24,7 @@
 #include "historic_proof.h"
 #include "../server/eth_clients.h"
 #include "../server/period_store_files.h"
+#include "../verifier/lcu_wire.h"
 #include "beacon.h"
 #include "beacon_types.h"
 #include "bootstrap_gloas.h"
@@ -259,17 +260,8 @@ void c4_free_block_proof(blockroot_proof_t* block_proof) {
 // SSZ validation. Used for both the primary (beacon-served) and fallback
 // (self-built) paths so the two share exactly the same validation.
 static c4_status_t decode_bootstrap_bytes(prover_ctx_t* ctx, bytes_t raw, ssz_ob_t* out_bootstrap, data_request_t* req) {
-  ssz_ob_t  result = {.bytes = raw, .def = NULL};
-  fork_id_t fork   = c4_eth_get_fork_for_lcu(ctx->chain_id, result.bytes);
-  if (fork == 0) THROW_ERROR("Invalid bootstrap data: cannot determine fork!");
-  // Single source of truth for fork -> bootstrap container mapping.
-  result.def = eth_get_light_client_bootstrap(fork);
-  if (!result.def) THROW_ERROR("Invalid bootstrap data: unsupported fork!");
-  if (!(req && req->validated)) {
-    if (!ssz_is_valid(result, true, &ctx->state)) THROW_ERROR("Invalid bootstrap data!");
-    if (req) req->validated = true;
-  }
-  *out_bootstrap = result;
+  if (!c4_eth_decode_bootstrap(ctx->chain_id, raw, &ctx->state, req, out_bootstrap))
+    return C4_ERROR;
   return C4_SUCCESS;
 }
 
@@ -392,9 +384,9 @@ c4_status_t c4_fetch_client_updates(prover_ctx_t* ctx, uint64_t start_period, ui
   // Preferred path (server context): read the LCUs from the local period_store
   // via the internal `lcu_updates` handler. That handler concatenates the
   // per-period `lcu.ssz` files (already in Beacon-API wire format: 8-byte LE
-  // length + 4-byte fork_version + LCU SSZ) and transparently backfills
-  // missing periods from a beacon node. It's noticeably cheaper than a
-  // dedicated beacon roundtrip when the cache is warm.
+  // length + 4-byte context (ForkDigest) + LCU SSZ) and transparently
+  // backfills missing periods from a beacon node. It's noticeably cheaper
+  // than a dedicated beacon roundtrip when the cache is warm.
   //
   // Fallback: if the internal handler errors out or returns a body that is
   // too short to hold even one update prefix, drop back to a direct beacon
@@ -447,6 +439,33 @@ c4_status_t c4_fetch_client_updates(prover_ctx_t* ctx, uint64_t start_period, ui
   return C4_SUCCESS;
 }
 
+// Context for the fetch_updates_data walker callback: it appends each chunk
+// to the SSZ builder with the correct union tag.
+typedef struct {
+  ssz_builder_t* updates;
+  uint32_t       count;
+} fetch_updates_cb_ctx_t;
+
+static bool fetch_updates_append_cb(void* user, const c4_lcu_chunk_t* chunk) {
+  fetch_updates_cb_ctx_t* c = (fetch_updates_cb_ctx_t*) user;
+
+  bytes_t prefixed = bytes(safe_malloc(chunk->update.bytes.len + 1), chunk->update.bytes.len + 1);
+  memcpy(prefixed.data + 1, chunk->update.bytes.data, chunk->update.bytes.len);
+  // Union tag for `C4_ETH_SYNCDATA_UPDATE_UNION`:
+  //   0 = DenepLightClientUpdate,
+  //   1 = ElectraLightClientUpdate (also used for Fulu),
+  //   2 = GloasLightClientUpdate.
+  uint8_t union_tag = 0;
+  if (chunk->fork >= C4_FORK_GLOAS)
+    union_tag = 2;
+  else if (chunk->fork >= C4_FORK_ELECTRA)
+    union_tag = 1;
+  prefixed.data[0] = union_tag;
+  ssz_add_dynamic_list_bytes(c->updates, c->count, prefixed);
+  safe_free(prefixed.data);
+  return true;
+}
+
 static c4_status_t fetch_updates_data(prover_ctx_t* ctx, syncdata_state_t* sync_data, ssz_builder_t* updates) {
   uint32_t count          = (uint32_t) (sync_data->required_period - sync_data->newest_period);
   bytes_t  client_updates = {0};
@@ -454,33 +473,14 @@ static c4_status_t fetch_updates_data(prover_ctx_t* ctx, syncdata_state_t* sync_
 
   if (!updates) return C4_SUCCESS;
 
-  uint64_t length = 0;
-  for (uint32_t pos = 0; pos + UPDATE_PREFIX_SIZE < client_updates.len; pos += length + SSZ_LENGTH_SIZE) {
-    uint32_t data_offset        = pos + SSZ_LENGTH_SIZE + SSZ_OFFSET_SIZE;
-    uint32_t data_length_offset = SSZ_OFFSET_SIZE;
-    length                      = uint64_from_le(client_updates.data + pos);
-
-    if (pos + SSZ_LENGTH_SIZE + length > client_updates.len && length > UPDATE_PREFIX_SIZE) break;
-
-    bytes_t   client_update_bytes = bytes(client_updates.data + data_offset, length - data_length_offset);
-    fork_id_t fork                = c4_eth_get_fork_for_lcu(ctx->chain_id, client_update_bytes);
-    ssz_ob_t  update              = {.bytes = client_update_bytes, .def = eth_get_light_client_update(fork)};
-    if (!update.def) THROW_ERROR("Invalid update data!");
-
-    bytes_t prefixed = bytes(safe_malloc(update.bytes.len + 1), update.bytes.len + 1);
-    memcpy(prefixed.data + 1, update.bytes.data, update.bytes.len);
-    // Union tag for `C4_ETH_SYNCDATA_UPDATE_UNION`:
-    //   0 = DenepLightClientUpdate, 1 = ElectraLightClientUpdate (also used for Fulu),
-    //   2 = GloasLightClientUpdate.
-    uint8_t union_tag = 0;
-    if (fork >= C4_FORK_GLOAS)
-      union_tag = 2;
-    else if (fork >= C4_FORK_ELECTRA)
-      union_tag = 1;
-    prefixed.data[0] = union_tag;
-    ssz_add_dynamic_list_bytes(updates, count, prefixed);
-    safe_free(prefixed.data);
-  }
+  // Walk the LCU list with framing + per-chunk SSZ validation. Consuming
+  // via the walker keeps the prover and verifier on the same wire-format
+  // rules (issue #356 acceptance criterion).
+  data_request_t* src_req = c4_state_get_data_request_by_response(&ctx->state, client_updates);
+  fetch_updates_cb_ctx_t cb_ctx = {.updates = updates, .count = count};
+  if (!c4_eth_walk_lcu_list(ctx->chain_id, client_updates, &ctx->state, src_req,
+                            /*validate_ssz*/ true, fetch_updates_append_cb, &cb_ctx))
+    THROW_ERROR("Invalid light client update list from beacon");
 
   return C4_SUCCESS;
 }

--- a/src/chains/eth/prover/historic_proof.h
+++ b/src/chains/eth/prover/historic_proof.h
@@ -102,7 +102,7 @@ c4_status_t c4_fetch_zk_proof_data(prover_ctx_t* ctx, zk_proof_data_t* zk_proof,
 /**
  * Fetches the raw wire bytes of `[start_period .. start_period + count - 1]`
  * `LightClientUpdate`s in Beacon-API list format (each entry is prefixed with
- * an 8-byte LE length + 4-byte fork_version).
+ * an 8-byte LE length + 4-byte context, per spec the `ForkDigest`).
  *
  * Two lookup paths are tried in order:
  *

--- a/src/chains/eth/prover/lcu_gloas.c
+++ b/src/chains/eth/prover/lcu_gloas.c
@@ -133,20 +133,20 @@ bool c4_gloas_lcu_assemble(bytes_t  attested_header,
 }
 
 bytes_t c4_gloas_lcu_wrap_beacon_response(bytes_t lcu_ssz,
-                                          uint8_t fork_version[4]) {
-  if (!lcu_ssz.data || lcu_ssz.len != C4_GLOAS_LCU_SSZ_SIZE || !fork_version)
+                                          uint8_t context[4]) {
+  if (!lcu_ssz.data || lcu_ssz.len != C4_GLOAS_LCU_SSZ_SIZE || !context)
     return NULL_BYTES;
 
   // Beacon-API `light_client/updates` wire format for one entry:
   //   [0 .. 8)  length = 4 + lcu_ssz.len (uint64 LE, big enough for both
   //                     current updates layout and future 2^64-1 extensions)
-  //   [8 .. 12) fork_version (raw bytes)
+  //   [8 .. 12) context (raw bytes; per spec this is the ForkDigest)
   //   [12 ..)   payload
   const uint64_t length = 4u + (uint64_t) lcu_ssz.len;
   uint8_t*       buf    = (uint8_t*) safe_malloc(C4_GLOAS_LCU_WIRE_PREFIX_SIZE + lcu_ssz.len);
 
   uint64_to_le(buf, length);
-  memcpy(buf + 8, fork_version, 4);
+  memcpy(buf + 8, context, 4);
   memcpy(buf + C4_GLOAS_LCU_WIRE_PREFIX_SIZE, lcu_ssz.data, lcu_ssz.len);
 
   return bytes(buf, C4_GLOAS_LCU_WIRE_PREFIX_SIZE + lcu_ssz.len);

--- a/src/chains/eth/prover/lcu_gloas.h
+++ b/src/chains/eth/prover/lcu_gloas.h
@@ -53,7 +53,11 @@ extern "C" {
 
 // Beacon-API `light_client/updates` wire-format prefix per update:
 //   [0 .. 8)  length (uint64 LE) = 4 + update_size
-//   [8 .. 12) fork_version (4 bytes)
+//   [8 .. 12) context (4 bytes) -- per Beacon API spec this is the
+//             `ForkDigest = hash_tree_root(ForkData{version, gvr})[:4]`.
+//             The wrapper copies whatever the caller supplies verbatim;
+//             production callers should pass the digest computed via
+//             `c4_eth_compute_fork_digest`.
 // followed by the raw LCU-SSZ payload.
 #define C4_GLOAS_LCU_WIRE_PREFIX_SIZE 12u
 #define C4_GLOAS_LCU_WIRE_SIZE        (C4_GLOAS_LCU_WIRE_PREFIX_SIZE + C4_GLOAS_LCU_SSZ_SIZE)
@@ -136,7 +140,7 @@ bool c4_gloas_lcu_assemble(bytes_t  attested_header,
  *
  * ```text
  * [8 bytes LE]  length = 4 + lcu_ssz.len
- * [4 bytes  ]   fork_version (as passed by caller)
+ * [4 bytes  ]   context (as passed by caller; per spec `ForkDigest`)
  * [lcu_ssz  ]   payload
  * ```
  *
@@ -144,12 +148,12 @@ bool c4_gloas_lcu_assemble(bytes_t  attested_header,
  * or `lcu_ssz.data == NULL`.
  *
  * @param lcu_ssz the raw LCU-SSZ payload (borrowed, not consumed).
- * @param fork_version the 4-byte fork version identifier written as-is.
+ * @param context the 4-byte context (typically a `ForkDigest`) written as-is.
  * @return heap-allocated `bytes_t` of length `12 + lcu_ssz.len` on success;
  *         `NULL_BYTES` on invalid input. Caller must `safe_free(.data)`.
  */
 bytes_t c4_gloas_lcu_wrap_beacon_response(bytes_t lcu_ssz,
-                                          uint8_t fork_version[4]);
+                                          uint8_t context[4]);
 
 #ifdef __cplusplus
 }

--- a/src/chains/eth/prover/proof_sync.c
+++ b/src/chains/eth/prover/proof_sync.c
@@ -21,6 +21,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include "../verifier/lcu_wire.h"
 #include "beacon_types.h"
 #include "eth_compute_units.h"
 #include "eth_tools.h"
@@ -47,16 +48,35 @@ typedef struct {
   bytes_t  proposer_index;
 } period_data_t;
 
+// Walker callback that captures the first chunk of a light-client-update
+// list. Aborts the walk after the first hit -- `c4_proof_sync` always fetches
+// with `count=1`.
+typedef struct {
+  bool     have_first;
+  ssz_ob_t first;
+} first_lcu_t;
+
+static bool capture_first_cb(void* user, const c4_lcu_chunk_t* chunk) {
+  first_lcu_t* f = (first_lcu_t*) user;
+  if (f->have_first) return false;
+  f->first      = chunk->update;
+  f->have_first = true;
+  return false;
+}
+
+// Framing-validated single-chunk unwrap. On success sets `.validated` on the
+// backing request and returns the first chunk as `{.bytes, .def}`; otherwise
+// returns `{.bytes = NULL_BYTES, .def = NULL}`.
 static ssz_ob_t unwrap_lcu_response(prover_ctx_t* ctx, bytes_t data) {
   ssz_ob_t result = {.bytes = NULL_BYTES, .def = NULL};
-  if (data.len < 12) return result;
-  uint64_t payload_len = uint64_from_le(data.data);
-  if (payload_len < 4 || 8 + payload_len > data.len) return result;
-  result.bytes          = bytes(data.data + 12, payload_len - 4);
-  fork_id_t        fork = c4_eth_get_fork_for_lcu(ctx->chain_id, result.bytes);
-  const ssz_def_t* def  = eth_get_light_client_update(fork);
-  result.def            = def;
-  return result;
+
+  data_request_t* src_req = c4_state_get_data_request_by_response(&ctx->state, data);
+  first_lcu_t     first   = {0};
+  bool ok = c4_eth_walk_lcu_list(ctx->chain_id, data, &ctx->state, src_req,
+                                 /*validate_ssz*/ true, capture_first_cb, &first);
+  if (!ok && !first.have_first) return result;
+  if (!first.have_first) return result;
+  return first.first;
 }
 
 static c4_status_t extract_sync_data(prover_ctx_t* ctx, bytes_t old_data, bytes_t new_data, period_data_t* period) {
@@ -68,7 +88,12 @@ static c4_status_t extract_sync_data(prover_ctx_t* ctx, bytes_t old_data, bytes_
   ssz_ob_t new_update = unwrap_lcu_response(ctx, new_data);
   if (!new_update.def) THROW_ERROR("invalid new client_update");
 
-  fork_id_t fork = c4_eth_get_fork_for_lcu(ctx->chain_id, new_update.bytes);
+  // Attested-header slot's fork drives the LCU container layout choice,
+  // exactly what the walker used to resolve `def` above.
+  ssz_ob_t attested = ssz_get(&new_update, "attestedHeader");
+  ssz_ob_t beacon0  = ssz_get(&attested, "beacon");
+  const chain_spec_t* spec = c4_eth_get_chain_spec(ctx->chain_id);
+  fork_id_t fork = c4_chain_fork_id(ctx->chain_id, epoch_for_slot(ssz_get_uint64(&beacon0, "slot"), spec));
 
   ssz_ob_t old_sync_keys  = ssz_get(&old_update, "nextSyncCommittee");
   ssz_ob_t new_sync_keys  = ssz_get(&new_update, "nextSyncCommittee");

--- a/src/chains/eth/server/period_store_lc.c
+++ b/src/chains/eth/server/period_store_lc.c
@@ -2,6 +2,7 @@
 #include "beacon_types.h"
 #include "eth_conf.h"
 #include "lcu_gloas.h"
+#include "lcu_wire.h"
 #include "logger.h"
 #include "period_store.h"
 #include "prover.h"
@@ -274,6 +275,12 @@ void c4_ps_fetch_lcb_for_checkpoint(bytes32_t checkpoint, uint64_t period) {
   *pdata                     = period;
   c4_add_request(&lcu_client, req, pdata, fetch_lcu_cb);
 }
+static bool fetch_lcb_first_cb(void* user, const c4_lcu_chunk_t* chunk) {
+  ssz_ob_t* out = (ssz_ob_t*) user;
+  if (!out->def) *out = chunk->update;
+  return true;
+}
+
 static void fetch_lcb_cb(client_t* client, void* data, data_request_t* r) {
   (void) client;
   uint64_t period = data ? *((uint64_t*) data) : 0;
@@ -283,10 +290,20 @@ static void fetch_lcb_cb(client_t* client, void* data, data_request_t* r) {
   if (r->error) THROW_PERIOD_ERROR(r, "period_store: LCU fetch for period %l failed: %s", period, r->error);
   if (r->response.len < UPDATE_PREFIX_SIZE) THROW_PERIOD_ERROR(r, "period_store: LCU fetch for period %l failed: response too short", period);
 
-  ssz_ob_t update = {.bytes = bytes(r->response.data + UPDATE_PREFIX_SIZE, uint64_from_le(r->response.data) - SSZ_OFFSET_SIZE), .def = NULL};
-  if (update.bytes.data + update.bytes.len > r->response.data + r->response.len) THROW_PERIOD_ERROR(r, "period_store: LCU fetch for period %l failed: response too short", period);
-  update.def = eth_get_light_client_update(c4_eth_get_fork_for_lcu(http_server.chain_id, update.bytes));
-  if (!update.def) THROW_PERIOD_ERROR(r, "period_store: LCU fetch for period %l failed: invalid update data len=%l", period, update.bytes.len);
+  // Framing + ForkDigest + SSZ in one place. `count=1` so the first chunk
+  // is the only one we need.
+  c4_state_t walk_state = {0};
+  ssz_ob_t   update     = {0};
+  bool       walked     = c4_eth_walk_lcu_list(http_server.chain_id, r->response, &walk_state, r,
+                                               /*validate_ssz*/ true, fetch_lcb_first_cb, &update);
+  if (!walked || !update.def) {
+    const char* err = walk_state.error ? walk_state.error : "invalid LCU list";
+    log_warn("period_store: LCU fetch for period %l failed: %s", period, err);
+    c4_state_free(&walk_state);
+    c4_request_free(r);
+    return;
+  }
+  c4_state_free(&walk_state);
   ssz_ob_t finalized         = ssz_get(&update, "finalizedHeader");
   ssz_ob_t header            = ssz_get(&finalized, "beacon");
   uint64_t checkpoint_period = ssz_get_uint64(&header, "slot") >> 13;
@@ -363,20 +380,28 @@ static void ps_build_lcu_cb(request_t* req) {
   switch (status) {
     case C4_SUCCESS: {
       // Wrap into the Beacon-API `light_client/updates` wire format so the
-      // existing consumers can parse it without any special-case.
+      // existing consumers can parse it without any special-case. Beacon
+      // nodes emit the 4-byte `ForkDigest` (not the raw fork_version) in
+      // the context slot, so we mirror that here to keep self-built and
+      // beacon-served entries indistinguishable to downstream parsers.
+      // Gloas LCU starts with attestedHeader.beacon.slot (uint64 LE).
+      // The digest is epoch-dependent after Fulu (EIP-7892 BPO mix-in).
       const chain_spec_t* chain = c4_eth_get_chain_spec(ctx->chain_id);
-      if (!chain || !chain->fork_version_func) {
-        // Defense-in-depth: every registered chain sets `fork_version_func`,
-        // but a future entry might forget. Fail loudly instead of NULL-deref.
-        log_warn("period_store: LCU self-build for period %l: chain spec missing fork_version_func", period);
+      uint64_t            slot  = (lcu_ssz.len >= 8) ? uint64_from_le(lcu_ssz.data) : 0;
+      uint64_t            epoch = epoch_for_slot(slot, chain);
+      uint8_t             fork_digest[4] = {0};
+      if (!c4_eth_compute_fork_digest(ctx->chain_id, epoch, fork_digest)) {
+        // Defense-in-depth: `c4_eth_compute_fork_digest` only fails if the
+        // chain spec is missing `fork_version_func` or `genesis_validators_root`,
+        // both of which every registered chain sets. Fail loudly instead of
+        // silently writing zeros.
+        log_warn("period_store: LCU self-build for period %l: cannot compute fork digest", period);
         safe_free(lcu_ssz.data);
         c4_prover_free(ctx);
         safe_free(req);
         return;
       }
-      uint8_t fork_version[4] = {0};
-      chain->fork_version_func(ctx->chain_id, C4_FORK_GLOAS, fork_version);
-      bytes_t wire = c4_gloas_lcu_wrap_beacon_response(lcu_ssz, fork_version);
+      bytes_t wire = c4_gloas_lcu_wrap_beacon_response(lcu_ssz, fork_digest);
       safe_free(lcu_ssz.data);
       if (!wire.data) {
         log_warn("period_store: LCU self-build wrapping failed for period %l", period);

--- a/src/chains/eth/ssz/beacon_types.c
+++ b/src/chains/eth/ssz/beacon_types.c
@@ -25,6 +25,7 @@
 
 #include "beacon_types.h"
 #include "ssz.h"
+#include <stdint.h>
 
 // fork_epochs[n] = activation epoch of fork (n+1) (Altair ..).
 // 0 = active at genesis. NOT_ASSIGNED_YET = not scheduled. Terminated by FORKS_END.
@@ -67,6 +68,21 @@ static const eth_blob_schedule_t eth_gnosis_blob_schedule[] = {
     {1746021820ULL, 1112826ULL}, // Prague/Pectra
     {1710181820ULL, 1112826ULL}, // Cancun/Deneb
     {0ULL, 0ULL},
+};
+
+// Consensus-layer BLOB_SCHEDULE (epoch + max_blobs). Used by
+// `compute_fork_digest` after Fulu (EIP-7892). Values from
+// `ethereum/consensus-specs` configs and `eth-clients/{mainnet,sepolia}`.
+static const eth_cl_blob_schedule_t eth_mainnet_cl_blob_schedule[] = {
+    {412672ULL, 15}, // BPO1 (2025-12-09)
+    {419072ULL, 21}, // BPO2 (2026-01-07)
+    {0, 0},
+};
+
+static const eth_cl_blob_schedule_t eth_sepolia_cl_blob_schedule[] = {
+    {274176ULL, 15}, // BPO1
+    {275712ULL, 21}, // BPO2
+    {0, 0},
 };
 
 static const eth_blob_schedule_t eth_chiado_blob_schedule[] = {
@@ -121,7 +137,8 @@ static const chain_spec_t chain_data[] = {
      .epochs_per_period_bits   = 8,
      .weak_subjectivity_epochs = 3682,
      .fork_version_func        = mainnet_fork_version,
-     .blob_schedule            = eth_mainnet_blob_schedule},
+     .blob_schedule            = eth_mainnet_blob_schedule,
+     .cl_blob_schedule         = eth_mainnet_cl_blob_schedule},
     {// Sepolia
      .chain_id                 = CHAIN_ID(C4_CHAIN_TYPE_ETHEREUM, 11155111),
      .fork_epochs              = eth_sepolia_fork_epochs,
@@ -131,7 +148,8 @@ static const chain_spec_t chain_data[] = {
      .epochs_per_period_bits   = 8,
      .weak_subjectivity_epochs = 3682,
      .fork_version_func        = sepolia_fork_version,
-     .blob_schedule            = eth_sepolia_blob_schedule},
+     .blob_schedule            = eth_sepolia_blob_schedule,
+     .cl_blob_schedule         = eth_sepolia_cl_blob_schedule},
     {// Plataberget
      .chain_id                 = CHAIN_ID(C4_CHAIN_TYPE_ETHEREUM, 7091047534),
      .fork_epochs              = eth_plataberget_fork_epochs,
@@ -150,8 +168,9 @@ static const chain_spec_t chain_data[] = {
      .epochs_per_period_bits   = 9,
      .weak_subjectivity_epochs = 1500,
      .fork_version_func        = gnosis_fork_version,
-     .blob_schedule            = eth_gnosis_blob_schedule,
-     .min_blob_base_fee        = 1000000000ULL},
+     .blob_schedule               = eth_gnosis_blob_schedule,
+     .min_blob_base_fee           = 1000000000ULL,
+     .electra_max_blobs_per_block = 2},
     {// Gnosis chiado
      .chain_id                 = CHAIN_ID(C4_CHAIN_TYPE_ETHEREUM, 10200ULL),
      .fork_epochs              = eth_chiado_fork_epochs,
@@ -160,8 +179,9 @@ static const chain_spec_t chain_data[] = {
      .epochs_per_period_bits   = 9,
      .weak_subjectivity_epochs = 1500,
      .fork_version_func        = gnosis_fork_version,
-     .blob_schedule            = eth_chiado_blob_schedule,
-     .min_blob_base_fee        = 1000000000ULL},
+     .blob_schedule               = eth_chiado_blob_schedule,
+     .min_blob_base_fee           = 1000000000ULL,
+     .electra_max_blobs_per_block = 2},
 };
 
 const chain_spec_t* c4_eth_get_chain_spec(chain_id_t id) {
@@ -225,6 +245,22 @@ bool c4_chain_schedules_fork(chain_id_t chain_id, fork_id_t fork) {
     n++;
   }
   return false;
+}
+
+uint64_t c4_chain_fork_epoch(chain_id_t chain_id, fork_id_t fork) {
+  const chain_spec_t* spec = c4_eth_get_chain_spec(chain_id);
+  if (!spec || !spec->fork_epochs) return UINT64_MAX;
+  if (fork <= C4_FORK_PHASE0) return 0;
+  unsigned want = (unsigned) fork - 1;
+  unsigned n    = 0;
+  while (spec->fork_epochs[n] != FORKS_END) {
+    if (n == want) {
+      uint64_t epoch = spec->fork_epochs[n];
+      return epoch < FORKS_END ? epoch : UINT64_MAX;
+    }
+    n++;
+  }
+  return UINT64_MAX;
 }
 
 // Generalized indices for the fork-specific `BeaconState` layout used by the

--- a/src/chains/eth/ssz/beacon_types.h
+++ b/src/chains/eth/ssz/beacon_types.h
@@ -120,17 +120,34 @@ typedef struct {
   uint64_t update_fraction;
 } eth_blob_schedule_t;
 
+/**
+ * Consensus-layer `BLOB_SCHEDULE` entry (EIP-7892 / Fulu).
+ *
+ * Used by `compute_fork_digest` after `FULU_FORK_EPOCH`: the digest is
+ * `xor(base_digest, sha256(epoch || max_blobs_per_block))[:4]`. Distinct
+ * from `eth_blob_schedule_t`, which carries the execution-layer
+ * `BLOB_BASE_FEE_UPDATE_FRACTION` keyed by timestamp.
+ *
+ * Tables are ASCENDING by epoch and terminated by `{0, 0}`.
+ */
 typedef struct {
-  chain_id_t                 chain_id;
-  const uint64_t*            fork_epochs;
-  const bytes32_t            genesis_validators_root;
-  const bytes32_t            zk_sync_keys_root;        // initial zk sync keys root
-  const int                  slots_per_epoch_bits;     // 5 = 32 slots per epoch
-  const int                  epochs_per_period_bits;   // 8 = 256 epochs per period
-  const uint64_t             weak_subjectivity_epochs; // max epochs before checkpoint validation required
-  fork_version_func_t        fork_version_func;
-  const eth_blob_schedule_t* blob_schedule;            // EIP-7892 blob schedule, DESCENDING by timestamp, {0,0}-terminated; NULL uses Cancun default
-  uint64_t                   min_blob_base_fee;        // MIN_BLOB_BASE_FEE (`minBlobGasPrice`); 0 uses Ethereum's default (1 wei). Gnosis / Chiado use 1e9.
+  uint64_t epoch;
+  uint64_t max_blobs_per_block;
+} eth_cl_blob_schedule_t;
+
+typedef struct {
+  chain_id_t                    chain_id;
+  const uint64_t*               fork_epochs;
+  const bytes32_t               genesis_validators_root;
+  const bytes32_t               zk_sync_keys_root;        // initial zk sync keys root
+  const int                     slots_per_epoch_bits;     // 5 = 32 slots per epoch
+  const int                     epochs_per_period_bits;   // 8 = 256 epochs per period
+  const uint64_t                weak_subjectivity_epochs; // max epochs before checkpoint validation required
+  fork_version_func_t           fork_version_func;
+  const eth_blob_schedule_t*    blob_schedule;            // EIP-7892 EL schedule, DESCENDING by timestamp, {0,0}-terminated; NULL uses Cancun default
+  uint64_t                      min_blob_base_fee;           // MIN_BLOB_BASE_FEE (`minBlobGasPrice`); 0 uses Ethereum's default (1 wei). Gnosis / Chiado use 1e9.
+  const eth_cl_blob_schedule_t* cl_blob_schedule;            // EIP-7892 CL BLOB_SCHEDULE, ASCENDING by epoch, {0,0}-terminated; NULL = no BPO entries
+  uint64_t                      electra_max_blobs_per_block; // `MAX_BLOBS_PER_BLOCK_ELECTRA` used as the Fulu digest fallback when `BLOB_SCHEDULE` has no matching entry. 0 = Ethereum default (9). Gnosis / Chiado use 2.
 } chain_spec_t;
 
 bool      c4_chain_genesis_validators_root(chain_id_t chain_id, bytes32_t genesis_validators_root);
@@ -145,6 +162,15 @@ fork_id_t c4_chain_fork_id(chain_id_t chain_id, uint64_t epoch);
  * @return true if the fork is on the chain's schedule
  */
 bool                c4_chain_schedules_fork(chain_id_t chain_id, fork_id_t fork);
+/**
+ * Activation epoch of `fork` on `chain_id`.
+ *
+ * @param chain_id chain to inspect
+ * @param fork fork id (Altair or later; Phase0 returns 0)
+ * @return the activation epoch, or `UINT64_MAX` if the fork is unscheduled
+ *         or the chain is unknown
+ */
+uint64_t            c4_chain_fork_epoch(chain_id_t chain_id, fork_id_t fork);
 const chain_spec_t* c4_eth_get_chain_spec(chain_id_t id);
 const ssz_def_t*    eth_ssz_type_for_fork(eth_ssz_type_t type, fork_id_t fork, chain_id_t chain_id);
 

--- a/src/chains/eth/verifier/lcu_wire.c
+++ b/src/chains/eth/verifier/lcu_wire.c
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2026 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "lcu_wire.h"
+
+#include "beacon_types.h"
+#include "bytes.h"
+#include "crypto.h"
+#include "logger.h"
+#include "ssz.h"
+#include "state.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+// Local mirror of the `ForkData` SSZ container used for fork-digest
+// computation. Kept file-local because `FORK_DATA_CONTAINER` in
+// `beacon_header.c` is `static` and we do not want to widen its scope
+// (the digest is only 4 bytes, hashing is cheap, and keeping a private
+// container avoids surprising other callers).
+static const ssz_def_t LCU_WIRE_FORK_DATA[] = {
+    SSZ_BYTE_VECTOR("version", 4),
+    SSZ_BYTES32("state")};
+
+static const ssz_def_t LCU_WIRE_FORK_DATA_CONTAINER =
+    SSZ_CONTAINER("ForkData", LCU_WIRE_FORK_DATA);
+
+// LCU-capable forks in ascending order. Kept as a private table so
+// `fork_from_context` scans exactly the forks the SSZ union supports
+// (mirrors `eth_get_light_client_update`).
+static const fork_id_t LCU_WIRE_CANDIDATE_FORKS[] = {
+    C4_FORK_DENEB,
+    C4_FORK_ELECTRA,
+    C4_FORK_FULU,
+    C4_FORK_GLOAS};
+
+// Loads the 4-byte `fork_version` for `(chain_id, fork)` into `out`.
+// Returns false if the chain spec is unknown.
+static bool load_fork_version(chain_id_t chain_id, fork_id_t fork, uint8_t out[4]) {
+  const chain_spec_t* spec = c4_eth_get_chain_spec(chain_id);
+  if (!spec || !spec->fork_version_func) return false;
+  spec->fork_version_func(chain_id, fork, out);
+  return true;
+}
+
+// `get_blob_parameters(epoch)` from the Fulu spec. `cl_blob_schedule` is
+// ASCENDING; the loop keeps the last entry with `entry.epoch <= epoch`
+// (equivalent to the spec's reverse-sorted first-match). If none apply,
+// falls back to `(ELECTRA_FORK_EPOCH, electra_max_blobs_per_block)`.
+static void get_blob_parameters(chain_id_t chain_id, const chain_spec_t* spec, uint64_t epoch,
+                                uint64_t* out_epoch, uint64_t* out_max_blobs) {
+  *out_epoch     = c4_chain_fork_epoch(chain_id, C4_FORK_ELECTRA);
+  *out_max_blobs = (spec && spec->electra_max_blobs_per_block) ? spec->electra_max_blobs_per_block : 9;
+  if (!spec || !spec->cl_blob_schedule) return;
+  for (const eth_cl_blob_schedule_t* e = spec->cl_blob_schedule; e->epoch || e->max_blobs_per_block; e++) {
+    if (epoch >= e->epoch) {
+      *out_epoch     = e->epoch;
+      *out_max_blobs = e->max_blobs_per_block;
+    }
+  }
+}
+
+bool c4_eth_compute_fork_digest(chain_id_t chain_id, uint64_t epoch, uint8_t out[4]) {
+  if (!out) return false;
+  const chain_spec_t* spec = c4_eth_get_chain_spec(chain_id);
+  if (!spec) return false;
+
+  fork_id_t fork = c4_chain_fork_id(chain_id, epoch);
+  uint8_t   buffer[36] = {0};
+  if (!load_fork_version(chain_id, fork, buffer)) return false;
+  if (!c4_chain_genesis_validators_root(chain_id, buffer + 4)) return false;
+
+  bytes32_t base = {0};
+  ssz_hash_tree_root(ssz_ob(LCU_WIRE_FORK_DATA_CONTAINER, bytes(buffer, 36)), base);
+
+  uint64_t fulu_epoch = c4_chain_fork_epoch(chain_id, C4_FORK_FULU);
+  if (fulu_epoch == UINT64_MAX || epoch < fulu_epoch) {
+    memcpy(out, base, 4);
+    return true;
+  }
+
+  // Fulu / EIP-7892: xor the 32-byte base digest with sha256(epoch || max_blobs)
+  // and take the first 4 bytes.
+  uint64_t blob_epoch = 0;
+  uint64_t max_blobs  = 0;
+  get_blob_parameters(chain_id, spec, epoch, &blob_epoch, &max_blobs);
+  uint8_t mix[16] = {0};
+  uint64_to_le(mix, blob_epoch);
+  uint64_to_le(mix + 8, max_blobs);
+  bytes32_t hashed = {0};
+  sha256(bytes(mix, 16), hashed);
+  for (int i = 0; i < 4; i++) out[i] = (uint8_t) (base[i] ^ hashed[i]);
+  return true;
+}
+
+fork_id_t c4_eth_fork_from_context(chain_id_t chain_id, const uint8_t context[4]) {
+  if (!context) return C4_FORK_INVALID;
+  const chain_spec_t* spec = c4_eth_get_chain_spec(chain_id);
+  if (!spec) return C4_FORK_INVALID;
+
+  // 1) Spec-correct path: match against the digest at every scheduled
+  //    LCU-capable fork's activation epoch.
+  for (size_t i = 0; i < sizeof(LCU_WIRE_CANDIDATE_FORKS) / sizeof(LCU_WIRE_CANDIDATE_FORKS[0]); i++) {
+    fork_id_t fork = LCU_WIRE_CANDIDATE_FORKS[i];
+    if (!c4_chain_schedules_fork(chain_id, fork)) continue;
+    uint64_t epoch = c4_chain_fork_epoch(chain_id, fork);
+    if (epoch == UINT64_MAX) continue;
+    uint8_t digest[4] = {0};
+    if (!c4_eth_compute_fork_digest(chain_id, epoch, digest)) continue;
+    if (memcmp(digest, context, 4) == 0) return fork;
+  }
+
+  // 2) BPO entries share a fork_version with Fulu (or later) but produce a
+  //    different digest. Match those too; the fork id follows the entry's epoch.
+  if (spec->cl_blob_schedule) {
+    for (const eth_cl_blob_schedule_t* e = spec->cl_blob_schedule; e->epoch || e->max_blobs_per_block; e++) {
+      uint8_t digest[4] = {0};
+      if (!c4_eth_compute_fork_digest(chain_id, e->epoch, digest)) continue;
+      if (memcmp(digest, context, 4) == 0) return c4_chain_fork_id(chain_id, e->epoch);
+    }
+  }
+
+  // 3) Compatibility fallback: match against raw `fork_version`. This keeps
+  //    period-store `lcu.ssz` files written by older builds working.
+  for (size_t i = 0; i < sizeof(LCU_WIRE_CANDIDATE_FORKS) / sizeof(LCU_WIRE_CANDIDATE_FORKS[0]); i++) {
+    fork_id_t fork = LCU_WIRE_CANDIDATE_FORKS[i];
+    if (!c4_chain_schedules_fork(chain_id, fork)) continue;
+    uint8_t version[4] = {0};
+    if (!load_fork_version(chain_id, fork, version)) continue;
+    if (memcmp(version, context, 4) == 0) return fork;
+  }
+
+  return C4_FORK_INVALID;
+}
+
+// Reads a chunk header at `pos`. Returns false and (optionally) records an
+// error if the header does not fit or `length` is out of bounds. On success
+// writes the total chunk length (including the 8-byte length prefix) into
+// `*out_chunk_len` and the payload span into `*out_payload`.
+static bool read_chunk(bytes_t     data,
+                       uint32_t    pos,
+                       uint32_t    idx,
+                       c4_state_t* state,
+                       uint32_t*   out_chunk_len,
+                       bytes_t*    out_payload,
+                       const uint8_t** out_context) {
+  // 64-bit compare: `pos + 12` as uint32 wraps near UINT32_MAX.
+  if ((uint64_t) pos + C4_LCU_WIRE_PREFIX_SIZE > (uint64_t) data.len) {
+    if (state) c4_state_add_error(state, "LCU list: truncated chunk header");
+    return false;
+  }
+  uint64_t length = uint64_from_le(data.data + pos);
+  // `length` counts the 4-byte context plus the SSZ payload.
+  if (length < C4_LCU_WIRE_CONTEXT_SIZE) {
+    if (state) c4_state_add_error(state, "LCU list: chunk length below context size");
+    return false;
+  }
+  // Compare against remaining bytes after the 8-byte length prefix.
+  // Do NOT compute `pos + 8 + length` in uint64: a hostile `length` near
+  // UINT64_MAX wraps that sum and would pass a `chunk_end > data.len` check,
+  // then yield `chunk_len == 0` (infinite walk) or a huge truncated payload.
+  uint64_t remaining = (uint64_t) data.len - (uint64_t) pos - C4_LCU_WIRE_LENGTH_SIZE;
+  if (length > remaining) {
+    if (state) c4_state_add_error(state, "LCU list: chunk length exceeds buffer");
+    return false;
+  }
+
+  *out_chunk_len = (uint32_t) (C4_LCU_WIRE_LENGTH_SIZE + length);
+  *out_payload   = bytes(data.data + pos + C4_LCU_WIRE_PREFIX_SIZE,
+                         (uint32_t) (length - C4_LCU_WIRE_CONTEXT_SIZE));
+  *out_context   = data.data + pos + C4_LCU_WIRE_LENGTH_SIZE;
+  (void) idx;
+  return true;
+}
+
+// Framing-only walk. Verifies that every chunk header fits, `length >= 4`,
+// and chunks tile `data` end-to-end (no gaps, no tail). Does NOT touch the
+// payload; SSZ / fork checks are performed in a second pass.
+static bool validate_framing(bytes_t data, c4_state_t* state, uint32_t* out_count) {
+  uint32_t pos   = 0;
+  uint32_t count = 0;
+  while (pos < data.len) {
+    uint32_t       chunk_len = 0;
+    bytes_t        payload   = NULL_BYTES;
+    const uint8_t* context   = NULL;
+    if (!read_chunk(data, pos, count, state, &chunk_len, &payload, &context))
+      return false;
+    pos += chunk_len;
+    count++;
+  }
+  // Loop invariant `pos <= data.len` is guaranteed by `read_chunk`; if we
+  // exit the loop `pos == data.len`, so there is no explicit tail check.
+  if (out_count) *out_count = count;
+  return true;
+}
+
+bool c4_eth_walk_lcu_list(chain_id_t        chain_id,
+                          bytes_t           data,
+                          c4_state_t*       state,
+                          data_request_t*   req,
+                          bool              validate_ssz,
+                          c4_lcu_chunk_cb_t cb,
+                          void*             user) {
+  // Empty list is a valid framing.
+  if (data.len == 0) {
+    if (req) req->validated = true;
+    return true;
+  }
+  if (!data.data) {
+    if (state) c4_state_add_error(state, "LCU list: NULL buffer with non-zero length");
+    return false;
+  }
+
+  // Pass 1: framing only. This is what earns the request its `validated`
+  // flag -- the acceptance criterion in issue #356 explicitly ties
+  // `validated` to structural framing, not to per-chunk SSZ.
+  uint32_t count = 0;
+  if (!validate_framing(data, state, &count)) return false;
+  if (req) req->validated = true;
+
+  // Pass 2: fork resolution, optional SSZ + slot cross-check, callback.
+  uint32_t pos = 0;
+  uint32_t idx = 0;
+  while (pos < data.len) {
+    uint32_t       chunk_len = 0;
+    bytes_t        payload   = NULL_BYTES;
+    const uint8_t* context   = NULL;
+    // Framing already validated -- this cannot fail unless memory changed
+    // under us; keep the check as defense-in-depth.
+    if (!read_chunk(data, pos, idx, state, &chunk_len, &payload, &context))
+      return false;
+
+    fork_id_t fork = c4_eth_fork_from_context(chain_id, context);
+    if (fork == C4_FORK_INVALID) {
+      if (state) c4_state_add_error(state, "LCU chunk: unknown fork context (digest/version mismatch)");
+      return false;
+    }
+
+    const ssz_def_t* def = eth_get_light_client_update(fork);
+    if (!def) {
+      if (state) c4_state_add_error(state, "LCU chunk: no SSZ def for resolved fork");
+      return false;
+    }
+
+    ssz_ob_t update = {.bytes = payload, .def = def};
+
+    if (validate_ssz) {
+      if (!ssz_is_valid(update, true, state)) {
+        if (state) c4_state_add_error(state, "LCU chunk: invalid SSZ payload");
+        return false;
+      }
+      // Slot cross-check: the fork implied by `attestedHeader.beacon.slot`
+      // must match the context-derived fork. Signature-slot is intentionally
+      // *not* cross-checked here -- per the light-client spec the fork used
+      // for `sync_aggregate` verification can differ from the digest fork
+      // (which follows the attested header).
+      ssz_ob_t            attested = ssz_get(&update, "attestedHeader");
+      ssz_ob_t            beacon   = ssz_get(&attested, "beacon");
+      uint64_t            slot     = ssz_get_uint64(&beacon, "slot");
+      const chain_spec_t* spec     = c4_eth_get_chain_spec(chain_id);
+      fork_id_t           slot_fork = c4_chain_fork_id(chain_id, epoch_for_slot(slot, spec));
+      if (slot_fork != fork) {
+        if (state) c4_state_add_error(state, "LCU chunk: attested-header slot fork disagrees with context digest");
+        return false;
+      }
+    }
+
+    if (cb) {
+      c4_lcu_chunk_t chunk = {
+          .index   = idx,
+          .fork    = fork,
+          .update  = update,
+          .context = context,
+      };
+      if (!cb(user, &chunk)) return false;
+    }
+
+    pos += chunk_len;
+    idx++;
+  }
+
+  (void) count;
+  return true;
+}
+
+// Resolves the bootstrap fork from the wire layout:
+//   - Gloas has no variable field, so we match on the total size.
+//   - Deneb / Electra / Fulu have a leading `header` offset (variable field)
+//     whose value equals the container's fixed portion -- 24788 for Deneb
+//     and 24820 for Electra/Fulu. We match on that offset instead of the
+//     total size, which depends on `execution.extraData` and is not fixed.
+static fork_id_t detect_bootstrap_fork(bytes_t data) {
+  if (data.len == C4_ETH_GLOAS_BOOTSTRAP_SIZE) return C4_FORK_GLOAS;
+  if (data.len < C4_ETH_DENEB_BOOTSTRAP_FIXED_SIZE) return C4_FORK_INVALID;
+  uint32_t hdr_offset = uint32_from_le(data.data);
+  // The header offset must lie strictly inside the buffer.
+  if (hdr_offset >= data.len) return C4_FORK_INVALID;
+  if (hdr_offset == C4_ETH_DENEB_BOOTSTRAP_FIXED_SIZE) return C4_FORK_DENEB;
+  if (hdr_offset == C4_ETH_ELECTRA_BOOTSTRAP_FIXED_SIZE) return C4_FORK_ELECTRA;
+  return C4_FORK_INVALID;
+}
+
+bool c4_eth_decode_bootstrap(chain_id_t      chain_id,
+                             bytes_t         data,
+                             c4_state_t*     state,
+                             data_request_t* req,
+                             ssz_ob_t*       out) {
+  if (!out) return false;
+  if (data.len > 0 && !data.data) {
+    if (state) c4_state_add_error(state, "Bootstrap: NULL buffer with non-zero length");
+    return false;
+  }
+  fork_id_t fork = detect_bootstrap_fork(data);
+  if (fork == C4_FORK_INVALID) {
+    if (state) c4_state_add_error(state, "Bootstrap: cannot resolve fork from wire layout");
+    return false;
+  }
+
+  // Defense-in-depth: reject a chain that has not scheduled the fork implied
+  // by the size / layout. This prevents e.g. accepting a Gloas-sized blob on
+  // a chain that has not yet activated Gloas. Only meaningful for Electra
+  // and later -- Deneb is unconditionally present on all supported chains.
+  if (fork >= C4_FORK_ELECTRA && !c4_chain_schedules_fork(chain_id, fork)) {
+    if (state) c4_state_add_error(state, "Bootstrap: fork implied by wire layout is not scheduled on chain");
+    return false;
+  }
+
+  const ssz_def_t* def = eth_get_light_client_bootstrap(fork);
+  if (!def) {
+    if (state) c4_state_add_error(state, "Bootstrap: no SSZ def for resolved fork");
+    return false;
+  }
+
+  ssz_ob_t view = {.bytes = data, .def = def};
+  if (!(req && req->validated)) {
+    if (!ssz_is_valid(view, true, state)) {
+      if (state) c4_state_add_error(state, "Bootstrap: invalid SSZ structure");
+      return false;
+    }
+    if (req) req->validated = true;
+  }
+
+  *out = view;
+  return true;
+}

--- a/src/chains/eth/verifier/lcu_wire.h
+++ b/src/chains/eth/verifier/lcu_wire.h
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2026 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Shared helpers for Beacon-API light-client wire framing:
+ *   - `light_client/updates` list framing + `ForkDigest` -> fork resolution.
+ *   - `light_client/bootstrap` size-based fork detection.
+ *
+ * Central home for the LCU/Bootstrap wire logic that used to live scattered
+ * across `sync_committee.c`, `historic_proof.c`, `proof_sync.c` and
+ * `period_store_lc.c`. The old slot-heuristic `c4_eth_get_fork_for_lcu`
+ * has been replaced by:
+ *
+ *   - `c4_eth_fork_from_context` for LCU chunks (uses the 4-byte
+ *     `context = compute_fork_digest(gvr, epoch)` from the wire prefix,
+ *     including the Fulu/EIP-7892 blob-parameter mix-in).
+ *   - `c4_eth_decode_bootstrap` for `LightClientBootstrap` blobs (uses
+ *     the fixed container size plus `ssz_is_valid`).
+ *
+ * See `<repo>/AGENTS.md` and GitHub issue #356 for background.
+ */
+
+#ifndef lcu_wire_h__
+#define lcu_wire_h__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "beacon_types.h"
+#include "bytes.h"
+#include "chains.h"
+#include "ssz.h"
+#include "state.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * Wire-format constants for `GET eth/v1/beacon/light_client/updates`.
+ *
+ * Each chunk is:
+ *
+ * ```text
+ *   [0 .. 8)   uint64 LE length (= 4 + payload_len)
+ *   [8 .. 12)  ForkDigest context (4 bytes)
+ *   [12 ..)    SSZ payload
+ * ```
+ */
+#define C4_LCU_WIRE_LENGTH_SIZE  8u
+#define C4_LCU_WIRE_CONTEXT_SIZE 4u
+#define C4_LCU_WIRE_PREFIX_SIZE  (C4_LCU_WIRE_LENGTH_SIZE + C4_LCU_WIRE_CONTEXT_SIZE)
+
+/**
+ * Bootstrap fork detection anchors.
+ *
+ * Bootstrap has no context/digest on the wire (Beacon API exposes the fork
+ * via `Eth-Consensus-Version` response header, which we do not persist on
+ * `data_request_t`). The Deneb / Electra / Fulu bootstrap containers are
+ * *not* fixed size because the embedded `LightClientHeader.execution` has
+ * a variable `extraData` list. Their fork-defining discriminator is instead
+ * the size of the container's fixed portion -- i.e. the value of the leading
+ * `header` offset in an SSZ container with one variable field first:
+ *
+ * - Deneb        : 4 + sync_committee(24624) + branch(5*32)  = 24788
+ * - Electra/Fulu : 4 + sync_committee(24624) + branch(6*32)  = 24820
+ *
+ * The Gloas bootstrap has no variable field (Gloas replaces the whole
+ * execution payload with just `executionBlockHash`), so its total size
+ * is deterministic:
+ *
+ * - Gloas        : header(496) + sync_committee(24624) + branch(11*32) = 25472
+ */
+#define C4_ETH_DENEB_BOOTSTRAP_FIXED_SIZE   24788u
+#define C4_ETH_ELECTRA_BOOTSTRAP_FIXED_SIZE 24820u
+#define C4_ETH_GLOAS_BOOTSTRAP_SIZE         25472u // must equal `C4_GLOAS_BOOTSTRAP_SIZE` in bootstrap_gloas.h
+
+/**
+ * View into a single chunk of a light-client-update list, produced by
+ * `c4_eth_walk_lcu_list`. The `update` is a *view* into the caller's
+ * buffer -- no allocation, no ownership.
+ */
+typedef struct {
+  uint32_t       index;   ///< 0-based position of the chunk inside the list
+  fork_id_t      fork;    ///< fork resolved from the wire `context` (never `C4_FORK_INVALID`)
+  ssz_ob_t       update;  ///< `.bytes` = payload (without the 12-byte wire prefix), `.def` = LCU SSZ def for `fork`
+  const uint8_t* context; ///< pointer into the source buffer at the 4-byte context (borrowed, do not free)
+} c4_lcu_chunk_t;
+
+/**
+ * Callback invoked once per chunk by `c4_eth_walk_lcu_list`.
+ *
+ * Return `false` to abort the walk; the walker returns `false`. Framing
+ * may already have set `req->validated` (see `c4_eth_walk_lcu_list`).
+ *
+ * @param user opaque pointer passed through from the walker call
+ * @param chunk borrowed view of the current chunk (invalidated after return)
+ * @return `true` to continue, `false` to abort
+ */
+typedef bool (*c4_lcu_chunk_cb_t)(void* user, const c4_lcu_chunk_t* chunk);
+
+/**
+ * Computes the 4-byte `ForkDigest` for `(chain_id, epoch)`.
+ *
+ * Pre-Fulu this is `hash_tree_root(ForkData{version, gvr})[:4]`. From Fulu
+ * onward (EIP-7892) the digest is mixed with the active blob parameters:
+ *
+ * ```text
+ * xor(base_digest, sha256(uint64_le(blob_epoch) || uint64_le(max_blobs)))[:4]
+ * ```
+ *
+ * so BPO forks (same `fork_version`, different blob limit) produce distinct
+ * digests. Beacon nodes emit this value as the 4-byte LCU-list context.
+ *
+ * @param chain_id chain to resolve
+ * @param epoch epoch the digest is computed for (typically the attested-header epoch)
+ * @param out receives the 4 fork-digest bytes on success (untouched on failure)
+ * @return `true` on success, `false` if the chain or fork version cannot be resolved
+ */
+bool c4_eth_compute_fork_digest(chain_id_t chain_id, uint64_t epoch, uint8_t out[4]);
+
+/**
+ * Resolves a 4-byte wire `context` to a fork id.
+ *
+ * Compares `context` against `compute_fork_digest` at every scheduled
+ * LCU-capable fork's activation epoch and at every CL `BLOB_SCHEDULE`
+ * entry (BPO1, BPO2, ...). As a compatibility fallback, `context` is also
+ * matched against the raw 4-byte `fork_version` of each fork -- this
+ * catches legacy period-store `lcu.ssz` files that wrote `fork_version`
+ * instead of `ForkDigest`.
+ *
+ * @param chain_id chain the wire data belongs to
+ * @param context 4-byte context / fork-version bytes from the wire prefix
+ * @return matching `fork_id_t`, or `C4_FORK_INVALID` if no scheduled fork matches
+ */
+fork_id_t c4_eth_fork_from_context(chain_id_t chain_id, const uint8_t context[4]);
+
+/**
+ * Validates the framing of a Beacon-API `light_client/updates` list and, for
+ * each chunk, resolves the fork from the wire `context`, optionally runs
+ * `ssz_is_valid` on the payload, and invokes `cb`.
+ *
+ * Framing rules (per Beacon API spec):
+ * - Each chunk: `[uint64 LE length][4 B context][payload of length-4 bytes]`.
+ * - `length >= 4` (must include the 4-byte context).
+ * - Chunks tile the buffer with no gaps or overlaps and no tail garbage.
+ * - Empty buffer (`data.len == 0`) is a valid empty list.
+ *
+ * When `validate_ssz` is `true`, each chunk's payload is checked with
+ * `ssz_is_valid` (recursive) before `cb` runs, and the chunk's fork is
+ * cross-checked against the fork implied by `attestedHeader.beacon.slot`.
+ * A mismatch is rejected as if the framing were invalid.
+ *
+ * On successful **framing** (chunks tile the buffer) and `req != NULL`,
+ * `req->validated` is set to `true` before Pass 2. That is the #356
+ * contract: `validated` means the list structure is well-formed, not that
+ * every payload passed `ssz_is_valid` or every callback returned true.
+ * A later semantic failure still returns `false` and records an error.
+ * Errors are appended to `state`.
+ *
+ * @param chain_id chain the wire data belongs to
+ * @param data raw wire bytes; the walker never mutates or frees this buffer
+ * @param state receives error messages (may be `NULL` to suppress)
+ * @param req optional request whose `validated` flag is set on success
+ * @param validate_ssz run `ssz_is_valid` + slot cross-check per chunk
+ * @param cb per-chunk callback (may be `NULL` to only validate framing)
+ * @param user opaque pointer forwarded to `cb`
+ * @return `true` iff the whole list validates and no callback aborted
+ */
+bool c4_eth_walk_lcu_list(chain_id_t        chain_id,
+                          bytes_t           data,
+                          c4_state_t*       state,
+                          data_request_t*   req,
+                          bool              validate_ssz,
+                          c4_lcu_chunk_cb_t cb,
+                          void*             user);
+
+/**
+ * Decodes a `LightClientBootstrap` blob by detecting the fork from the
+ * container size, then running `ssz_is_valid`.
+ *
+ * On success: `out->bytes = data`, `out->def` resolves to the correct
+ * fork variant, and (when `req != NULL`) `req->validated = true`.
+ * The `data` buffer is *not* copied -- `out->bytes.data` aliases it and
+ * remains owned by the caller.
+ *
+ * @param chain_id chain the bootstrap belongs to (used for `ssz_is_valid` context)
+ * @param data raw SSZ bytes of the bootstrap
+ * @param state receives error messages (may be `NULL` to suppress)
+ * @param req optional request whose `validated` flag is set on success
+ * @param out receives the typed SSZ view on success
+ * @return `true` on success, `false` if the size is unknown or SSZ validation fails
+ */
+bool c4_eth_decode_bootstrap(chain_id_t      chain_id,
+                             bytes_t         data,
+                             c4_state_t*     state,
+                             data_request_t* req,
+                             ssz_ob_t*       out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/chains/eth/verifier/sync_committee.c
+++ b/src/chains/eth/verifier/sync_committee.c
@@ -26,6 +26,7 @@
 #include "crypto.h"
 #include "eth_verify.h"
 #include "json.h"
+#include "lcu_wire.h"
 #include "logger.h"
 #include "plugin.h"
 #include "ssz.h"
@@ -488,21 +489,6 @@ INTERNAL c4_status_t c4_update_from_sync_data(verify_ctx_t* ctx) {
     RETURN_VERIFY_ERROR_STATUS(ctx, "unknown sync_data type!");
 }
 
-fork_id_t c4_eth_get_fork_for_lcu(chain_id_t chain_id, bytes_t data) {
-  if (data.len < 4) return 0;
-  uint64_t slot   = 0;
-  uint32_t offset = uint32_from_le(data.data);
-  if (offset + 8 > data.len)
-    // this is most likely a gloas bootstrap!
-    // TODO(gloas): this may break if the lower 4 bytes of the slot are smaller than the lcu length.
-    // so in 99% of the cases it will work, but we should find a better way to detect the fork.
-    slot = uint64_from_le(data.data);
-  else
-    slot = uint64_from_le(data.data + offset);
-  const chain_spec_t* spec = c4_eth_get_chain_spec(chain_id);
-  return c4_chain_fork_id(chain_id, epoch_for_slot(slot, spec));
-}
-
 /**
  * Detects the format of light client updates (Standard SSZ or Lighthouse variant).
  * Lighthouse format uses a different offset structure.
@@ -517,55 +503,75 @@ static bool detect_update_format(bytes_t data) {
          uint32_from_le(data.data) < 1000;
 }
 
-/**
- * Process light client updates with a callback function for each update.
- * This handles both standard SSZ and Lighthouse formats.
- *
- * @param ctx Verification context
- * @param light_client_updates Raw bytes containing one or more light client updates
- * @param process_update Callback function to process each individual update
- * @return true if all updates were processed successfully, false otherwise
- */
-INTERNAL bool c4_process_light_client_updates(verify_ctx_t* ctx, bytes_t light_client_updates, bool (*process_update)(verify_ctx_t*, ssz_ob_t*)) {
-  uint64_t length     = 0;
-  bool     success    = true;
-  bool     lighthouse = detect_update_format(light_client_updates);
-  int      idx        = 0;
+// Trampoline that adapts the walker's `c4_lcu_chunk_cb_t` to the verifier's
+// `(verify_ctx_t*, ssz_ob_t*)` callback signature.
+typedef struct {
+  verify_ctx_t* ctx;
+  bool (*process_update)(verify_ctx_t*, ssz_ob_t*);
+} lcu_verify_cb_ctx_t;
 
-  // Per-update ssz_is_valid only. The enclosing list request stays
-  // unvalidated until a list-level check exists.
+static bool lcu_verify_chunk_cb(void* user, const c4_lcu_chunk_t* chunk) {
+  lcu_verify_cb_ctx_t* c = (lcu_verify_cb_ctx_t*) user;
+  // `chunk->update` is const in intent, but `ssz_get` / callers may mutate
+  // ancillary caches inside the ssz_ob_t. Copy locally to keep the
+  // walker-owned view untouched.
+  ssz_ob_t update = chunk->update;
+  return c->process_update(c->ctx, &update);
+}
+
+// Legacy fallback for the Lighthouse variant of the update list. Lighthouse
+// clients emit a per-list SSZ offset table instead of the Beacon-API framing,
+// so we cannot feed it into `c4_eth_walk_lcu_list`. Kept as a pre-existing
+// compatibility path -- issue #356 leaves the Lighthouse format out of scope.
+static bool process_lighthouse_updates(verify_ctx_t* ctx, bytes_t light_client_updates, bool (*process_update)(verify_ctx_t*, ssz_ob_t*)) {
+  uint64_t length  = 0;
+  bool     success = true;
+  int      idx     = 0;
+
   for (uint32_t pos = 0; pos + UPDATE_PREFIX_SIZE < light_client_updates.len; pos += length + SSZ_LENGTH_SIZE, idx++) {
-    uint32_t data_offset        = pos + SSZ_LENGTH_SIZE + SSZ_OFFSET_SIZE;
-    uint32_t data_length_offset = SSZ_OFFSET_SIZE;
+    uint32_t data_offset = pos + SSZ_LENGTH_SIZE + SSZ_OFFSET_SIZE;
 
-    if (lighthouse) {
-      // Check bounds before reading offset
-      if (idx * SSZ_OFFSET_SIZE + SSZ_OFFSET_SIZE > light_client_updates.len) {
-        success = false;
-        c4_state_add_error(&ctx->state, "invalid lighthouse index exceeds data bounds!");
-        break;
-      }
-      pos = uint32_from_le(light_client_updates.data + (idx * SSZ_OFFSET_SIZE));
-      if (pos + UPDATE_PREFIX_SIZE > light_client_updates.len) {
-        success = false;
-        c4_state_add_error(&ctx->state, "invalid offset in lighthouse client update!");
-        break;
-      }
-      data_offset = pos + LIGHTHOUSE_OFFSET_SIZE + SSZ_OFFSET_SIZE;
+    // Check bounds before reading offset
+    if (idx * SSZ_OFFSET_SIZE + SSZ_OFFSET_SIZE > light_client_updates.len) {
+      success = false;
+      c4_state_add_error(&ctx->state, "invalid lighthouse index exceeds data bounds!");
+      break;
     }
+    pos = uint32_from_le(light_client_updates.data + (idx * SSZ_OFFSET_SIZE));
+    if (pos + UPDATE_PREFIX_SIZE > light_client_updates.len) {
+      success = false;
+      c4_state_add_error(&ctx->state, "invalid offset in lighthouse client update!");
+      break;
+    }
+    data_offset = pos + LIGHTHOUSE_OFFSET_SIZE + SSZ_OFFSET_SIZE;
 
     length = uint64_from_le(light_client_updates.data + pos);
 
     // Check for integer overflow and bounds
-    if (length > UPDATE_PREFIX_SIZE && (pos + SSZ_LENGTH_SIZE + length > light_client_updates.len || pos + SSZ_LENGTH_SIZE + length < pos)) {
+    if (length < SSZ_OFFSET_SIZE ||
+        (length > UPDATE_PREFIX_SIZE && (pos + SSZ_LENGTH_SIZE + length > light_client_updates.len || pos + SSZ_LENGTH_SIZE + length < pos))) {
       success = false;
       c4_state_add_error(&ctx->state, "invalid length causes overflow or exceeds bounds!");
       break;
     }
 
-    bytes_t          light_client_update_bytes = bytes(light_client_updates.data + data_offset, length - data_length_offset);
-    fork_id_t        fork                      = c4_eth_get_fork_for_lcu(ctx->chain_id, light_client_update_bytes);
-    const ssz_def_t* light_client_update_def   = eth_get_light_client_update(fork);
+    bytes_t light_client_update_bytes = bytes(light_client_updates.data + data_offset, length - SSZ_OFFSET_SIZE);
+    // Lighthouse framing puts its own header between the length prefix and
+    // the payload -- the 4 bytes at `pos+8` are NOT a ForkDigest. Recover
+    // the fork from the attested-header slot inside the payload (the
+    // pre-#356 heuristic), which is out of scope for the shared walker.
+    uint64_t            slot = 0;
+    if (light_client_update_bytes.len >= 4) {
+      uint32_t hdr_off = uint32_from_le(light_client_update_bytes.data);
+      // 64-bit compare: `hdr_off + 8` as uint32 wraps for hdr_off > UINT32_MAX-8.
+      if ((uint64_t) hdr_off + 8u <= (uint64_t) light_client_update_bytes.len)
+        slot = uint64_from_le(light_client_update_bytes.data + hdr_off);
+      else if (light_client_update_bytes.len >= 8)
+        slot = uint64_from_le(light_client_update_bytes.data);
+    }
+    const chain_spec_t* spec                   = c4_eth_get_chain_spec(ctx->chain_id);
+    fork_id_t           fork                   = c4_chain_fork_id(ctx->chain_id, epoch_for_slot(slot, spec));
+    const ssz_def_t*    light_client_update_def = eth_get_light_client_update(fork);
 
     if (!light_client_update_def) {
       c4_state_add_error(&ctx->state, "light client update: unknown/unsupported fork");
@@ -589,6 +595,31 @@ INTERNAL bool c4_process_light_client_updates(verify_ctx_t* ctx, bytes_t light_c
   }
 
   return success;
+}
+
+/**
+ * Process light client updates with a callback function for each update.
+ *
+ * Uses `c4_eth_walk_lcu_list` for the Beacon-API framing (which also marks
+ * the enclosing `data_request_t` as `validated` on structural success -- see
+ * issue #356). Falls back to a Lighthouse-specific parser when the input is
+ * detected as the offset-table variant.
+ *
+ * @param ctx Verification context
+ * @param light_client_updates Raw bytes containing one or more light client updates
+ * @param process_update Callback function to process each individual update
+ * @return true if all updates were processed successfully, false otherwise
+ */
+INTERNAL bool c4_process_light_client_updates(verify_ctx_t* ctx, bytes_t light_client_updates, bool (*process_update)(verify_ctx_t*, ssz_ob_t*)) {
+  if (detect_update_format(light_client_updates))
+    return process_lighthouse_updates(ctx, light_client_updates, process_update);
+
+  // Standard Beacon-API format: hand off to the shared walker, which also
+  // marks the request `validated` on framing success.
+  data_request_t* src_req = c4_state_get_data_request_by_response(&ctx->state, light_client_updates);
+  lcu_verify_cb_ctx_t cb_ctx = {.ctx = ctx, .process_update = process_update};
+  return c4_eth_walk_lcu_list(ctx->chain_id, light_client_updates, &ctx->state, src_req,
+                              /*validate_ssz*/ true, lcu_verify_chunk_cb, &cb_ctx);
 }
 
 INTERNAL bool c4_handle_client_updates(verify_ctx_t* ctx, bytes_t light_client_updates) {

--- a/src/chains/eth/verifier/sync_committee.h
+++ b/src/chains/eth/verifier/sync_committee.h
@@ -179,17 +179,6 @@ c4_chain_state_t c4_get_chain_state(chain_id_t chain_id);
  */
 void c4_eth_set_trusted_checkpoint(chain_id_t chain_id, bytes32_t checkpoint);
 
-/**
- * Detect the fork for a light client update based on the slot embedded in the payload.
- * Reads the slot from the SSZ-encoded data and determines the fork (Deneb, Electra,
- * Fulu, or Gloas once scheduled).
- *
- * @param chain_id Chain identifier
- * @param data SSZ-encoded light client update data
- * @return Fork identifier corresponding to the slot in the update payload
- */
-fork_id_t c4_eth_get_fork_for_lcu(chain_id_t chain_id, bytes_t data);
-
 // `c4_current_sync_committee_gindex`, `c4_next_sync_committee_gindex` and
 // `c4_finalized_root_gindex` are declared in `beacon_types.h` (which is
 // already included via `#include "beacon_types.h"` above).

--- a/src/chains/eth/verifier/sync_committee_state.c
+++ b/src/chains/eth/verifier/sync_committee_state.c
@@ -52,6 +52,7 @@
 #include "../util/crypto.h"
 #include "../util/logger.h"
 #include "../util/plugin.h"
+#include "./lcu_wire.h"
 #include "./sync_committee.h"
 #include <stdint.h>
 #include <stdio.h>
@@ -323,19 +324,13 @@ static bool req_bootstrap(c4_state_t* state, bytes32_t block_root, chain_id_t ch
 
 c4_status_t c4_handle_bootstrap(verify_ctx_t* ctx, bytes_t bootstrap_data, bytes32_t trusted_checkpoint) {
   // Parse bootstrap data as SSZ. The bootstrap container layout differs by fork
-  // (branch depth changes), so we resolve it via the central helper.
-  fork_id_t        fork          = c4_eth_get_fork_for_lcu(ctx->chain_id, bootstrap_data);
-  const ssz_def_t* bootstrap_def = eth_get_light_client_bootstrap(fork);
-  if (!bootstrap_def) THROW_ERROR("Bootstrap data: unsupported fork");
-  ssz_ob_t  bootstrap             = {.bytes = bootstrap_data, .def = bootstrap_def};
-  bytes32_t previous_pubkeys_hash = {0}; // in case of a bootstrap, there is no previous pubkey hash, so we set it to 0
-
-  data_request_t* src_req = c4_state_get_data_request_by_response(&ctx->state, bootstrap_data);
-  if (!(src_req && src_req->validated)) {
-    if (!ssz_is_valid(bootstrap, true, &ctx->state))
-      THROW_ERROR("Invalid SSZ structure in bootstrap data");
-    if (src_req) src_req->validated = true;
-  }
+  // (branch depth changes), so we resolve it via container size + `ssz_is_valid`
+  // in `c4_eth_decode_bootstrap`. Sets `src_req->validated` on success.
+  ssz_ob_t        bootstrap             = {0};
+  data_request_t* src_req               = c4_state_get_data_request_by_response(&ctx->state, bootstrap_data);
+  bytes32_t       previous_pubkeys_hash = {0}; // in case of a bootstrap, there is no previous pubkey hash, so we set it to 0
+  if (!c4_eth_decode_bootstrap(ctx->chain_id, bootstrap_data, &ctx->state, src_req, &bootstrap))
+    return C4_ERROR;
 
   // Extract components (no need for ssz_is_error checks after validation)
   ssz_ob_t header                 = ssz_get(&bootstrap, "header");
@@ -672,6 +667,23 @@ static c4_sync_validators_t get_validators_from_cache(verify_ctx_t* ctx, uint32_
   return result;
 }
 
+// Helper state for the edge-case sync `c4_try_sync_from_next_period`: capture
+// the first LCU chunk returned by the walker and abort the walk after it.
+// Declared before the `USE_CHECKPOINTZ` gate because the edge-case path is
+// compiled unconditionally.
+typedef struct {
+  bool     have_first;
+  ssz_ob_t first;
+} first_lcu_chunk_t;
+
+static bool capture_first_lcu_chunk_cb(void* user, const c4_lcu_chunk_t* chunk) {
+  first_lcu_chunk_t* f = (first_lcu_chunk_t*) user;
+  if (f->have_first) return false;
+  f->first      = chunk->update;
+  f->have_first = true;
+  return false; // stop the walker after the first chunk
+}
+
 #ifdef USE_CHECKPOINTZ
 /**
  * Anchor a locally derived finalized header root against an external `checkpointz` / Beacon API
@@ -832,6 +844,37 @@ INTERNAL c4_status_t c4_verify_checkpointz_root(verify_ctx_t* ctx, uint64_t slot
  *         malformed bootstrap, `C4_PENDING` while checkpointz or bootstrap requests are
  *         in flight.
  */
+// Helper state for WSP chain-of-trust scan: locate the LCU whose
+// `attestedHeader.beacon.slot` is inside `target_period` and, once found,
+// record `hash_tree_root(nextSyncCommittee.pubkeys)` for the bootstrap
+// cross-check.
+typedef struct {
+  const chain_spec_t* spec;
+  uint32_t            target_period;
+  bool                found;
+  bytes32_t           pubkeys_root;
+} wsp_scan_state_t;
+
+static bool wsp_locate_target_lcu_cb(void* user, const c4_lcu_chunk_t* chunk) {
+  wsp_scan_state_t* scan = (wsp_scan_state_t*) user;
+  if (scan->found) return false; // stop the walker as soon as we have a hit
+
+  ssz_ob_t update          = chunk->update;
+  ssz_ob_t attested        = ssz_get(&update, "attestedHeader");
+  ssz_ob_t attested_beacon = ssz_get(&attested, "beacon");
+  uint64_t attested_slot   = ssz_get_uint64(&attested_beacon, "slot");
+  uint32_t attested_period = (uint32_t) (attested_slot >> (scan->spec->slots_per_epoch_bits + scan->spec->epochs_per_period_bits));
+
+  if (attested_period == scan->target_period) {
+    ssz_ob_t next_sync_committee = ssz_get(&update, "nextSyncCommittee");
+    ssz_ob_t next_pubkeys        = ssz_get(&next_sync_committee, "pubkeys");
+    ssz_hash_tree_root(next_pubkeys, scan->pubkeys_root);
+    scan->found = true;
+    return false; // abort the walk; we have what we need
+  }
+  return true;
+}
+
 static c4_status_t c4_check_weak_subjectivity(verify_ctx_t* ctx, c4_sync_validators_t* sync_state, uint32_t target_period) {
   const chain_spec_t* spec = c4_eth_get_chain_spec(ctx->chain_id);
   if (!spec) return C4_SUCCESS; // Cannot validate without spec
@@ -860,20 +903,11 @@ static c4_status_t c4_check_weak_subjectivity(verify_ctx_t* ctx, c4_sync_validat
     return ctx->state.error ? C4_ERROR : C4_PENDING;
 
   // 3. Parse the bootstrap SSZ and bind the header to the checkpointz root.
-  fork_id_t        fork          = c4_eth_get_fork_for_lcu(ctx->chain_id, bootstrap_data);
-  const ssz_def_t* bootstrap_def = eth_get_light_client_bootstrap(fork);
-  if (!bootstrap_def) {
-    clear_sync_state(ctx->chain_id);
-    return c4_state_add_error(&ctx->state, "WSP bootstrap: unsupported fork");
-  }
-  ssz_ob_t        bootstrap = {.bytes = bootstrap_data, .def = bootstrap_def};
+  ssz_ob_t        bootstrap = {0};
   data_request_t* src_req   = c4_state_get_data_request_by_response(&ctx->state, bootstrap_data);
-  if (!(src_req && src_req->validated)) {
-    if (!ssz_is_valid(bootstrap, true, &ctx->state)) {
-      clear_sync_state(ctx->chain_id);
-      return c4_state_add_error(&ctx->state, "WSP bootstrap: invalid SSZ structure");
-    }
-    if (src_req) src_req->validated = true;
+  if (!c4_eth_decode_bootstrap(ctx->chain_id, bootstrap_data, &ctx->state, src_req, &bootstrap)) {
+    clear_sync_state(ctx->chain_id);
+    return C4_ERROR;
   }
 
   ssz_ob_t header                 = ssz_get(&bootstrap, "header");
@@ -901,9 +935,9 @@ static c4_status_t c4_check_weak_subjectivity(verify_ctx_t* ctx, c4_sync_validat
 
   // 5. Chain-of-trust: find the LCU whose `nextSyncCommittee.pubkeys` are the keys for
   //    `bootstrap_period` -- i.e. the LCU with `attested_slot` in `bootstrap_period - 1`.
-  uint32_t  target_lcu_period = bootstrap_period - 1;
-  bytes32_t lcu_pubkeys_root  = {0};
-  bool      found_lcu         = false;
+  wsp_scan_state_t scan = {.spec = spec, .target_period = bootstrap_period - 1};
+
+  bool found_lcu = false;
   for (data_request_t* req = ctx->state.requests; req && !found_lcu; req = req->next) {
     if (req->type != C4_DATA_TYPE_BEACON_API ||
         strncmp(req->url, "eth/v1/beacon/light_client/updates", 34) != 0 ||
@@ -911,33 +945,16 @@ static c4_status_t c4_check_weak_subjectivity(verify_ctx_t* ctx, c4_sync_validat
         req->encoding != C4_DATA_ENCODING_SSZ)
       continue;
 
-    bytes_t  client_updates = req->response;
-    uint64_t length         = 0;
-    for (uint32_t pos = 0; pos + UPDATE_PREFIX_SIZE < client_updates.len && !found_lcu; pos += length + SSZ_LENGTH_SIZE) {
-      uint32_t data_offset        = pos + SSZ_LENGTH_SIZE + SSZ_OFFSET_SIZE;
-      uint32_t data_length_offset = SSZ_OFFSET_SIZE;
-      length                      = uint64_from_le(client_updates.data + pos);
-      if (pos + SSZ_LENGTH_SIZE + length > client_updates.len && length > UPDATE_PREFIX_SIZE) break;
-
-      bytes_t          client_update_bytes = bytes(client_updates.data + data_offset, length - data_length_offset);
-      fork_id_t        lcu_fork            = c4_eth_get_fork_for_lcu(ctx->chain_id, client_update_bytes);
-      const ssz_def_t* lcu_def             = eth_get_light_client_update(lcu_fork);
-      if (!lcu_def) break;
-
-      ssz_ob_t update          = {.bytes = client_update_bytes, .def = lcu_def};
-      ssz_ob_t attested        = ssz_get(&update, "attestedHeader");
-      ssz_ob_t attested_beacon = ssz_get(&attested, "beacon");
-      uint64_t attested_slot   = ssz_get_uint64(&attested_beacon, "slot");
-      uint32_t attested_period = (uint32_t) (attested_slot >> (spec->slots_per_epoch_bits + spec->epochs_per_period_bits));
-
-      if (attested_period == target_lcu_period) {
-        ssz_ob_t next_sync_committee = ssz_get(&update, "nextSyncCommittee");
-        ssz_ob_t next_pubkeys        = ssz_get(&next_sync_committee, "pubkeys");
-        ssz_hash_tree_root(next_pubkeys, lcu_pubkeys_root);
-        found_lcu = true;
-      }
-    }
+    // Best-effort: ignore walker errors here (the response might be from a
+    // prior successful sync and validation state need not survive re-scans).
+    // `validate_ssz` is off because per-chunk SSZ was already checked when
+    // the response first went through `c4_process_light_client_updates`.
+    (void) c4_eth_walk_lcu_list(ctx->chain_id, req->response, /*state*/ NULL, /*req*/ NULL,
+                                /*validate_ssz*/ false, wsp_locate_target_lcu_cb, &scan);
+    found_lcu = scan.found;
   }
+  bytes32_t lcu_pubkeys_root = {0};
+  if (found_lcu) memcpy(lcu_pubkeys_root, scan.pubkeys_root, 32);
 
   if (!found_lcu) {
     // The verifier did sync into `sync_state->highest_period` via LCUs but none of the
@@ -1028,25 +1045,20 @@ static c4_status_t c4_try_sync_from_next_period(verify_ctx_t* ctx, uint32_t peri
   bytes_t   light_client_update = {0};
   bytes32_t computed_root       = {0};
   if (req_client_update(&ctx->state, period, 1, ctx->chain_id, &light_client_update)) {
-    // Parse the SSZ-encoded update
-    fork_id_t        fork              = c4_eth_get_fork_for_lcu(ctx->chain_id, light_client_update);
-    const ssz_def_t* client_update_def = eth_get_light_client_update(fork);
-
-    if (!client_update_def || light_client_update.len < UPDATE_PREFIX_SIZE)
-      THROW_ERROR("Invalid light client update format in edge case sync");
-
-    // Navigate to the first update in the list
-    uint32_t offset = uint32_from_le(light_client_update.data);
-    if (offset + UPDATE_PREFIX_SIZE > light_client_update.len)
-      THROW_ERROR("Invalid offset in light client update list");
-
-    uint64_t length                    = uint64_from_le(light_client_update.data + offset);
-    bytes_t  light_client_update_bytes = bytes(light_client_update.data + offset + UPDATE_PREFIX_SIZE, length - SSZ_OFFSET_SIZE);
-    ssz_ob_t update_ob                 = {.bytes = light_client_update_bytes, .def = client_update_def};
-    // One item is not the enclosing list. Leave the list request unvalidated
-    // until a list-level SSZ check exists.
-    if (!ssz_is_valid(update_ob, true, &ctx->state))
-      THROW_ERROR("Invalid SSZ structure in light client update");
+    // Validate list framing + first-chunk SSZ + fork resolution in one shot.
+    // The previous code sniffed the wire prefix as if it were an SSZ offset
+    // (see the removed `c4_eth_get_fork_for_lcu` and its TODO(gloas));
+    // replace it with the walker which uses the `ForkDigest` context and
+    // marks the request `validated`.
+    data_request_t*      lcu_req = c4_state_get_data_request_by_response(&ctx->state, light_client_update);
+    first_lcu_chunk_t    first   = {0};
+    bool ok = c4_eth_walk_lcu_list(ctx->chain_id, light_client_update, &ctx->state, lcu_req,
+                                   /*validate_ssz*/ true, capture_first_lcu_chunk_cb, &first);
+    if (!ok && !first.have_first)
+      THROW_ERROR("Invalid light client update in edge case sync");
+    if (!first.have_first)
+      THROW_ERROR("Edge case sync: LCU list is empty");
+    ssz_ob_t update_ob = first.first;
 
     // Step 4: Extract nextSyncCommittee from the update (this is period N+1's committee in period N's update)
     ssz_ob_t next_sync_committee = ssz_get(&update_ob, "nextSyncCommittee");

--- a/test/unittests/test_eth_chain_spec.c
+++ b/test/unittests/test_eth_chain_spec.c
@@ -25,6 +25,7 @@
 #include "chains.h"
 #include "el_header.h"
 #include "unity.h"
+#include <stdint.h>
 #include <string.h>
 
 void setUp(void) {}
@@ -176,6 +177,17 @@ void test_chain_schedules_fork(void) {
   TEST_ASSERT_FALSE(c4_chain_schedules_fork(CHAIN(999999), C4_FORK_GLOAS));
 }
 
+void test_chain_fork_epoch(void) {
+  TEST_ASSERT_EQUAL_UINT64(0ULL, c4_chain_fork_epoch(C4_CHAIN_MAINNET, C4_FORK_PHASE0));
+  TEST_ASSERT_EQUAL_UINT64(364032ULL, c4_chain_fork_epoch(C4_CHAIN_MAINNET, C4_FORK_ELECTRA));
+  TEST_ASSERT_EQUAL_UINT64(411392ULL, c4_chain_fork_epoch(C4_CHAIN_MAINNET, C4_FORK_FULU));
+  TEST_ASSERT_EQUAL_UINT64(UINT64_MAX, c4_chain_fork_epoch(C4_CHAIN_MAINNET, C4_FORK_GLOAS));
+  TEST_ASSERT_EQUAL_UINT64(UINT64_MAX, c4_chain_fork_epoch(CHAIN(999999), C4_FORK_FULU));
+  // 0 is a valid activation epoch (Platåberget genesis-at-Fulu), not "unset".
+  TEST_ASSERT_EQUAL_UINT64(0ULL, c4_chain_fork_epoch(C4_CHAIN_PLATABERGET, C4_FORK_FULU));
+  TEST_ASSERT_EQUAL_UINT64(1536ULL, c4_chain_fork_epoch(C4_CHAIN_PLATABERGET, C4_FORK_GLOAS));
+}
+
 // EIP-7892 BLOB_BASE_FEE_UPDATE_FRACTION per active fork; the timestamps come
 // from go-ethereum's `params/config.go` (mainnet + sepolia). Pre-Cancun input
 // as well as chains without a schedule fall back to the Cancun value.
@@ -230,6 +242,7 @@ int main(void) {
   RUN_TEST(test_mainnet_gloas_still_unassigned);
   RUN_TEST(test_zk_sync_trust_anchors);
   RUN_TEST(test_chain_schedules_fork);
+  RUN_TEST(test_chain_fork_epoch);
   RUN_TEST(test_blob_base_fee_update_fraction);
   RUN_TEST(test_min_blob_base_fee);
   return UNITY_END();

--- a/test/unittests/test_lcu_gloas.c
+++ b/test/unittests/test_lcu_gloas.c
@@ -70,8 +70,8 @@ static void build_dummy_lc_header(uint8_t out[C4_GLOAS_LCU_HEADER_SIZE],
 // SyncAggregate: BitVector[512] (64 B) + ByteVector[96] = 160 B fixed.
 static void build_dummy_sync_aggregate(uint8_t out[C4_GLOAS_LCU_SYNC_AGGREGATE_SIZE]) {
   memset(out, 0, C4_GLOAS_LCU_SYNC_AGGREGATE_SIZE);
-  for (uint32_t i = 0; i < 64; i++) out[i] = (uint8_t) (0xa0 + i);       // bits
-  for (uint32_t i = 0; i < 96; i++) out[64 + i] = (uint8_t) (0xb0 + i);  // signature
+  for (uint32_t i = 0; i < 64; i++) out[i] = (uint8_t) (0xa0 + i);      // bits
+  for (uint32_t i = 0; i < 96; i++) out[64 + i] = (uint8_t) (0xb0 + i); // signature
 }
 
 // -----------------------------------------------------------------------------
@@ -168,12 +168,12 @@ void test_gloas_lcu_assemble_layout_and_validity(void) {
 }
 
 void test_gloas_lcu_assemble_size_mismatches_rejected(void) {
-  uint8_t attested_ok[C4_GLOAS_LCU_HEADER_SIZE]           = {0};
-  uint8_t finalized_ok[C4_GLOAS_LCU_HEADER_SIZE]          = {0};
-  uint8_t nsc_ok[C4_GLOAS_LCU_SYNC_COMMITTEE_SIZE]        = {0};
-  uint8_t sc_branch_ok[C4_GLOAS_LCU_NEXT_SC_BRANCH_SIZE]  = {0};
+  uint8_t attested_ok[C4_GLOAS_LCU_HEADER_SIZE]            = {0};
+  uint8_t finalized_ok[C4_GLOAS_LCU_HEADER_SIZE]           = {0};
+  uint8_t nsc_ok[C4_GLOAS_LCU_SYNC_COMMITTEE_SIZE]         = {0};
+  uint8_t sc_branch_ok[C4_GLOAS_LCU_NEXT_SC_BRANCH_SIZE]   = {0};
   uint8_t fin_branch_ok[C4_GLOAS_LCU_FINALITY_BRANCH_SIZE] = {0};
-  uint8_t sync_agg_ok[C4_GLOAS_LCU_SYNC_AGGREGATE_SIZE]   = {0};
+  uint8_t sync_agg_ok[C4_GLOAS_LCU_SYNC_AGGREGATE_SIZE]    = {0};
 
   bytes_t out = NULL_BYTES;
 
@@ -307,12 +307,12 @@ void test_gloas_lcu_wrap_beacon_response_prefix(void) {
   for (uint32_t i = 0; i < C4_GLOAS_LCU_SSZ_SIZE; i++)
     lcu_bytes[i] = (uint8_t) (i & 0xff);
 
-  // Arbitrary 4-byte fork_version. The wrapper copies these bytes verbatim
-  // and never inspects them; the concrete Gloas value depends on the chain
-  // (`mainnet_fork_version` -> 0x07000000, plataberget -> 0x80733183, ...).
-  uint8_t fork_version[4] = {0xde, 0xad, 0xbe, 0xef};
-  bytes_t wire            = c4_gloas_lcu_wrap_beacon_response(
-      bytes(lcu_bytes, sizeof(lcu_bytes)), fork_version);
+  // Arbitrary 4-byte context. The wrapper copies these bytes verbatim and
+  // never inspects them; per Beacon-API spec production callers pass a
+  // `ForkDigest` computed via `c4_eth_compute_fork_digest`.
+  uint8_t context[4] = {0xde, 0xad, 0xbe, 0xef};
+  bytes_t wire       = c4_gloas_lcu_wrap_beacon_response(
+      bytes(lcu_bytes, sizeof(lcu_bytes)), context);
   TEST_ASSERT_NOT_NULL_MESSAGE(wire.data, "wrap must produce a buffer");
   TEST_ASSERT_EQUAL_MESSAGE(C4_GLOAS_LCU_WIRE_SIZE, wire.len,
                             "wire response = 12 + LCU_SSZ_SIZE bytes");
@@ -324,9 +324,9 @@ void test_gloas_lcu_wrap_beacon_response_prefix(void) {
     TEST_ASSERT_EQUAL_UINT8_MESSAGE(expected, wire.data[i],
                                     "length prefix LE byte mismatch");
   }
-  // fork_version at offset 8..12.
-  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(fork_version, wire.data + 8, 4,
-                                        "fork_version at offset 8");
+  // context (ForkDigest) at offset 8..12.
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(context, wire.data + 8, 4,
+                                        "context at offset 8");
   // Payload starts at offset 12.
   TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(
       lcu_bytes, wire.data + C4_GLOAS_LCU_WIRE_PREFIX_SIZE,
@@ -337,17 +337,17 @@ void test_gloas_lcu_wrap_beacon_response_prefix(void) {
 
 void test_gloas_lcu_wrap_beacon_response_rejects_invalid(void) {
   uint8_t lcu_bytes[C4_GLOAS_LCU_SSZ_SIZE] = {0};
-  uint8_t fork_version[4]                  = {0xde, 0xad, 0xbe, 0xef};
+  uint8_t context[4]                       = {0xde, 0xad, 0xbe, 0xef};
 
   // NULL data pointer.
   bytes_t null_input = {.data = NULL, .len = C4_GLOAS_LCU_SSZ_SIZE};
-  bytes_t r          = c4_gloas_lcu_wrap_beacon_response(null_input, fork_version);
+  bytes_t r          = c4_gloas_lcu_wrap_beacon_response(null_input, context);
   TEST_ASSERT_NULL_MESSAGE(r.data, "NULL data pointer must be rejected");
   TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, r.len, "returned bytes_t must be zero on failure");
 
   // Wrong LCU length -> NULL_BYTES.
   bytes_t short_lcu = {.data = lcu_bytes, .len = C4_GLOAS_LCU_SSZ_SIZE - 1};
-  r                 = c4_gloas_lcu_wrap_beacon_response(short_lcu, fork_version);
+  r                 = c4_gloas_lcu_wrap_beacon_response(short_lcu, context);
   TEST_ASSERT_NULL_MESSAGE(r.data, "wrong LCU length must be rejected");
 }
 

--- a/test/unittests/test_lcu_wire.c
+++ b/test/unittests/test_lcu_wire.c
@@ -1,0 +1,779 @@
+/*
+ * Copyright (c) 2026 corpus.core
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// Unit tests for src/chains/eth/verifier/lcu_wire.{h,c}:
+//   - c4_eth_compute_fork_digest (ForkDigest per Beacon-API spec)
+//   - c4_eth_fork_from_context   (ForkDigest -> fork_id, with fork_version fallback)
+//   - c4_eth_walk_lcu_list       (Beacon-API `light_client/updates` framing)
+//   - c4_eth_decode_bootstrap    (LightClientBootstrap size / offset detection)
+
+#include "beacon_types.h"
+#include "bytes.h"
+#include "c4_assert.h"
+#include "chains.h"
+#include "lcu_wire.h"
+#include "ssz.h"
+#include "state.h"
+#include "unity.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// Digest at a fork's activation epoch. After Fulu this is the BPO-mixed
+// digest (EIP-7892), not the raw ForkData root.
+static bool digest_at_fork(chain_id_t chain, fork_id_t fork, uint8_t out[4]) {
+  uint64_t epoch = c4_chain_fork_epoch(chain, fork);
+  if (epoch == UINT64_MAX) return false;
+  return c4_eth_compute_fork_digest(chain, epoch, out);
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+// Writes an LCU wire chunk into `dst` at offset `off`:
+//   [8 bytes length = 4 + payload_len][4 bytes context][payload_len bytes payload]
+// Returns the byte-position immediately after the chunk (so the caller can
+// keep appending).
+static uint32_t emit_chunk(uint8_t* dst, uint32_t off, const uint8_t context[4],
+                           const uint8_t* payload, uint32_t payload_len) {
+  const uint64_t length = 4u + (uint64_t) payload_len;
+  uint64_to_le(dst + off, length);
+  memcpy(dst + off + 8, context, 4);
+  if (payload_len && payload) memcpy(dst + off + 12, payload, payload_len);
+  return (uint32_t) (off + 12u + payload_len);
+}
+
+typedef struct {
+  uint32_t  seen;
+  fork_id_t forks[8];
+  bool      stop_after_first;
+} chunk_counter_t;
+
+static bool count_chunks_cb(void* user, const c4_lcu_chunk_t* chunk) {
+  chunk_counter_t* c = (chunk_counter_t*) user;
+  if (c->seen < 8) c->forks[c->seen] = chunk->fork;
+  c->seen++;
+  if (c->stop_after_first) return false;
+  return true;
+}
+
+// -----------------------------------------------------------------------------
+// Fork-digest math
+// -----------------------------------------------------------------------------
+
+void test_compute_fork_digest_deterministic(void) {
+  // Same (chain, fork) must yield the same digest.
+  uint8_t a[4] = {0};
+  uint8_t b[4] = {0};
+  TEST_ASSERT_TRUE(digest_at_fork(C4_CHAIN_MAINNET, C4_FORK_DENEB, a));
+  TEST_ASSERT_TRUE(digest_at_fork(C4_CHAIN_MAINNET, C4_FORK_DENEB, b));
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(a, b, 4);
+}
+
+void test_compute_fork_digest_differs_per_fork(void) {
+  uint8_t d_deneb[4]   = {0};
+  uint8_t d_electra[4] = {0};
+  uint8_t d_fulu[4]    = {0};
+  TEST_ASSERT_TRUE(digest_at_fork(C4_CHAIN_MAINNET, C4_FORK_DENEB, d_deneb));
+  TEST_ASSERT_TRUE(digest_at_fork(C4_CHAIN_MAINNET, C4_FORK_ELECTRA, d_electra));
+  TEST_ASSERT_TRUE(digest_at_fork(C4_CHAIN_MAINNET, C4_FORK_FULU, d_fulu));
+  // Any two distinct forks yield distinct digests -- collisions in the first
+  // 4 bytes of hash_tree_root(ForkData) are cryptographically negligible for
+  // scheduled Mainnet forks.
+  TEST_ASSERT_NOT_EQUAL(0, memcmp(d_deneb, d_electra, 4));
+  TEST_ASSERT_NOT_EQUAL(0, memcmp(d_deneb, d_fulu, 4));
+  TEST_ASSERT_NOT_EQUAL(0, memcmp(d_electra, d_fulu, 4));
+}
+
+void test_compute_fork_digest_bpo_differs_from_fulu_activation(void) {
+  // After Fulu, EIP-7892 mixes blob parameters into the digest. BPO2
+  // (epoch 419072, 21 blobs) must not equal the digest at Fulu activation
+  // (epoch 411392, Electra's 9-blob fallback). Both must still resolve to
+  // C4_FORK_FULU -- this is what Lodestar emits on mainnet today.
+  uint8_t d_fulu[4] = {0};
+  uint8_t d_bpo2[4] = {0};
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_MAINNET, 411392ULL, d_fulu));
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_MAINNET, 419072ULL, d_bpo2));
+  TEST_ASSERT_NOT_EQUAL(0, memcmp(d_fulu, d_bpo2, 4));
+  TEST_ASSERT_EQUAL_INT((int) C4_FORK_FULU, (int) c4_eth_fork_from_context(C4_CHAIN_MAINNET, d_fulu));
+  TEST_ASSERT_EQUAL_INT((int) C4_FORK_FULU, (int) c4_eth_fork_from_context(C4_CHAIN_MAINNET, d_bpo2));
+}
+
+void test_compute_fork_digest_bpo1_and_epoch_boundaries(void) {
+  // BPO1 (epoch 412672, 15 blobs) is a distinct schedule entry, not just
+  // "somewhere between Fulu and BPO2". An off-by-one in
+  // `get_blob_parameters` (`epoch >= entry.epoch`) would collapse BPO1
+  // into the 9-blob Fulu fallback or into BPO2.
+  uint8_t d_fulu[4]     = {0};
+  uint8_t d_pre_bpo1[4] = {0};
+  uint8_t d_bpo1[4]     = {0};
+  uint8_t d_pre_bpo2[4] = {0};
+  uint8_t d_bpo2[4]     = {0};
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_MAINNET, 411392ULL, d_fulu));
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_MAINNET, 412671ULL, d_pre_bpo1));
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_MAINNET, 412672ULL, d_bpo1));
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_MAINNET, 419071ULL, d_pre_bpo2));
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_MAINNET, 419072ULL, d_bpo2));
+
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(d_fulu, d_pre_bpo1, 4);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(d_bpo1, d_pre_bpo2, 4);
+  TEST_ASSERT_NOT_EQUAL(0, memcmp(d_fulu, d_bpo1, 4));
+  TEST_ASSERT_NOT_EQUAL(0, memcmp(d_bpo1, d_bpo2, 4));
+  TEST_ASSERT_EQUAL_INT((int) C4_FORK_FULU, (int) c4_eth_fork_from_context(C4_CHAIN_MAINNET, d_bpo1));
+}
+
+void test_compute_fork_digest_sepolia_bpo(void) {
+  // Sepolia has its own CL BLOB_SCHEDULE (BPO1 274176 / BPO2 275712) and a
+  // different genesis_validators_root. Copying mainnet BPO epochs here
+  // would make 274176 and 275712 share the 9-blob Fulu fallback.
+  uint8_t d_fulu[4] = {0};
+  uint8_t d_bpo1[4] = {0};
+  uint8_t d_bpo2[4] = {0};
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_SEPOLIA, 272640ULL, d_fulu));
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_SEPOLIA, 274176ULL, d_bpo1));
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_SEPOLIA, 275712ULL, d_bpo2));
+  TEST_ASSERT_NOT_EQUAL(0, memcmp(d_fulu, d_bpo1, 4));
+  TEST_ASSERT_NOT_EQUAL(0, memcmp(d_bpo1, d_bpo2, 4));
+  TEST_ASSERT_EQUAL_INT((int) C4_FORK_FULU, (int) c4_eth_fork_from_context(C4_CHAIN_SEPOLIA, d_fulu));
+  TEST_ASSERT_EQUAL_INT((int) C4_FORK_FULU, (int) c4_eth_fork_from_context(C4_CHAIN_SEPOLIA, d_bpo1));
+  TEST_ASSERT_EQUAL_INT((int) C4_FORK_FULU, (int) c4_eth_fork_from_context(C4_CHAIN_SEPOLIA, d_bpo2));
+}
+
+void test_compute_fork_digest_gnosis_empty_cl_blob_schedule(void) {
+  // Gnosis schedules Fulu but has no CL BPO table. After Fulu the mixin
+  // is the constant Electra fallback (epoch, 9), so the digest must stay
+  // stable across later epochs and still resolve to C4_FORK_FULU.
+  const chain_spec_t* spec = c4_eth_get_chain_spec(C4_CHAIN_GNOSIS);
+  TEST_ASSERT_NOT_NULL(spec);
+  TEST_ASSERT_NULL(spec->cl_blob_schedule);
+
+  uint64_t fulu = c4_chain_fork_epoch(C4_CHAIN_GNOSIS, C4_FORK_FULU);
+  TEST_ASSERT_NOT_EQUAL(UINT64_MAX, fulu);
+
+  uint8_t d_fulu[4]  = {0};
+  uint8_t d_later[4] = {0};
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_GNOSIS, fulu, d_fulu));
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_GNOSIS, fulu + 10000ULL, d_later));
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(d_fulu, d_later, 4);
+  TEST_ASSERT_EQUAL_INT((int) C4_FORK_FULU, (int) c4_eth_fork_from_context(C4_CHAIN_GNOSIS, d_fulu));
+}
+
+void test_compute_fork_digest_rejects_unknown_chain(void) {
+  uint8_t out[4] = {0xff, 0xff, 0xff, 0xff};
+  TEST_ASSERT_FALSE(c4_eth_compute_fork_digest(CHAIN(999999), 0, out));
+  // On failure `out` must be left untouched.
+  TEST_ASSERT_EQUAL_UINT8(0xff, out[0]);
+  TEST_ASSERT_EQUAL_UINT8(0xff, out[3]);
+}
+
+// -----------------------------------------------------------------------------
+// Context -> fork resolution
+// -----------------------------------------------------------------------------
+
+void test_fork_from_context_digest_hits(void) {
+  for (fork_id_t f = C4_FORK_DENEB; f <= C4_FORK_FULU; f++) {
+    uint8_t digest[4] = {0};
+    TEST_ASSERT_TRUE(digest_at_fork(C4_CHAIN_MAINNET, f, digest));
+    TEST_ASSERT_EQUAL_INT((int) f, (int) c4_eth_fork_from_context(C4_CHAIN_MAINNET, digest));
+  }
+}
+
+void test_fork_from_context_fork_version_fallback(void) {
+  // Compat path: raw `fork_version` bytes must still resolve, so period-store
+  // `lcu.ssz` written by older builds keeps parsing.
+  const chain_spec_t* spec = c4_eth_get_chain_spec(C4_CHAIN_MAINNET);
+  TEST_ASSERT_NOT_NULL(spec);
+  uint8_t v[4] = {0};
+  spec->fork_version_func(C4_CHAIN_MAINNET, C4_FORK_ELECTRA, v);
+  TEST_ASSERT_EQUAL_INT((int) C4_FORK_ELECTRA,
+                        (int) c4_eth_fork_from_context(C4_CHAIN_MAINNET, v));
+}
+
+void test_fork_from_context_rejects_unknown(void) {
+  uint8_t junk[4] = {0xde, 0xad, 0xbe, 0xef};
+  TEST_ASSERT_EQUAL_INT((int) C4_FORK_INVALID,
+                        (int) c4_eth_fork_from_context(C4_CHAIN_MAINNET, junk));
+}
+
+// -----------------------------------------------------------------------------
+// LCU list framing (structural walk; ssz_is_valid disabled so payload can be
+// arbitrary bytes)
+// -----------------------------------------------------------------------------
+
+void test_walk_lcu_list_empty(void) {
+  c4_state_t      state = {0};
+  data_request_t  req   = {0};
+  chunk_counter_t cnt   = {0};
+  TEST_ASSERT_TRUE(c4_eth_walk_lcu_list(C4_CHAIN_MAINNET, NULL_BYTES, &state, &req,
+                                        /*validate_ssz*/ false, count_chunks_cb, &cnt));
+  TEST_ASSERT_EQUAL_UINT32(0, cnt.seen);
+  TEST_ASSERT_TRUE(req.validated);
+  TEST_ASSERT_NULL(state.error);
+}
+
+void test_walk_lcu_list_one_chunk_marks_validated(void) {
+  uint8_t digest[4] = {0};
+  TEST_ASSERT_TRUE(digest_at_fork(C4_CHAIN_MAINNET, C4_FORK_ELECTRA, digest));
+
+  uint8_t buf[64] = {0};
+  uint8_t payload[16];
+  memset(payload, 0xab, sizeof(payload));
+  uint32_t end = emit_chunk(buf, 0, digest, payload, sizeof(payload));
+
+  c4_state_t      state = {0};
+  data_request_t  req   = {0};
+  chunk_counter_t cnt   = {0};
+  TEST_ASSERT_TRUE(c4_eth_walk_lcu_list(C4_CHAIN_MAINNET, bytes(buf, end), &state, &req,
+                                        /*validate_ssz*/ false, count_chunks_cb, &cnt));
+  TEST_ASSERT_EQUAL_UINT32(1, cnt.seen);
+  TEST_ASSERT_EQUAL_INT((int) C4_FORK_ELECTRA, (int) cnt.forks[0]);
+  TEST_ASSERT_TRUE(req.validated);
+}
+
+void test_walk_lcu_list_two_chunks(void) {
+  uint8_t digest_e[4] = {0};
+  uint8_t digest_f[4] = {0};
+  TEST_ASSERT_TRUE(digest_at_fork(C4_CHAIN_MAINNET, C4_FORK_ELECTRA, digest_e));
+  TEST_ASSERT_TRUE(digest_at_fork(C4_CHAIN_MAINNET, C4_FORK_FULU, digest_f));
+
+  uint8_t  buf[128] = {0};
+  uint8_t  p1[8]    = {0x11};
+  uint8_t  p2[4]    = {0x22};
+  uint32_t off      = 0;
+  off               = emit_chunk(buf, off, digest_e, p1, sizeof(p1));
+  off               = emit_chunk(buf, off, digest_f, p2, sizeof(p2));
+
+  c4_state_t      state = {0};
+  data_request_t  req   = {0};
+  chunk_counter_t cnt   = {0};
+  TEST_ASSERT_TRUE(c4_eth_walk_lcu_list(C4_CHAIN_MAINNET, bytes(buf, off), &state, &req,
+                                        /*validate_ssz*/ false, count_chunks_cb, &cnt));
+  TEST_ASSERT_EQUAL_UINT32(2, cnt.seen);
+  TEST_ASSERT_EQUAL_INT((int) C4_FORK_ELECTRA, (int) cnt.forks[0]);
+  TEST_ASSERT_EQUAL_INT((int) C4_FORK_FULU, (int) cnt.forks[1]);
+  TEST_ASSERT_TRUE(req.validated);
+}
+
+void test_walk_lcu_list_truncated_header(void) {
+  // Buffer with only 8 bytes -- shorter than the required 12-byte prefix.
+  uint8_t buf[8] = {0};
+  uint64_to_le(buf, 4);
+  c4_state_t     state = {0};
+  data_request_t req   = {0};
+  TEST_ASSERT_FALSE(c4_eth_walk_lcu_list(C4_CHAIN_MAINNET, bytes(buf, sizeof(buf)), &state, &req,
+                                         /*validate_ssz*/ false, count_chunks_cb, NULL));
+  TEST_ASSERT_FALSE(req.validated);
+  TEST_ASSERT_NOT_NULL(state.error);
+  c4_state_free(&state);
+}
+
+void test_walk_lcu_list_length_below_context(void) {
+  // length = 3 is invalid because the mandatory 4-byte context alone requires
+  // length >= 4. This is the framing check we cannot express with a payload
+  // of size 0 (which would still declare length == 4).
+  uint8_t buf[12] = {0};
+  uint64_to_le(buf, 3);
+  c4_state_t     state = {0};
+  data_request_t req   = {0};
+  TEST_ASSERT_FALSE(c4_eth_walk_lcu_list(C4_CHAIN_MAINNET, bytes(buf, sizeof(buf)), &state, &req,
+                                         /*validate_ssz*/ false, count_chunks_cb, NULL));
+  TEST_ASSERT_FALSE(req.validated);
+  c4_state_free(&state);
+}
+
+void test_walk_lcu_list_length_exceeds_buffer(void) {
+  // Declare an oversized chunk that would overrun the buffer.
+  uint8_t buf[32] = {0};
+  uint64_to_le(buf, 999);
+  c4_state_t     state = {0};
+  data_request_t req   = {0};
+  TEST_ASSERT_FALSE(c4_eth_walk_lcu_list(C4_CHAIN_MAINNET, bytes(buf, sizeof(buf)), &state, &req,
+                                         /*validate_ssz*/ false, count_chunks_cb, NULL));
+  TEST_ASSERT_FALSE(req.validated);
+  c4_state_free(&state);
+}
+
+void test_walk_lcu_list_length_uint64_wrap(void) {
+  // Hostile length near UINT64_MAX used to wrap `pos + 8 + length` so the
+  // bounds check passed, `chunk_len` truncated to 0, and the walker looped.
+  uint8_t buf[16] = {0};
+  uint64_to_le(buf, UINT64_MAX - 7ULL);
+  c4_state_t     state = {0};
+  data_request_t req   = {0};
+  TEST_ASSERT_FALSE(c4_eth_walk_lcu_list(C4_CHAIN_MAINNET, bytes(buf, sizeof(buf)), &state, &req,
+                                         /*validate_ssz*/ false, NULL, NULL));
+  TEST_ASSERT_FALSE(req.validated);
+  TEST_ASSERT_NOT_NULL(state.error);
+  c4_state_free(&state);
+}
+
+void test_walk_lcu_list_tail_garbage(void) {
+  // Two-chunk framing where the declared length undershoots the buffer -- the
+  // remaining tail bytes would not tile.
+  uint8_t digest[4] = {0};
+  TEST_ASSERT_TRUE(digest_at_fork(C4_CHAIN_MAINNET, C4_FORK_ELECTRA, digest));
+  uint8_t  buf[64] = {0};
+  uint8_t  p[4]    = {0};
+  uint32_t off     = emit_chunk(buf, 0, digest, p, sizeof(p));
+  // Append 3 uncovered tail bytes.
+  off += 3;
+  c4_state_t     state = {0};
+  data_request_t req   = {0};
+  TEST_ASSERT_FALSE(c4_eth_walk_lcu_list(C4_CHAIN_MAINNET, bytes(buf, off), &state, &req,
+                                         /*validate_ssz*/ false, count_chunks_cb, NULL));
+  TEST_ASSERT_FALSE(req.validated);
+  c4_state_free(&state);
+}
+
+void test_walk_lcu_list_unknown_context(void) {
+  // Framing valid, but the 4-byte context matches no scheduled fork on the
+  // chain. Framing pass still marks `validated`; the semantic pass reports
+  // an error and returns false.
+  uint8_t  buf[32]    = {0};
+  uint8_t  junk[4]    = {0xde, 0xad, 0xbe, 0xef};
+  uint8_t  payload[8] = {0};
+  uint32_t off        = emit_chunk(buf, 0, junk, payload, sizeof(payload));
+
+  c4_state_t     state = {0};
+  data_request_t req   = {0};
+  TEST_ASSERT_FALSE(c4_eth_walk_lcu_list(C4_CHAIN_MAINNET, bytes(buf, off), &state, &req,
+                                         /*validate_ssz*/ false, count_chunks_cb, NULL));
+  // Framing pass succeeded before the context resolution failed, so the
+  // request is marked validated even though the walker aborted.
+  TEST_ASSERT_TRUE(req.validated);
+  TEST_ASSERT_NOT_NULL(state.error);
+  c4_state_free(&state);
+}
+
+void test_walk_lcu_list_cb_stop_after_first(void) {
+  uint8_t digest[4] = {0};
+  TEST_ASSERT_TRUE(digest_at_fork(C4_CHAIN_MAINNET, C4_FORK_ELECTRA, digest));
+  uint8_t  buf[64] = {0};
+  uint8_t  p[4]    = {0};
+  uint32_t off     = 0;
+  off              = emit_chunk(buf, off, digest, p, sizeof(p));
+  off              = emit_chunk(buf, off, digest, p, sizeof(p));
+
+  c4_state_t      state = {0};
+  data_request_t  req   = {0};
+  chunk_counter_t cnt   = {.stop_after_first = true};
+  // Callback returns false -> walker returns false, but framing has already
+  // marked `validated`.
+  TEST_ASSERT_FALSE(c4_eth_walk_lcu_list(C4_CHAIN_MAINNET, bytes(buf, off), &state, &req,
+                                         /*validate_ssz*/ false, count_chunks_cb, &cnt));
+  TEST_ASSERT_EQUAL_UINT32(1, cnt.seen);
+  TEST_ASSERT_TRUE(req.validated);
+}
+
+// -----------------------------------------------------------------------------
+// Bootstrap decoder
+// -----------------------------------------------------------------------------
+
+void test_decode_bootstrap_recorded_deneb(void) {
+  bytes_t data = read_testdata(
+      "eth_getBlockByNumber1/eth_v1_beacon_light_client_bootstrap_"
+      "0x46d52dc3db74df14187554fb7afd5cc4af4558e3c8ca185e409955d6ac148.ssz");
+  TEST_ASSERT_NOT_NULL_MESSAGE(data.data,
+                               "Deneb bootstrap fixture is missing from test data");
+
+  ssz_ob_t       out   = {0};
+  c4_state_t     state = {0};
+  data_request_t req   = {0};
+  bool           ok    = c4_eth_decode_bootstrap(C4_CHAIN_MAINNET, data, &state, &req, &out);
+  TEST_ASSERT_TRUE_MESSAGE(ok, state.error ? state.error : "Deneb bootstrap must decode");
+  TEST_ASSERT_NOT_NULL(out.def);
+  TEST_ASSERT_TRUE(req.validated);
+  safe_free(data.data);
+  c4_state_free(&state);
+}
+
+void test_decode_bootstrap_recorded_electra(void) {
+  bytes_t data = read_testdata(
+      "eth_call_authorization_list/eth_v1_beacon_light_client_bootstrap_"
+      "0x625c1e521cedccc30c1f696a205cdad18859eb7b06fd9f848e1e5434bba19.ssz");
+  TEST_ASSERT_NOT_NULL_MESSAGE(data.data,
+                               "Electra bootstrap fixture is missing from test data");
+  // Sanity: the fixture's leading offset must equal the Electra fixed-size
+  // constant, otherwise the discriminator is stale.
+  TEST_ASSERT_EQUAL_UINT32(C4_ETH_ELECTRA_BOOTSTRAP_FIXED_SIZE, uint32_from_le(data.data));
+
+  ssz_ob_t       out   = {0};
+  c4_state_t     state = {0};
+  data_request_t req   = {0};
+  bool           ok    = c4_eth_decode_bootstrap(C4_CHAIN_MAINNET, data, &state, &req, &out);
+  TEST_ASSERT_TRUE_MESSAGE(ok, state.error ? state.error : "Electra bootstrap must decode");
+  TEST_ASSERT_NOT_NULL(out.def);
+  TEST_ASSERT_TRUE(req.validated);
+  safe_free(data.data);
+  c4_state_free(&state);
+}
+
+void test_decode_bootstrap_rejects_short(void) {
+  uint8_t    buf[16] = {0};
+  ssz_ob_t   out     = {0};
+  c4_state_t state   = {0};
+  TEST_ASSERT_FALSE(
+      c4_eth_decode_bootstrap(C4_CHAIN_MAINNET, bytes(buf, sizeof(buf)), &state, NULL, &out));
+  TEST_ASSERT_NOT_NULL(state.error);
+  c4_state_free(&state);
+}
+
+void test_decode_bootstrap_rejects_bogus_offset(void) {
+  // Buffer large enough to look like a Deneb/Electra bootstrap, but the
+  // leading offset value points to neither fork's fixed-portion size.
+  uint8_t buf[26000] = {0};
+  uint32_to_le(buf, 12345); // definitely not a valid header offset
+  ssz_ob_t   out   = {0};
+  c4_state_t state = {0};
+  TEST_ASSERT_FALSE(
+      c4_eth_decode_bootstrap(C4_CHAIN_MAINNET, bytes(buf, sizeof(buf)), &state, NULL, &out));
+  TEST_ASSERT_NOT_NULL(state.error);
+  c4_state_free(&state);
+}
+
+// -----------------------------------------------------------------------------
+// NULL-parameter and edge-case behaviour of the public API. These are cheap
+// but load-bearing: every caller under `src/chains/eth/` relies on the helpers
+// tolerating a NULL `req` (the walker is invoked from paths that don't have a
+// backing `data_request_t`) and on `decode_bootstrap` refusing NULL `out`
+// instead of dereferencing it.
+// -----------------------------------------------------------------------------
+
+void test_compute_fork_digest_null_out(void) {
+  TEST_ASSERT_FALSE(c4_eth_compute_fork_digest(C4_CHAIN_MAINNET, 0, NULL));
+}
+
+void test_fork_from_context_null_context(void) {
+  TEST_ASSERT_EQUAL_INT((int) C4_FORK_INVALID,
+                        (int) c4_eth_fork_from_context(C4_CHAIN_MAINNET, NULL));
+}
+
+void test_fork_from_context_fork_version_fallback_fulu(void) {
+  // Extend the fallback-path coverage beyond Electra: Fulu's raw `fork_version`
+  // must also resolve so any period-store `lcu.ssz` written by an older build
+  // that used the raw version instead of the ForkDigest keeps parsing after
+  // the migration.
+  const chain_spec_t* spec = c4_eth_get_chain_spec(C4_CHAIN_MAINNET);
+  TEST_ASSERT_NOT_NULL(spec);
+  uint8_t v[4] = {0};
+  spec->fork_version_func(C4_CHAIN_MAINNET, C4_FORK_FULU, v);
+  TEST_ASSERT_EQUAL_INT((int) C4_FORK_FULU,
+                        (int) c4_eth_fork_from_context(C4_CHAIN_MAINNET, v));
+}
+
+void test_walk_lcu_list_null_data_nonzero_len(void) {
+  // Non-zero `len` with a NULL `data` pointer must be rejected explicitly --
+  // an unchecked NULL deref would be a memory-safety bug. This is a distinct
+  // code path from the empty-buffer case (which succeeds).
+  bytes_t        bogus = {.len = 4, .data = NULL};
+  c4_state_t     state = {0};
+  data_request_t req   = {0};
+  TEST_ASSERT_FALSE(c4_eth_walk_lcu_list(C4_CHAIN_MAINNET, bogus, &state, &req,
+                                         /*validate_ssz*/ false, NULL, NULL));
+  TEST_ASSERT_FALSE(req.validated);
+  TEST_ASSERT_NOT_NULL(state.error);
+  c4_state_free(&state);
+}
+
+void test_walk_lcu_list_null_req(void) {
+  // Every helper documents `req` as optional. The walker is invoked from paths
+  // that don't have a backing request (e.g. the WSP chain-of-trust re-scan in
+  // `sync_committee_state.c`), so a NULL `req` on the happy path must not
+  // crash and must not affect the return value.
+  uint8_t digest[4] = {0};
+  TEST_ASSERT_TRUE(digest_at_fork(C4_CHAIN_MAINNET, C4_FORK_ELECTRA, digest));
+  uint8_t buf[64] = {0};
+  uint8_t payload[8];
+  memset(payload, 0xcd, sizeof(payload));
+  uint32_t end = emit_chunk(buf, 0, digest, payload, sizeof(payload));
+
+  c4_state_t      state = {0};
+  chunk_counter_t cnt   = {0};
+  TEST_ASSERT_TRUE(c4_eth_walk_lcu_list(C4_CHAIN_MAINNET, bytes(buf, end), &state,
+                                        /*req*/ NULL, /*validate_ssz*/ false,
+                                        count_chunks_cb, &cnt));
+  TEST_ASSERT_EQUAL_UINT32(1, cnt.seen);
+  TEST_ASSERT_EQUAL_INT((int) C4_FORK_ELECTRA, (int) cnt.forks[0]);
+  TEST_ASSERT_NULL(state.error);
+}
+
+void test_walk_lcu_list_null_cb(void) {
+  // `cb == NULL` is a documented mode for framing-only validation. Two chunks
+  // with valid framing and known contexts must return true.
+  uint8_t digest[4] = {0};
+  TEST_ASSERT_TRUE(digest_at_fork(C4_CHAIN_MAINNET, C4_FORK_DENEB, digest));
+  uint8_t  buf[64] = {0};
+  uint8_t  p[4]    = {0};
+  uint32_t off     = 0;
+  off              = emit_chunk(buf, off, digest, p, sizeof(p));
+  off              = emit_chunk(buf, off, digest, p, sizeof(p));
+
+  c4_state_t     state = {0};
+  data_request_t req   = {0};
+  TEST_ASSERT_TRUE(c4_eth_walk_lcu_list(C4_CHAIN_MAINNET, bytes(buf, off), &state, &req,
+                                        /*validate_ssz*/ false, /*cb*/ NULL, NULL));
+  TEST_ASSERT_TRUE(req.validated);
+  TEST_ASSERT_NULL(state.error);
+}
+
+void test_walk_lcu_list_null_state_on_error(void) {
+  // `state == NULL` is documented as valid ("may be NULL to suppress"). The
+  // framing-error path must not attempt to write into a NULL state pointer.
+  uint8_t buf[8] = {0};
+  uint64_to_le(buf, 4);
+  data_request_t req = {0};
+  TEST_ASSERT_FALSE(c4_eth_walk_lcu_list(C4_CHAIN_MAINNET, bytes(buf, sizeof(buf)),
+                                         /*state*/ NULL, &req,
+                                         /*validate_ssz*/ false, NULL, NULL));
+  TEST_ASSERT_FALSE(req.validated);
+}
+
+void test_walk_lcu_list_zero_payload_chunk(void) {
+  // Chunk with `length == 4` (context only, empty payload) is valid framing.
+  // The walker must count it and resolve its fork; whether an empty payload
+  // is a valid LCU-SSZ is intentionally not checked here (validate_ssz=false).
+  uint8_t digest[4] = {0};
+  TEST_ASSERT_TRUE(digest_at_fork(C4_CHAIN_MAINNET, C4_FORK_ELECTRA, digest));
+  uint8_t buf[12] = {0};
+  uint64_to_le(buf, 4); // length = 4 (context only)
+  memcpy(buf + 8, digest, 4);
+
+  c4_state_t      state = {0};
+  data_request_t  req   = {0};
+  chunk_counter_t cnt   = {0};
+  TEST_ASSERT_TRUE(c4_eth_walk_lcu_list(C4_CHAIN_MAINNET, bytes(buf, sizeof(buf)), &state, &req,
+                                        /*validate_ssz*/ false, count_chunks_cb, &cnt));
+  TEST_ASSERT_EQUAL_UINT32(1, cnt.seen);
+  TEST_ASSERT_EQUAL_INT((int) C4_FORK_ELECTRA, (int) cnt.forks[0]);
+  TEST_ASSERT_TRUE(req.validated);
+}
+
+// -----------------------------------------------------------------------------
+// Bootstrap: NULL-`out`, NULL-`req`, and chain-schedule cross-check.
+// -----------------------------------------------------------------------------
+
+void test_decode_bootstrap_null_out(void) {
+  uint8_t    buf[16] = {0};
+  c4_state_t state   = {0};
+  TEST_ASSERT_FALSE(c4_eth_decode_bootstrap(C4_CHAIN_MAINNET, bytes(buf, sizeof(buf)),
+                                            &state, NULL, /*out*/ NULL));
+  // The NULL-out check happens before any error is recorded on state -- a
+  // caller passing NULL out is a programmer error, not a data error.
+  c4_state_free(&state);
+}
+
+void test_decode_bootstrap_null_req_recorded_deneb(void) {
+  // Re-runs the Deneb happy path with `req == NULL` to exercise the branch
+  // that skips setting `req->validated`.
+  bytes_t data = read_testdata(
+      "eth_getBlockByNumber1/eth_v1_beacon_light_client_bootstrap_"
+      "0x46d52dc3db74df14187554fb7afd5cc4af4558e3c8ca185e409955d6ac148.ssz");
+  TEST_ASSERT_NOT_NULL_MESSAGE(data.data, "Deneb bootstrap fixture missing");
+
+  ssz_ob_t   out   = {0};
+  c4_state_t state = {0};
+  bool       ok    = c4_eth_decode_bootstrap(C4_CHAIN_MAINNET, data, &state, /*req*/ NULL, &out);
+  TEST_ASSERT_TRUE_MESSAGE(ok, state.error ? state.error : "must decode without req");
+  TEST_ASSERT_NOT_NULL(out.def);
+  safe_free(data.data);
+  c4_state_free(&state);
+}
+
+void test_decode_bootstrap_gloas_size_rejected_on_mainnet(void) {
+  // A blob whose size matches the Gloas bootstrap (25472 B) but sent to
+  // Mainnet (where Gloas is NOT scheduled) must be rejected by the chain-
+  // schedule cross-check BEFORE `ssz_is_valid` is invoked. This defends
+  // against a beacon node accidentally serving a Gloas-shaped blob to a
+  // pre-Gloas chain.
+  uint8_t*   buf   = safe_calloc(1, C4_ETH_GLOAS_BOOTSTRAP_SIZE);
+  ssz_ob_t   out   = {0};
+  c4_state_t state = {0};
+  TEST_ASSERT_FALSE(c4_eth_decode_bootstrap(C4_CHAIN_MAINNET,
+                                            bytes(buf, C4_ETH_GLOAS_BOOTSTRAP_SIZE),
+                                            &state, /*req*/ NULL, &out));
+  TEST_ASSERT_NOT_NULL_MESSAGE(state.error, "must record schedule-check error");
+  // Sanity: `out` must remain untouched on failure so callers can't mistake
+  // a stale/uninitialised view for a valid one.
+  TEST_ASSERT_NULL(out.def);
+  safe_free(buf);
+  c4_state_free(&state);
+}
+
+// -----------------------------------------------------------------------------
+// validate_ssz=true against the recorded Mainnet LCU fixture and the slot /
+// context-digest cross-check. The fixture belongs to `trusted_block1` (period
+// 1392) so it is guaranteed to be present.
+// -----------------------------------------------------------------------------
+
+// Real Beacon-API list fixture: an LE uint64 length + 4-byte ForkDigest +
+// SSZ LCU payload for exactly one update.
+#define LCU_FIXTURE_PATH \
+  "trusted_block1/eth_v1_beacon_light_client_updates_start_period_1392_count_1.ssz"
+
+// The LCU container's fixed portion is
+//   attestedHeader offset(4) + nextSyncCommittee(24624) + nextSyncCommitteeBranch(5*32)
+// + finalizedHeader offset(4) + finalityBranch(6*32) + syncAggregate(160) + signatureSlot(8)
+// = 25152 bytes for the Deneb layout that this fixture uses. The first 4 bytes
+// of the payload therefore encode 25152 as the attestedHeader offset (verified
+// in `test_walk_lcu_list_validate_ssz_ok`), which is where `beacon.slot` lives.
+#define LCU_FIXTURE_ATTESTED_HEADER_OFFSET 25152u
+
+void test_walk_lcu_list_validate_ssz_ok(void) {
+  bytes_t data = read_testdata(LCU_FIXTURE_PATH);
+  TEST_ASSERT_NOT_NULL_MESSAGE(data.data, "LCU fixture missing");
+
+  // Sanity: the fixture context resolves to a scheduled Mainnet fork (i.e.
+  // Deneb or Electra depending on when the fixture was captured). If this
+  // assertion breaks, the fixture was regenerated and the test's other
+  // assumptions probably need revisiting.
+  fork_id_t fork_from_ctx = c4_eth_fork_from_context(C4_CHAIN_MAINNET, data.data + 8);
+  TEST_ASSERT_TRUE_MESSAGE(fork_from_ctx == C4_FORK_DENEB || fork_from_ctx == C4_FORK_ELECTRA,
+                           "fixture must belong to Deneb or Electra");
+
+  // Sanity: our slot-mutation offset only makes sense for the Deneb layout.
+  // Fail early with a helpful message if the fixture was regenerated as
+  // Electra (branch depths change -> 25184 fixed portion instead of 25152).
+  TEST_ASSERT_EQUAL_UINT32_MESSAGE(LCU_FIXTURE_ATTESTED_HEADER_OFFSET,
+                                   uint32_from_le(data.data + 12),
+                                   "fixture layout drifted; refresh LCU_FIXTURE_ATTESTED_HEADER_OFFSET");
+
+  c4_state_t      state = {0};
+  data_request_t  req   = {0};
+  chunk_counter_t cnt   = {0};
+  bool            ok    = c4_eth_walk_lcu_list(C4_CHAIN_MAINNET, data, &state, &req,
+                                               /*validate_ssz*/ true, count_chunks_cb, &cnt);
+  TEST_ASSERT_TRUE_MESSAGE(ok, state.error ? state.error : "walker must accept real fixture");
+  TEST_ASSERT_EQUAL_UINT32(1, cnt.seen);
+  TEST_ASSERT_EQUAL_INT((int) fork_from_ctx, (int) cnt.forks[0]);
+  TEST_ASSERT_TRUE(req.validated);
+  safe_free(data.data);
+  c4_state_free(&state);
+}
+
+void test_walk_lcu_list_validate_ssz_slot_mismatch(void) {
+  // Take a real Mainnet Deneb LCU, keep the SSZ layout & context intact, and
+  // only mutate `attestedHeader.beacon.slot` to a slot that maps to Electra
+  // on Mainnet (Electra activates at epoch 364032 = slot 11649024). The
+  // walker must:
+  //   - pass framing (unchanged),
+  //   - pass `ssz_is_valid` (mutating an 8-byte scalar leaves SSZ structure
+  //     intact),
+  //   - reject on the slot-vs-context-digest cross-check.
+  bytes_t data = read_testdata(LCU_FIXTURE_PATH);
+  TEST_ASSERT_NOT_NULL_MESSAGE(data.data, "LCU fixture missing");
+
+  fork_id_t fork_from_ctx = c4_eth_fork_from_context(C4_CHAIN_MAINNET, data.data + 8);
+  // Skip the test if the fixture was regenerated as a non-Deneb layout --
+  // the mutation offset would be wrong and we'd silently corrupt a length
+  // prefix. The other tests still cover the happy path in that case.
+  if (fork_from_ctx != C4_FORK_DENEB) {
+    safe_free(data.data);
+    TEST_IGNORE_MESSAGE("fixture is not Deneb; slot-mutation offset would drift");
+    return;
+  }
+  TEST_ASSERT_EQUAL_UINT32(LCU_FIXTURE_ATTESTED_HEADER_OFFSET,
+                           uint32_from_le(data.data + 12));
+
+  // Absolute byte offset of `attestedHeader.beacon.slot` inside the fixture:
+  //   8 (wire length) + 4 (context) + attestedHeader offset (25152) + 0 (slot
+  //   is the first field of BeaconBlockHeader).
+  const uint32_t slot_offset =
+      C4_LCU_WIRE_PREFIX_SIZE + LCU_FIXTURE_ATTESTED_HEADER_OFFSET;
+  TEST_ASSERT_TRUE_MESSAGE(slot_offset + 8 <= data.len, "slot offset out of bounds");
+
+  // Slot 12_800_000 -> epoch 400_000. On Mainnet Electra activates at epoch
+  // 364_032 and Fulu at 411_392, so this slot is unambiguously Electra.
+  const uint64_t electra_slot = 12800000ULL;
+  uint64_to_le(data.data + slot_offset, electra_slot);
+
+  c4_state_t      state = {0};
+  data_request_t  req   = {0};
+  chunk_counter_t cnt   = {0};
+  bool            ok    = c4_eth_walk_lcu_list(C4_CHAIN_MAINNET, data, &state, &req,
+                                               /*validate_ssz*/ true, count_chunks_cb, &cnt);
+  TEST_ASSERT_FALSE_MESSAGE(ok, "walker must reject slot/context fork mismatch");
+  // Framing succeeded, so `validated` must have been set before the pass-2
+  // slot-check fired.
+  TEST_ASSERT_TRUE_MESSAGE(req.validated,
+                           "framing pass must have marked the request validated");
+  TEST_ASSERT_NOT_NULL(state.error);
+  // The callback must not have been invoked -- the cross-check runs before it.
+  TEST_ASSERT_EQUAL_UINT32(0, cnt.seen);
+  safe_free(data.data);
+  c4_state_free(&state);
+}
+
+int main(void) {
+  UNITY_BEGIN();
+
+  RUN_TEST(test_compute_fork_digest_deterministic);
+  RUN_TEST(test_compute_fork_digest_differs_per_fork);
+  RUN_TEST(test_compute_fork_digest_bpo_differs_from_fulu_activation);
+  RUN_TEST(test_compute_fork_digest_bpo1_and_epoch_boundaries);
+  RUN_TEST(test_compute_fork_digest_sepolia_bpo);
+  RUN_TEST(test_compute_fork_digest_gnosis_empty_cl_blob_schedule);
+  RUN_TEST(test_compute_fork_digest_rejects_unknown_chain);
+
+  RUN_TEST(test_fork_from_context_digest_hits);
+  RUN_TEST(test_fork_from_context_fork_version_fallback);
+  RUN_TEST(test_fork_from_context_rejects_unknown);
+
+  RUN_TEST(test_walk_lcu_list_empty);
+  RUN_TEST(test_walk_lcu_list_one_chunk_marks_validated);
+  RUN_TEST(test_walk_lcu_list_two_chunks);
+  RUN_TEST(test_walk_lcu_list_truncated_header);
+  RUN_TEST(test_walk_lcu_list_length_below_context);
+  RUN_TEST(test_walk_lcu_list_length_exceeds_buffer);
+  RUN_TEST(test_walk_lcu_list_length_uint64_wrap);
+  RUN_TEST(test_walk_lcu_list_tail_garbage);
+  RUN_TEST(test_walk_lcu_list_unknown_context);
+  RUN_TEST(test_walk_lcu_list_cb_stop_after_first);
+
+  RUN_TEST(test_decode_bootstrap_recorded_deneb);
+  RUN_TEST(test_decode_bootstrap_recorded_electra);
+  RUN_TEST(test_decode_bootstrap_rejects_short);
+  RUN_TEST(test_decode_bootstrap_rejects_bogus_offset);
+
+  // NULL / edge-case coverage
+  RUN_TEST(test_compute_fork_digest_null_out);
+  RUN_TEST(test_fork_from_context_null_context);
+  RUN_TEST(test_fork_from_context_fork_version_fallback_fulu);
+  RUN_TEST(test_walk_lcu_list_null_data_nonzero_len);
+  RUN_TEST(test_walk_lcu_list_null_req);
+  RUN_TEST(test_walk_lcu_list_null_cb);
+  RUN_TEST(test_walk_lcu_list_null_state_on_error);
+  RUN_TEST(test_walk_lcu_list_zero_payload_chunk);
+  RUN_TEST(test_decode_bootstrap_null_out);
+  RUN_TEST(test_decode_bootstrap_null_req_recorded_deneb);
+  RUN_TEST(test_decode_bootstrap_gloas_size_rejected_on_mainnet);
+
+  // Real-fixture SSZ validation & slot-vs-context cross-check
+  RUN_TEST(test_walk_lcu_list_validate_ssz_ok);
+  RUN_TEST(test_walk_lcu_list_validate_ssz_slot_mismatch);
+
+  return UNITY_END();
+}

--- a/test/unittests/test_ssz_gloas.c
+++ b/test/unittests/test_ssz_gloas.c
@@ -254,7 +254,7 @@ void test_gloas_update_union_layout(void) {
   TEST_ASSERT_EQUAL_PTR_MESSAGE(d + 2, g, "Gloas update must be at update-union index 2");
 
   // The container names embedded in the union are the on-wire discriminators
-  // used by the `ssz_dump` output and by `c4_eth_get_fork_for_lcu` callers.
+  // used by the `ssz_dump` output and by `eth_get_light_client_update` callers.
   TEST_ASSERT_EQUAL_STRING("DenepLightClientUpdate", d->name);
   TEST_ASSERT_EQUAL_STRING("ElectraLightClientUpdate", e->name);
   TEST_ASSERT_EQUAL_STRING("GloasLightClientUpdate", g->name);


### PR DESCRIPTION
## Summary
- Validates Beacon-API `light_client/updates` list framing (`[uint64 length][4 B context][payload]`) in a shared walker and marks the request `validated` on structural success (#356).
- Derives the LCU fork from `ForkDigest` (including the Fulu/EIP-7892 blob-parameter XOR that Lodestar emits on mainnet BPO2) instead of the old slot heuristic; bootstrap fork uses fixed layout / header offset + `ssz_is_valid`.
- Production self-build writes the digest; legacy period-store files that still store raw `fork_version` keep working via a fallback.

Fixes #356. Follows #355 (`def == NULL` lists are now validated by the walker).

## Test plan
- [x] `cmake --build build/default`
- [x] `ctest --test-dir build/default` (73/73)
- [x] `test_lcu_wire` — framing, digest/BPO1/BPO2, Sepolia, Gnosis empty schedule, bootstrap sizes, slot mismatch
- [x] Live Lodestar SSZ (`start_period=1848`) context `8c9f62fe` matches computed mainnet BPO2 digest
- [ ] Re-run local prover against a stale sync committee (the path that previously failed with `unknown fork context`)