### PR TITLE
fix(eth): store transaction chainId as uint64

### DIFF
--- a/src/chains/eth/ssz/verify_data_types.h
+++ b/src/chains/eth/ssz/verify_data_types.h
@@ -86,7 +86,7 @@ static const ssz_def_t ETH_ACCESS_LIST_DATA_CONTAINER = SSZ_CONTAINER("AccessLis
 // Entry in the authorization list of a transaction or call.
 static const ssz_def_t ETH_AUTHORIZATION_LIST_DATA[] = {
     SSZ_ADDRESS("address"), // the codebase to be used for the authorization
-    SSZ_UINT32("chainId"),  // the chainId of the transaction
+    SSZ_UINT64("chainId"),  // the chainId of the authorization (EIP-7702)
     SSZ_UINT64("nonce"),    // nonce of the transaction
     SSZ_UINT256("r"),       // the r value of the transaction signature (QUANTITY per RPC spec)
     SSZ_UINT256("s"),       // the s value of the transaction signature (QUANTITY per RPC spec)
@@ -108,7 +108,7 @@ static const ssz_def_t ETH_TX_DATA[] = {
     SSZ_BYTES("input", 1073741824),                                            // the raw transaction payload
     SSZ_UINT256("r"),                                                          // the r value of the transaction signature (QUANTITY per RPC spec)
     SSZ_UINT256("s"),                                                          // the s value of the transaction signature (QUANTITY per RPC spec)
-    SSZ_UINT32("chainId"),                                                     // the chain ID of the transaction
+    SSZ_UINT64("chainId"),                                                     // the chain ID of the transaction
     SSZ_UINT64("v"),                                                           // the v value of the transaction signature
     SSZ_UINT64("gas"),                                                         // the gas limit
     SSZ_ADDRESS("from"),                                                       // the sender of the transaction

--- a/src/chains/eth/verifier/eth_tx.c
+++ b/src/chains/eth/verifier/eth_tx.c
@@ -997,9 +997,9 @@ bool c4_write_receipt_data_from_raw(verify_ctx_t* ctx, ssz_builder_t* buffer, by
   // the created contract address is keccak256(rlp([sender, nonce]))[12:32].
   // CREATE2-style deployments produce their own address inside the EVM and are
   // NOT set on the outer receipt.  Deposit txs never create contracts here.
-  bytes32_t contract_hash_buf   = {0};
-  bytes_t   contract_address    = NULL_BYTES;
-  bool      has_contract_addr   = false;
+  bytes32_t contract_hash_buf = {0};
+  bytes_t   contract_address  = NULL_BYTES;
+  bool      has_contract_addr = false;
   if (type != TX_TYPE_DEPOSITED && status_u64 == 1 && to_field.len == 0) {
     uint8_t  rlp_tmp[64] = {0};
     buffer_t rlp_buf     = {.data = {.data = rlp_tmp, .len = 0}, .allocated = -(int32_t) sizeof(rlp_tmp)};

--- a/src/chains/eth/verifier/eth_tx.c
+++ b/src/chains/eth/verifier/eth_tx.c
@@ -598,7 +598,7 @@ static ssz_builder_t build_authorization_list_ssz(verify_ctx_t* ctx, bytes_t rlp
         ssz_builder_free(&authorization_list_builder);
         return (ssz_builder_t) {0};
       }
-      ssz_add_uint32(&auth_entry_builder, (uint32_t) bytes_as_be(rlp_item_chain_id));
+      ssz_add_uint64(&auth_entry_builder, bytes_as_be(rlp_item_chain_id));
 
       // Field 2 in SSZ: nonce (from RLP index 2)
       if (rlp_decode(&auth_tuple_rlp, 2, &rlp_item_nonce) != RLP_ITEM) {
@@ -698,7 +698,7 @@ INTERNAL bool c4_write_tx_data_from_raw(verify_ctx_t* ctx, ssz_builder_t* buffer
   bytes_t  rlp_v_field                      = {0};
   uint8_t  tx_sig_y_parity                  = 0;
   uint64_t v_for_ssz                        = 0;
-  uint32_t chain_id                         = 0;
+  uint64_t chain_id                         = 0;
   uint64_t gas_price_rlp_val                = 0;
   uint64_t max_priority_fee_per_gas_rlp_val = 0;
   uint64_t max_fee_per_gas_rlp_val          = 0;
@@ -708,7 +708,7 @@ INTERNAL bool c4_write_tx_data_from_raw(verify_ctx_t* ctx, ssz_builder_t* buffer
     rlp_tx_sig_y_parity = get_rlp_field(ctx, rlp_list_payload, defs_ptr, "yParity", RLP_ITEM);
     rlp_v_field         = get_rlp_field(ctx, rlp_list_payload, defs_ptr, "v", RLP_ITEM);
     tx_sig_y_parity     = rlp_tx_sig_y_parity.len ? rlp_tx_sig_y_parity.data[0] : 0;
-    chain_id            = (uint32_t) bytes_as_be(get_rlp_field(ctx, rlp_list_payload, defs_ptr, "chainId", RLP_ITEM));
+    chain_id            = bytes_as_be(get_rlp_field(ctx, rlp_list_payload, defs_ptr, "chainId", RLP_ITEM));
     gas_price_rlp_val   = bytes_as_be(get_rlp_field(ctx, rlp_list_payload, defs_ptr, "gasPrice", RLP_ITEM));
   }
 
@@ -826,7 +826,7 @@ INTERNAL bool c4_write_tx_data_from_raw(verify_ctx_t* ctx, ssz_builder_t* buffer
     ssz_add_uint256(buffer, get_rlp_field(ctx, rlp_list_payload, defs_ptr, "s", RLP_ITEM));
   }
 
-  ssz_add_uint32(buffer, chain_id);
+  ssz_add_uint64(buffer, chain_id);
   ssz_add_uint64(buffer, v_for_ssz);
   ssz_add_uint64(buffer, bytes_as_be(get_rlp_field(ctx, rlp_list_payload, defs_ptr, "gas", RLP_ITEM)));
   ssz_add_bytes(buffer, "from", bytes(from_address, 20));

--- a/test/unittests/test_eth_local.c
+++ b/test/unittests/test_eth_local.c
@@ -25,8 +25,11 @@
 #include "beacon_types.h"
 #include "bytes.h"
 #include "c4_assert.h"
+#include "eth_tx.h"
+#include "rlp.h"
 #include "ssz.h"
 #include "unity.h"
+#include <string.h>
 void setUp(void) {
 }
 
@@ -186,6 +189,144 @@ void test_colibri_decodeTransaction() {
   c4_verify_free_data(&ctx);
 }
 
+// PlatAberg-sized chain id: 0x1a6a8cc6e does not fit in uint32 (truncated to 0xa6a8cc6e).
+#define TEST_LARGE_CHAIN_ID 0x1a6a8cc6eULL
+
+static void fill_test_sig(uint8_t r[32], uint8_t s[32]) {
+  hex_to_bytes("28ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276", -1, bytes(r, 32));
+  hex_to_bytes("67cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83", -1, bytes(s, 32));
+}
+
+static void append_test_sig(buffer_t* payload) {
+  uint8_t r[32], s[32];
+  fill_test_sig(r, s);
+  rlp_add_item(payload, bytes(r, 32));
+  rlp_add_item(payload, bytes(s, 32));
+}
+
+static ssz_ob_t decode_raw_tx(bytes_t raw) {
+  verify_ctx_t  ctx     = {0};
+  ssz_builder_t builder = ssz_builder_for_type(ETH_SSZ_DATA_TX);
+  bytes32_t     zero    = {0};
+  bool          ok      = c4_write_tx_data_from_raw(&ctx, &builder, raw, zero, zero, 0, 0, 0, 0);
+  TEST_ASSERT_NULL_MESSAGE(ctx.state.error, ctx.state.error ? ctx.state.error : "decode error");
+  TEST_ASSERT_TRUE_MESSAGE(ok, "c4_write_tx_data_from_raw failed");
+  return ssz_builder_to_bytes(&builder);
+}
+
+// RPC JSON uses write_unit_as_hex; the PlatAberg bug was "0xa6a8cc6e" instead of "0x1a6a8cc6e".
+static void assert_large_chain_id_json(ssz_ob_t ob) {
+  char* json = ssz_dump_to_str(ob, false, true);
+  TEST_ASSERT_NOT_NULL(json);
+  TEST_ASSERT_NOT_NULL_MESSAGE(strstr(json, "\"chainId\":\"0x1a6a8cc6e\""), json);
+  TEST_ASSERT_NULL_MESSAGE(strstr(json, "\"chainId\":\"0xa6a8cc6e\""), json);
+  safe_free(json);
+}
+
+void test_tx_chainId_uint64() {
+  const ssz_def_t* tx_def       = eth_ssz_verification_type(ETH_SSZ_DATA_TX);
+  const ssz_def_t* chain_id_def = ssz_get_def(tx_def, "chainId");
+  TEST_ASSERT_NOT_NULL(chain_id_def);
+  TEST_ASSERT_EQUAL_UINT32(8, chain_id_def->def.uint.len);
+
+  buffer_t payload = {0};
+  uint8_t  to[20]  = {0};
+  rlp_add_uint64(&payload, TEST_LARGE_CHAIN_ID);
+  rlp_add_uint64(&payload, 0);     // nonce
+  rlp_add_uint64(&payload, 1);     // maxPriorityFeePerGas
+  rlp_add_uint64(&payload, 1);     // maxFeePerGas
+  rlp_add_uint64(&payload, 21000); // gas
+  rlp_add_item(&payload, bytes(to, 20));
+  rlp_add_uint64(&payload, 0);        // value
+  rlp_add_item(&payload, NULL_BYTES); // input
+  rlp_add_list(&payload, NULL_BYTES); // empty accessList
+  rlp_add_uint64(&payload, 0);        // yParity
+  append_test_sig(&payload);
+  rlp_to_list(&payload);
+  uint8_t type = 2;
+  buffer_splice(&payload, 0, 0, bytes(&type, 1));
+
+  ssz_ob_t tx = decode_raw_tx(payload.data);
+  TEST_ASSERT_EQUAL_UINT64(TEST_LARGE_CHAIN_ID, ssz_get_uint64(&tx, "chainId"));
+  assert_large_chain_id_json(tx);
+  safe_free(tx.bytes.data);
+  buffer_free(&payload);
+}
+
+void test_auth_list_chainId_uint64() {
+  const ssz_def_t* tx_def        = eth_ssz_verification_type(ETH_SSZ_DATA_TX);
+  const ssz_def_t* auth_list_def = ssz_get_def(tx_def, "authorizationList");
+  TEST_ASSERT_NOT_NULL(auth_list_def);
+  const ssz_def_t* auth_entry_def = auth_list_def->def.vector.type;
+  const ssz_def_t* auth_chain_def = ssz_get_def(auth_entry_def, "chainId");
+  TEST_ASSERT_NOT_NULL(auth_chain_def);
+  TEST_ASSERT_EQUAL_UINT32(8, auth_chain_def->def.uint.len);
+
+  uint8_t to[20] = {0};
+  uint8_t r[32], s[32];
+  fill_test_sig(r, s);
+
+  buffer_t auth = {0};
+  rlp_add_uint64(&auth, TEST_LARGE_CHAIN_ID);
+  rlp_add_item(&auth, bytes(to, 20));
+  rlp_add_uint64(&auth, 0); // nonce
+  rlp_add_uint64(&auth, 1); // yParity
+  rlp_add_item(&auth, bytes(r, 32));
+  rlp_add_item(&auth, bytes(s, 32));
+  rlp_to_list(&auth);
+
+  buffer_t payload = {0};
+  rlp_add_uint64(&payload, TEST_LARGE_CHAIN_ID);
+  rlp_add_uint64(&payload, 0);     // nonce
+  rlp_add_uint64(&payload, 1);     // maxPriorityFeePerGas
+  rlp_add_uint64(&payload, 1);     // maxFeePerGas
+  rlp_add_uint64(&payload, 21000); // gas
+  rlp_add_item(&payload, bytes(to, 20));
+  rlp_add_uint64(&payload, 0);        // value
+  rlp_add_item(&payload, NULL_BYTES); // input
+  rlp_add_list(&payload, NULL_BYTES); // empty accessList
+  rlp_add_list(&payload, auth.data);  // authorizationList with one entry
+  rlp_add_uint64(&payload, 0);        // yParity
+  append_test_sig(&payload);
+  rlp_to_list(&payload);
+  uint8_t type = 4;
+  buffer_splice(&payload, 0, 0, bytes(&type, 1));
+
+  ssz_ob_t tx        = decode_raw_tx(payload.data);
+  ssz_ob_t auth_list = ssz_get(&tx, "authorizationList");
+  TEST_ASSERT_EQUAL_UINT32(1, ssz_len(auth_list));
+  ssz_ob_t entry = ssz_at(auth_list, 0);
+  TEST_ASSERT_EQUAL_UINT64(TEST_LARGE_CHAIN_ID, ssz_get_uint64(&tx, "chainId"));
+  TEST_ASSERT_EQUAL_UINT64(TEST_LARGE_CHAIN_ID, ssz_get_uint64(&entry, "chainId"));
+  assert_large_chain_id_json(tx);
+  assert_large_chain_id_json(entry);
+  safe_free(tx.bytes.data);
+  buffer_free(&auth);
+  buffer_free(&payload);
+}
+
+void test_legacy_eip155_chainId_uint64() {
+  // EIP-155: v = chainId * 2 + 35 + yParity. The writer derives chainId from v,
+  // so a uint32 store would still truncate PlatAberg-sized ids on legacy txs.
+  buffer_t payload = {0};
+  uint8_t  to[20]  = {0};
+  rlp_add_uint64(&payload, 0);     // nonce
+  rlp_add_uint64(&payload, 1);     // gasPrice
+  rlp_add_uint64(&payload, 21000); // gas
+  rlp_add_item(&payload, bytes(to, 20));
+  rlp_add_uint64(&payload, 0);        // value
+  rlp_add_item(&payload, NULL_BYTES); // input
+  rlp_add_uint64(&payload, TEST_LARGE_CHAIN_ID * 2 + 35);
+  append_test_sig(&payload);
+  rlp_to_list(&payload);
+
+  ssz_ob_t tx = decode_raw_tx(payload.data);
+  TEST_ASSERT_EQUAL_UINT64(TEST_LARGE_CHAIN_ID, ssz_get_uint64(&tx, "chainId"));
+  assert_large_chain_id_json(tx);
+  safe_free(tx.bytes.data);
+  buffer_free(&payload);
+}
+
 // TODO: Fix decoder to properly handle invalid input without crashing
 // Currently crashes with invalid hex input
 /*
@@ -227,6 +368,9 @@ int main(void) {
 
   // Transaction Decoding
   RUN_TEST(test_colibri_decodeTransaction);
+  RUN_TEST(test_tx_chainId_uint64);
+  RUN_TEST(test_auth_list_chainId_uint64);
+  RUN_TEST(test_legacy_eip155_chainId_uint64);
   // RUN_TEST(test_colibri_decodeTransaction_invalid); // TODO: Decoder crashes with invalid input
 
   // Error handling


### PR DESCRIPTION
## Summary
- `ETH_TX_DATA.chainId` and EIP-7702 `authorizationList.chainId` are now `uint64`, matching `chain_id_t`.
- Fixes truncated RPC output on chains such as PlatAberg (`0x1a6a8cc6e` was shown as `0xa6a8cc6e`).
- Adds regression tests for typed txs, authorization lists, legacy EIP-155 `v` derivation, and JSON hex rendering.

## Test plan
- [x] `test_eth_local` (including new uint64 / JSON / legacy EIP-155 cases)
- [x] `test_eth_verify_tx`, `test_eth_verify_block`, `test_eth_verify_call`, `test_eth_verify_receipt`
- [x] Re-check `eth_getTransactionByHash` on PlatAberg against a direct RPC `chainId`