### PR TITLE
feat(eth): detect LCU fork from Beacon-API ForkDigest

### DIFF
--- a/src/chains/eth/prover/historic_proof.c
+++ b/src/chains/eth/prover/historic_proof.c
@@ -392,7 +392,7 @@ c4_status_t c4_fetch_client_updates(prover_ctx_t* ctx, uint64_t start_period, ui
   // Preferred path (server context): read the LCUs from the local period_store
   // via the internal `lcu_updates` handler. That handler concatenates the
   // per-period `lcu.ssz` files (already in Beacon-API wire format: 8-byte LE
-  // length + 4-byte fork_version + LCU SSZ) and transparently backfills
+  // length + 4-byte ForkDigest + LCU SSZ) and transparently backfills
   // missing periods from a beacon node. It's noticeably cheaper than a
   // dedicated beacon roundtrip when the cache is warm.
   //
@@ -460,12 +460,21 @@ static c4_status_t fetch_updates_data(prover_ctx_t* ctx, syncdata_state_t* sync_
     uint32_t data_length_offset = SSZ_OFFSET_SIZE;
     length                      = uint64_from_le(client_updates.data + pos);
 
-    if (pos + SSZ_LENGTH_SIZE + length > client_updates.len && length > UPDATE_PREFIX_SIZE) break;
+    if (length < data_length_offset ||
+        pos + SSZ_LENGTH_SIZE + length > client_updates.len ||
+        pos + SSZ_LENGTH_SIZE + length < pos) {
+      c4_state_add_error(&ctx->state, "invalid light client update length");
+      return C4_ERROR;
+    }
 
     bytes_t   client_update_bytes = bytes(client_updates.data + data_offset, length - data_length_offset);
-    fork_id_t fork                = c4_eth_get_fork_for_lcu(ctx->chain_id, client_update_bytes);
+    bytes_t   fork_digest         = bytes(client_updates.data + pos + SSZ_LENGTH_SIZE, 4);
+    fork_id_t fork                = c4_eth_get_fork_for_lcu(ctx->chain_id, fork_digest);
     ssz_ob_t  update              = {.bytes = client_update_bytes, .def = eth_get_light_client_update(fork)};
-    if (!update.def) THROW_ERROR("Invalid update data!");
+    if (!update.def) {
+      c4_eth_unknown_lcu_fork_error(&ctx->state, fork_digest.data);
+      return C4_ERROR;
+    }
 
     bytes_t prefixed = bytes(safe_malloc(update.bytes.len + 1), update.bytes.len + 1);
     memcpy(prefixed.data + 1, update.bytes.data, update.bytes.len);

--- a/src/chains/eth/prover/historic_proof.c
+++ b/src/chains/eth/prover/historic_proof.c
@@ -463,18 +463,15 @@ static c4_status_t fetch_updates_data(prover_ctx_t* ctx, syncdata_state_t* sync_
     if (length < data_length_offset ||
         pos + SSZ_LENGTH_SIZE + length > client_updates.len ||
         pos + SSZ_LENGTH_SIZE + length < pos) {
-      c4_state_add_error(&ctx->state, "invalid light client update length");
-      return C4_ERROR;
+      THROW_ERROR("invalid light client update length");
     }
 
     bytes_t   client_update_bytes = bytes(client_updates.data + data_offset, length - data_length_offset);
     bytes_t   fork_digest         = bytes(client_updates.data + pos + SSZ_LENGTH_SIZE, 4);
-    fork_id_t fork                = c4_eth_get_fork_for_lcu(ctx->chain_id, fork_digest);
+    fork_id_t fork                = c4_eth_fork_from_digest(ctx->chain_id, fork_digest.data);
     ssz_ob_t  update              = {.bytes = client_update_bytes, .def = eth_get_light_client_update(fork)};
-    if (!update.def) {
-      c4_eth_unknown_lcu_fork_error(&ctx->state, fork_digest.data);
-      return C4_ERROR;
-    }
+    if (!update.def)
+      THROW_ERROR_WITH(C4_ETH_UNKNOWN_LCU_FORK_FMT, fork_digest, c4_client_version);
 
     bytes_t prefixed = bytes(safe_malloc(update.bytes.len + 1), update.bytes.len + 1);
     memcpy(prefixed.data + 1, update.bytes.data, update.bytes.len);

--- a/src/chains/eth/prover/historic_proof.h
+++ b/src/chains/eth/prover/historic_proof.h
@@ -93,7 +93,7 @@ c4_status_t c4_fetch_zk_proof_data(prover_ctx_t* ctx, zk_proof_data_t* zk_proof,
 /**
  * Fetches the raw wire bytes of `[start_period .. start_period + count - 1]`
  * `LightClientUpdate`s in Beacon-API list format (each entry is prefixed with
- * an 8-byte LE length + 4-byte fork_version).
+ * an 8-byte LE length + 4-byte ForkDigest).
  *
  * Two lookup paths are tried in order:
  *

--- a/src/chains/eth/prover/lcu_gloas.c
+++ b/src/chains/eth/prover/lcu_gloas.c
@@ -133,20 +133,20 @@ bool c4_gloas_lcu_assemble(bytes_t  attested_header,
 }
 
 bytes_t c4_gloas_lcu_wrap_beacon_response(bytes_t lcu_ssz,
-                                          uint8_t fork_version[4]) {
-  if (!lcu_ssz.data || lcu_ssz.len != C4_GLOAS_LCU_SSZ_SIZE || !fork_version)
+                                          uint8_t fork_digest[4]) {
+  if (!lcu_ssz.data || lcu_ssz.len != C4_GLOAS_LCU_SSZ_SIZE || !fork_digest)
     return NULL_BYTES;
 
   // Beacon-API `light_client/updates` wire format for one entry:
   //   [0 .. 8)  length = 4 + lcu_ssz.len (uint64 LE, big enough for both
   //                     current updates layout and future 2^64-1 extensions)
-  //   [8 .. 12) fork_version (raw bytes)
+  //   [8 .. 12) ForkDigest (caller-supplied; typically compute_fork_digest at the fork activation epoch)
   //   [12 ..)   payload
   const uint64_t length = 4u + (uint64_t) lcu_ssz.len;
   uint8_t*       buf    = (uint8_t*) safe_malloc(C4_GLOAS_LCU_WIRE_PREFIX_SIZE + lcu_ssz.len);
 
   uint64_to_le(buf, length);
-  memcpy(buf + 8, fork_version, 4);
+  memcpy(buf + 8, fork_digest, 4);
   memcpy(buf + C4_GLOAS_LCU_WIRE_PREFIX_SIZE, lcu_ssz.data, lcu_ssz.len);
 
   return bytes(buf, C4_GLOAS_LCU_WIRE_PREFIX_SIZE + lcu_ssz.len);

--- a/src/chains/eth/prover/lcu_gloas.h
+++ b/src/chains/eth/prover/lcu_gloas.h
@@ -53,7 +53,7 @@ extern "C" {
 
 // Beacon-API `light_client/updates` wire-format prefix per update:
 //   [0 .. 8)  length (uint64 LE) = 4 + update_size
-//   [8 .. 12) fork_version (4 bytes)
+//   [8 .. 12) ForkDigest (4 bytes)
 // followed by the raw LCU-SSZ payload.
 #define C4_GLOAS_LCU_WIRE_PREFIX_SIZE 12u
 #define C4_GLOAS_LCU_WIRE_SIZE        (C4_GLOAS_LCU_WIRE_PREFIX_SIZE + C4_GLOAS_LCU_SSZ_SIZE)
@@ -136,7 +136,7 @@ bool c4_gloas_lcu_assemble(bytes_t  attested_header,
  *
  * ```text
  * [8 bytes LE]  length = 4 + lcu_ssz.len
- * [4 bytes  ]   fork_version (as passed by caller)
+ * [4 bytes  ]   ForkDigest (as passed by caller)
  * [lcu_ssz  ]   payload
  * ```
  *
@@ -144,12 +144,12 @@ bool c4_gloas_lcu_assemble(bytes_t  attested_header,
  * or `lcu_ssz.data == NULL`.
  *
  * @param lcu_ssz the raw LCU-SSZ payload (borrowed, not consumed).
- * @param fork_version the 4-byte fork version identifier written as-is.
+ * @param fork_digest the 4-byte Beacon-API ForkDigest written as-is.
  * @return heap-allocated `bytes_t` of length `12 + lcu_ssz.len` on success;
  *         `NULL_BYTES` on invalid input. Caller must `safe_free(.data)`.
  */
 bytes_t c4_gloas_lcu_wrap_beacon_response(bytes_t lcu_ssz,
-                                          uint8_t fork_version[4]);
+                                          uint8_t fork_digest[4]);
 
 #ifdef __cplusplus
 }

--- a/src/chains/eth/prover/proof_sync.c
+++ b/src/chains/eth/prover/proof_sync.c
@@ -51,11 +51,16 @@ static ssz_ob_t unwrap_lcu_response(prover_ctx_t* ctx, bytes_t data) {
   ssz_ob_t result = {.bytes = NULL_BYTES, .def = NULL};
   if (data.len < 12) return result;
   uint64_t payload_len = uint64_from_le(data.data);
-  if (payload_len < 4 || 8 + payload_len > data.len) return result;
-  result.bytes          = bytes(data.data + 12, payload_len - 4);
-  fork_id_t        fork = c4_eth_get_fork_for_lcu(ctx->chain_id, result.bytes);
-  const ssz_def_t* def  = eth_get_light_client_update(fork);
-  result.def            = def;
+  if (payload_len < 4 || 8 + payload_len > data.len || 8 + payload_len < payload_len) return result;
+  result.bytes            = bytes(data.data + 12, payload_len - 4);
+  bytes_t          digest = bytes(data.data + 8, 4);
+  fork_id_t        fork   = c4_eth_get_fork_for_lcu(ctx->chain_id, digest);
+  const ssz_def_t* def    = eth_get_light_client_update(fork);
+  if (!def) {
+    c4_eth_unknown_lcu_fork_error(&ctx->state, digest.data);
+    return result;
+  }
+  result.def = def;
   return result;
 }
 
@@ -68,7 +73,7 @@ static c4_status_t extract_sync_data(prover_ctx_t* ctx, bytes_t old_data, bytes_
   ssz_ob_t new_update = unwrap_lcu_response(ctx, new_data);
   if (!new_update.def) THROW_ERROR("invalid new client_update");
 
-  fork_id_t fork = c4_eth_get_fork_for_lcu(ctx->chain_id, new_update.bytes);
+  fork_id_t fork = c4_eth_get_fork_for_lcu(ctx->chain_id, bytes(new_data.data + 8, 4));
 
   ssz_ob_t old_sync_keys  = ssz_get(&old_update, "nextSyncCommittee");
   ssz_ob_t new_sync_keys  = ssz_get(&new_update, "nextSyncCommittee");

--- a/src/chains/eth/prover/proof_sync.c
+++ b/src/chains/eth/prover/proof_sync.c
@@ -54,7 +54,7 @@ static ssz_ob_t unwrap_lcu_response(prover_ctx_t* ctx, bytes_t data) {
   if (payload_len < 4 || 8 + payload_len > data.len || 8 + payload_len < payload_len) return result;
   result.bytes            = bytes(data.data + 12, payload_len - 4);
   bytes_t          digest = bytes(data.data + 8, 4);
-  fork_id_t        fork   = c4_eth_get_fork_for_lcu(ctx->chain_id, digest);
+  fork_id_t        fork   = c4_eth_fork_from_digest(ctx->chain_id, digest.data);
   const ssz_def_t* def    = eth_get_light_client_update(fork);
   if (!def) {
     c4_eth_unknown_lcu_fork_error(&ctx->state, digest.data);
@@ -73,7 +73,7 @@ static c4_status_t extract_sync_data(prover_ctx_t* ctx, bytes_t old_data, bytes_
   ssz_ob_t new_update = unwrap_lcu_response(ctx, new_data);
   if (!new_update.def) THROW_ERROR("invalid new client_update");
 
-  fork_id_t fork = c4_eth_get_fork_for_lcu(ctx->chain_id, bytes(new_data.data + 8, 4));
+  fork_id_t fork = c4_eth_fork_from_digest(ctx->chain_id, new_data.data + 8);
 
   ssz_ob_t old_sync_keys  = ssz_get(&old_update, "nextSyncCommittee");
   ssz_ob_t new_sync_keys  = ssz_get(&new_update, "nextSyncCommittee");

--- a/src/chains/eth/server/period_store_lc.c
+++ b/src/chains/eth/server/period_store_lc.c
@@ -290,7 +290,7 @@ static void fetch_lcb_cb(client_t* client, void* data, data_request_t* r) {
     THROW_PERIOD_ERROR(r, "period_store: LCU fetch for period %l failed: response too short", period);
   ssz_ob_t  update      = {.bytes = bytes(r->response.data + UPDATE_PREFIX_SIZE, length - SSZ_OFFSET_SIZE), .def = NULL};
   bytes_t   fork_digest = bytes(r->response.data + 8, 4);
-  fork_id_t fork        = c4_eth_get_fork_for_lcu(http_server.chain_id, fork_digest);
+  fork_id_t fork        = c4_eth_fork_from_digest(http_server.chain_id, fork_digest.data);
   update.def            = eth_get_light_client_update(fork);
   if (!update.def) THROW_PERIOD_ERROR(r, "period_store: LCU fetch for period %l failed: unrecognized fork digest 0x%x; this Colibri version does not support the current chain fork - please update the app", period, fork_digest);
   ssz_ob_t finalized         = ssz_get(&update, "finalizedHeader");

--- a/src/chains/eth/server/period_store_lc.c
+++ b/src/chains/eth/server/period_store_lc.c
@@ -283,10 +283,16 @@ static void fetch_lcb_cb(client_t* client, void* data, data_request_t* r) {
   if (r->error) THROW_PERIOD_ERROR(r, "period_store: LCU fetch for period %l failed: %s", period, r->error);
   if (r->response.len < UPDATE_PREFIX_SIZE) THROW_PERIOD_ERROR(r, "period_store: LCU fetch for period %l failed: response too short", period);
 
-  ssz_ob_t update = {.bytes = bytes(r->response.data + UPDATE_PREFIX_SIZE, uint64_from_le(r->response.data) - SSZ_OFFSET_SIZE), .def = NULL};
-  if (update.bytes.data + update.bytes.len > r->response.data + r->response.len) THROW_PERIOD_ERROR(r, "period_store: LCU fetch for period %l failed: response too short", period);
-  update.def = eth_get_light_client_update(c4_eth_get_fork_for_lcu(http_server.chain_id, update.bytes));
-  if (!update.def) THROW_PERIOD_ERROR(r, "period_store: LCU fetch for period %l failed: invalid update data len=%l", period, update.bytes.len);
+  uint64_t length = uint64_from_le(r->response.data);
+  if (length < SSZ_OFFSET_SIZE ||
+      SSZ_LENGTH_SIZE + length > r->response.len ||
+      SSZ_LENGTH_SIZE + length < length)
+    THROW_PERIOD_ERROR(r, "period_store: LCU fetch for period %l failed: response too short", period);
+  ssz_ob_t  update      = {.bytes = bytes(r->response.data + UPDATE_PREFIX_SIZE, length - SSZ_OFFSET_SIZE), .def = NULL};
+  bytes_t   fork_digest = bytes(r->response.data + 8, 4);
+  fork_id_t fork        = c4_eth_get_fork_for_lcu(http_server.chain_id, fork_digest);
+  update.def            = eth_get_light_client_update(fork);
+  if (!update.def) THROW_PERIOD_ERROR(r, "period_store: LCU fetch for period %l failed: unrecognized fork digest 0x%x; this Colibri version does not support the current chain fork - please update the app", period, fork_digest);
   ssz_ob_t finalized         = ssz_get(&update, "finalizedHeader");
   ssz_ob_t header            = ssz_get(&finalized, "beacon");
   uint64_t checkpoint_period = ssz_get_uint64(&header, "slot") >> 13;
@@ -364,19 +370,15 @@ static void ps_build_lcu_cb(request_t* req) {
     case C4_SUCCESS: {
       // Wrap into the Beacon-API `light_client/updates` wire format so the
       // existing consumers can parse it without any special-case.
-      const chain_spec_t* chain = c4_eth_get_chain_spec(ctx->chain_id);
-      if (!chain || !chain->fork_version_func) {
-        // Defense-in-depth: every registered chain sets `fork_version_func`,
-        // but a future entry might forget. Fail loudly instead of NULL-deref.
-        log_warn("period_store: LCU self-build for period %l: chain spec missing fork_version_func", period);
+      uint8_t fork_digest[4] = {0};
+      if (!c4_eth_compute_fork_digest(ctx->chain_id, C4_FORK_GLOAS, fork_digest)) {
+        log_warn("period_store: LCU self-build for period %l: cannot compute Gloas fork digest", period);
         safe_free(lcu_ssz.data);
         c4_prover_free(ctx);
         safe_free(req);
         return;
       }
-      uint8_t fork_version[4] = {0};
-      chain->fork_version_func(ctx->chain_id, C4_FORK_GLOAS, fork_version);
-      bytes_t wire = c4_gloas_lcu_wrap_beacon_response(lcu_ssz, fork_version);
+      bytes_t wire = c4_gloas_lcu_wrap_beacon_response(lcu_ssz, fork_digest);
       safe_free(lcu_ssz.data);
       if (!wire.data) {
         log_warn("period_store: LCU self-build wrapping failed for period %l", period);

--- a/src/chains/eth/ssz/beacon_types.c
+++ b/src/chains/eth/ssz/beacon_types.c
@@ -24,7 +24,9 @@
 #define FORKS_END        0xfffffffffffffffeULL // must stay < NOT_ASSIGNED_YET
 
 #include "beacon_types.h"
+#include "crypto.h"
 #include "ssz.h"
+#include <string.h>
 
 // fork_epochs[n] = activation epoch of fork (n+1) (Altair ..).
 // 0 = active at genesis. NOT_ASSIGNED_YET = not scheduled. Terminated by FORKS_END.
@@ -76,6 +78,28 @@ static const eth_blob_schedule_t eth_chiado_blob_schedule[] = {
     {0ULL, 0ULL},
 };
 
+// Consensus-layer BLOB_SCHEDULE for `compute_fork_digest` / `get_blob_parameters`.
+// DESCENDING by epoch so the first match wins. Terminated by max_blobs == 0.
+// Official sources: consensus-specs configs/mainnet.yaml, eth-clients/sepolia,
+// ethpandaops/glamsterdam-devnets (Platåberget / devnet-8). Gnosis has no BPO
+// entries (empty schedule → Electra fallback).
+static const eth_blob_params_t eth_mainnet_blob_params[] = {
+    {419072ULL, 21ULL}, // BPO2
+    {412672ULL, 15ULL}, // BPO1
+    {0ULL, 0ULL},
+};
+
+static const eth_blob_params_t eth_sepolia_blob_params[] = {
+    {275712ULL, 21ULL}, // BPO2
+    {274176ULL, 15ULL}, // BPO1
+    {0ULL, 0ULL},
+};
+
+static const eth_blob_params_t eth_plataberget_blob_params[] = {
+    {0ULL, 21ULL}, // genesis-at-Fulu: single BLOB_SCHEDULE entry
+    {0ULL, 0ULL},
+};
+
 static void mainnet_fork_version(chain_id_t chain_id, fork_id_t fork, uint8_t* version) {
   version[0] = (uint8_t) fork;
   version[1] = 0x00;
@@ -120,8 +144,10 @@ static const chain_spec_t chain_data[] = {
      .slots_per_epoch_bits     = 5,
      .epochs_per_period_bits   = 8,
      .weak_subjectivity_epochs = 3682,
-     .fork_version_func        = mainnet_fork_version,
-     .blob_schedule            = eth_mainnet_blob_schedule},
+     .fork_version_func             = mainnet_fork_version,
+     .blob_schedule                 = eth_mainnet_blob_schedule,
+     .blob_params                   = eth_mainnet_blob_params,
+     .max_blobs_per_block_electra   = 9ULL},
     {// Sepolia
      .chain_id                 = CHAIN_ID(C4_CHAIN_TYPE_ETHEREUM, 11155111),
      .fork_epochs              = eth_sepolia_fork_epochs,
@@ -130,8 +156,10 @@ static const chain_spec_t chain_data[] = {
      .slots_per_epoch_bits     = 5,
      .epochs_per_period_bits   = 8,
      .weak_subjectivity_epochs = 3682,
-     .fork_version_func        = sepolia_fork_version,
-     .blob_schedule            = eth_sepolia_blob_schedule},
+     .fork_version_func             = sepolia_fork_version,
+     .blob_schedule                 = eth_sepolia_blob_schedule,
+     .blob_params                   = eth_sepolia_blob_params,
+     .max_blobs_per_block_electra   = 9ULL},
     {// Plataberget
      .chain_id                 = CHAIN_ID(C4_CHAIN_TYPE_ETHEREUM, 7091047534),
      .fork_epochs              = eth_plataberget_fork_epochs,
@@ -139,8 +167,10 @@ static const chain_spec_t chain_data[] = {
      .zk_sync_keys_root        = "\x82\xb2\x41\xf5\x2b\x29\x0f\x82\x78\x81\x11\xbd\x79\x74\xee\x87\xd9\xbb\xac\xfb\xe5\xd0\x84\xa3\x70\x31\x7f\x34\xe7\xb7\xfa\x84", // TODO: replace Sepolia placeholder with Plataberget v6 anchor
      .slots_per_epoch_bits     = 5,
      .epochs_per_period_bits   = 8,
-     .weak_subjectivity_epochs = 3682,
-     .fork_version_func        = plataberget_fork_version},
+     .weak_subjectivity_epochs      = 3682,
+     .fork_version_func             = plataberget_fork_version,
+     .blob_params                   = eth_plataberget_blob_params,
+     .max_blobs_per_block_electra   = 9ULL},
     {// Gnosis
      .chain_id                 = CHAIN_ID(C4_CHAIN_TYPE_ETHEREUM, 100ULL),
      .fork_epochs              = eth_gnosis_fork_epochs,
@@ -149,9 +179,10 @@ static const chain_spec_t chain_data[] = {
      .slots_per_epoch_bits     = 4,
      .epochs_per_period_bits   = 9,
      .weak_subjectivity_epochs = 1500,
-     .fork_version_func        = gnosis_fork_version,
-     .blob_schedule            = eth_gnosis_blob_schedule,
-     .min_blob_base_fee        = 1000000000ULL},
+     .fork_version_func             = gnosis_fork_version,
+     .blob_schedule                 = eth_gnosis_blob_schedule,
+     .min_blob_base_fee             = 1000000000ULL,
+     .max_blobs_per_block_electra   = 2ULL},
     {// Gnosis chiado
      .chain_id                 = CHAIN_ID(C4_CHAIN_TYPE_ETHEREUM, 10200ULL),
      .fork_epochs              = eth_chiado_fork_epochs,
@@ -159,9 +190,10 @@ static const chain_spec_t chain_data[] = {
      .slots_per_epoch_bits     = 4,
      .epochs_per_period_bits   = 9,
      .weak_subjectivity_epochs = 1500,
-     .fork_version_func        = gnosis_fork_version,
-     .blob_schedule            = eth_chiado_blob_schedule,
-     .min_blob_base_fee        = 1000000000ULL},
+     .fork_version_func             = gnosis_fork_version,
+     .blob_schedule                 = eth_chiado_blob_schedule,
+     .min_blob_base_fee             = 1000000000ULL,
+     .max_blobs_per_block_electra   = 2ULL},
 };
 
 const chain_spec_t* c4_eth_get_chain_spec(chain_id_t id) {
@@ -225,6 +257,145 @@ bool c4_chain_schedules_fork(chain_id_t chain_id, fork_id_t fork) {
     n++;
   }
   return false;
+}
+
+// ForkData used by `compute_fork_data_root` / `compute_fork_digest`.
+static const ssz_def_t FORK_DATA[] = {
+    SSZ_BYTE_VECTOR("version", 4),
+    SSZ_BYTES32("state")};
+static const ssz_def_t FORK_DATA_CONTAINER = SSZ_CONTAINER("ForkData", FORK_DATA);
+
+static uint64_t fork_activation_epoch(const chain_spec_t* spec, fork_id_t fork) {
+  if (fork <= C4_FORK_PHASE0) return 0;
+  return spec->fork_epochs[(unsigned) fork - 1];
+}
+
+static fork_id_t fork_id_at_epoch(const chain_spec_t* spec, uint64_t epoch) {
+  return c4_chain_fork_id(spec->chain_id, epoch);
+}
+
+static bool fork_data_root_for_spec(const chain_spec_t* spec, fork_id_t fork, bytes32_t out) {
+  if (!spec || !spec->fork_version_func || fork < C4_FORK_PHASE0 || fork > C4_FORK_MAX)
+    return false;
+  uint8_t buffer[36] = {0};
+  spec->fork_version_func(spec->chain_id, fork, buffer);
+  memcpy(buffer + 4, spec->genesis_validators_root, 32);
+  ssz_hash_tree_root(ssz_ob(FORK_DATA_CONTAINER, bytes(buffer, 36)), out);
+  return true;
+}
+
+static void get_blob_parameters(const chain_spec_t* spec, uint64_t epoch,
+                                uint64_t* out_epoch, uint64_t* out_max_blobs) {
+  uint64_t electra_epoch = fork_activation_epoch(spec, C4_FORK_ELECTRA);
+  if (electra_epoch >= FORKS_END) electra_epoch = 0;
+  *out_epoch     = electra_epoch;
+  *out_max_blobs = spec->max_blobs_per_block_electra ? spec->max_blobs_per_block_electra : 9ULL;
+  if (!spec->blob_params) return;
+  for (const eth_blob_params_t* e = spec->blob_params; e->max_blobs_per_block != 0; e++) {
+    if (epoch >= e->epoch) {
+      *out_epoch     = e->epoch;
+      *out_max_blobs = e->max_blobs_per_block;
+      return;
+    }
+  }
+}
+
+static bool compute_digest_at_epoch(const chain_spec_t* spec, uint64_t epoch, uint8_t out[4]) {
+  fork_id_t fork = fork_id_at_epoch(spec, epoch);
+  bytes32_t base = {0};
+  if (!fork_data_root_for_spec(spec, fork, base)) return false;
+
+  uint64_t fulu_epoch = fork_activation_epoch(spec, C4_FORK_FULU);
+  if (fulu_epoch >= FORKS_END || epoch < fulu_epoch) {
+    memcpy(out, base, 4);
+    return true;
+  }
+
+  uint64_t bp_epoch = 0, max_blobs = 0;
+  get_blob_parameters(spec, epoch, &bp_epoch, &max_blobs);
+  uint8_t blob_in[16] = {0};
+  uint64_to_le(blob_in, bp_epoch);
+  uint64_to_le(blob_in + 8, max_blobs);
+  bytes32_t mask = {0};
+  sha256(bytes(blob_in, 16), mask);
+  for (int i = 0; i < 4; i++)
+    out[i] = (uint8_t) (base[i] ^ mask[i]);
+  return true;
+}
+
+bool c4_eth_fork_data_root(chain_id_t chain_id, fork_id_t fork, bytes32_t out) {
+  return fork_data_root_for_spec(c4_eth_get_chain_spec(chain_id), fork, out);
+}
+
+bool c4_eth_compute_fork_digest(chain_id_t chain_id, fork_id_t fork, uint8_t out[4]) {
+  const chain_spec_t* spec = c4_eth_get_chain_spec(chain_id);
+  if (!spec || !out || fork < C4_FORK_PHASE0 || fork > C4_FORK_MAX) return false;
+  return compute_digest_at_epoch(spec, fork_activation_epoch(spec, fork), out);
+}
+
+// One digest per regular fork plus room for future BPO rows. Overflow must
+// not mark the cache ready: a silent drop would fail-closed on a known fork.
+#define MAX_FORK_DIGEST_CANDIDATES ((unsigned) C4_FORK_MAX + 1 + 16)
+
+typedef struct {
+  bool    ready;
+  uint8_t count;
+  uint8_t digests[MAX_FORK_DIGEST_CANDIDATES][4];
+  int8_t  forks[MAX_FORK_DIGEST_CANDIDATES];
+} fork_digest_cache_t;
+
+static fork_digest_cache_t digest_caches[sizeof(chain_data) / sizeof(chain_data[0])];
+
+static bool cache_add(fork_digest_cache_t* cache, const uint8_t digest[4], fork_id_t fork) {
+  if (cache->count >= MAX_FORK_DIGEST_CANDIDATES) return false;
+  for (uint8_t i = 0; i < cache->count; i++) {
+    if (memcmp(cache->digests[i], digest, 4) == 0) return true;
+  }
+  memcpy(cache->digests[cache->count], digest, 4);
+  cache->forks[cache->count] = (int8_t) fork;
+  cache->count++;
+  return true;
+}
+
+static void cache_build(const chain_spec_t* spec, fork_digest_cache_t* cache) {
+  cache->count = 0;
+  cache->ready = false;
+  for (int f = 0; f <= (int) C4_FORK_MAX; f++) {
+    fork_id_t fork = (fork_id_t) f;
+    if (fork != C4_FORK_PHASE0 && !c4_chain_schedules_fork(spec->chain_id, fork))
+      continue;
+    uint8_t digest[4] = {0};
+    if (!compute_digest_at_epoch(spec, fork_activation_epoch(spec, fork), digest))
+      continue;
+    if (!cache_add(cache, digest, fork)) return;
+  }
+  if (spec->blob_params) {
+    for (const eth_blob_params_t* e = spec->blob_params; e->max_blobs_per_block != 0; e++) {
+      uint8_t   digest[4] = {0};
+      fork_id_t fork      = fork_id_at_epoch(spec, e->epoch);
+      if (fork > C4_FORK_MAX) continue;
+      if (fork != C4_FORK_PHASE0 && !c4_chain_schedules_fork(spec->chain_id, fork))
+        continue;
+      if (!compute_digest_at_epoch(spec, e->epoch, digest)) continue;
+      if (!cache_add(cache, digest, fork)) return;
+    }
+  }
+  cache->ready = true;
+}
+
+fork_id_t c4_eth_fork_from_digest(chain_id_t chain_id, const uint8_t digest[4]) {
+  const chain_spec_t* spec = c4_eth_get_chain_spec(chain_id);
+  if (!spec || !digest) return C4_FORK_INVALID;
+  int idx = (int) (spec - chain_data);
+  if (idx < 0 || idx >= (int) (sizeof(chain_data) / sizeof(chain_data[0])))
+    return C4_FORK_INVALID;
+  fork_digest_cache_t* cache = digest_caches + idx;
+  if (!cache->ready) cache_build(spec, cache);
+  for (uint8_t i = 0; i < cache->count; i++) {
+    if (memcmp(cache->digests[i], digest, 4) == 0)
+      return (fork_id_t) cache->forks[i];
+  }
+  return C4_FORK_INVALID;
 }
 
 // Generalized indices for the fork-specific `BeaconState` layout used by the

--- a/src/chains/eth/ssz/beacon_types.h
+++ b/src/chains/eth/ssz/beacon_types.h
@@ -37,6 +37,7 @@ typedef enum {
   C4_FORK_ELECTRA   = 5,
   C4_FORK_FULU      = 6,
   C4_FORK_GLOAS     = 7,
+  C4_FORK_MAX       = C4_FORK_GLOAS, // last regular fork; bump when adding the next
 
   C4_FORK_INVALID = -1
 } fork_id_t;
@@ -106,6 +107,15 @@ typedef struct {
   uint64_t update_fraction;
 } eth_blob_schedule_t;
 
+// Consensus-layer BLOB_SCHEDULE entry (Fulu `get_blob_parameters` / `compute_fork_digest`).
+// Distinct from `eth_blob_schedule_t`, which is the EL blob-base-fee table
+// (timestamp + update_fraction). Terminated by `max_blobs_per_block == 0`
+// because epoch 0 is a valid activation on genesis-at-Fulu devnets.
+typedef struct {
+  uint64_t epoch;
+  uint64_t max_blobs_per_block;
+} eth_blob_params_t;
+
 typedef struct {
   chain_id_t                 chain_id;
   const uint64_t*            fork_epochs;
@@ -117,6 +127,8 @@ typedef struct {
   fork_version_func_t        fork_version_func;
   const eth_blob_schedule_t* blob_schedule;     // EIP-7892 blob schedule, DESCENDING by timestamp, {0,0}-terminated; NULL uses Cancun default
   uint64_t                   min_blob_base_fee; // MIN_BLOB_BASE_FEE (`minBlobGasPrice`); 0 uses Ethereum's default (1 wei). Gnosis / Chiado use 1e9.
+  const eth_blob_params_t*   blob_params;                  // CL BLOB_SCHEDULE, DESCENDING by epoch, {*,0}-terminated; NULL = empty
+  uint64_t                   max_blobs_per_block_electra;  // MAX_BLOBS_PER_BLOCK_ELECTRA; 0 uses Ethereum's default (9). Gnosis / Chiado use 2.
 } chain_spec_t;
 
 bool      c4_chain_genesis_validators_root(chain_id_t chain_id, bytes32_t genesis_validators_root);
@@ -133,6 +145,41 @@ fork_id_t c4_chain_fork_id(chain_id_t chain_id, uint64_t epoch);
 bool                c4_chain_schedules_fork(chain_id_t chain_id, fork_id_t fork);
 const chain_spec_t* c4_eth_get_chain_spec(chain_id_t id);
 const ssz_def_t*    eth_ssz_type_for_fork(eth_ssz_type_t type, fork_id_t fork, chain_id_t chain_id);
+
+/**
+ * Computes `hash_tree_root(ForkData(fork_version, genesis_validators_root))`
+ * for `fork` on `chain_id`. Shared by domain calculation and `compute_fork_digest`.
+ *
+ * @param chain_id chain whose genesis validators root and fork-version function to use
+ * @param fork fork whose 4-byte version is mixed into `ForkData`
+ * @param out 32-byte fork-data root
+ * @return true on success, false if the chain is unknown or `fork` is out of range
+ */
+bool c4_eth_fork_data_root(chain_id_t chain_id, fork_id_t fork, bytes32_t out);
+
+/**
+ * Computes the 4-byte `ForkDigest` for `fork` at its activation epoch
+ * (`compute_fork_digest` from the Fulu consensus spec, including the
+ * blob-parameter XOR once `epoch >= FULU_FORK_EPOCH`).
+ *
+ * @param chain_id chain whose spec, genesis validators root and blob params to use
+ * @param fork fork whose version and activation epoch drive the digest
+ * @param out 4-byte fork digest
+ * @return true on success, false if the chain is unknown or `fork` is out of range
+ */
+bool c4_eth_compute_fork_digest(chain_id_t chain_id, fork_id_t fork, uint8_t out[4]);
+
+/**
+ * Resolves a 4-byte Beacon-API `ForkDigest` to the `fork_id_t` whose SSZ
+ * type should be used to decode the following LightClientUpdate. BPO
+ * digests map to the regular fork they sit on (Fulu / Gloas), not a
+ * separate enum value. Unknown digests return `C4_FORK_INVALID`.
+ *
+ * @param chain_id chain whose cached digest table to search
+ * @param digest 4-byte fork digest from the wire
+ * @return matching fork, or `C4_FORK_INVALID`
+ */
+fork_id_t c4_eth_fork_from_digest(chain_id_t chain_id, const uint8_t digest[4]);
 
 // forks
 const ssz_def_t* eth_ssz_type_for_denep(eth_ssz_type_t type, chain_id_t chain_id);

--- a/src/chains/eth/verifier/beacon_header.c
+++ b/src/chains/eth/verifier/beacon_header.c
@@ -60,28 +60,16 @@ static const ssz_def_t SIGNING_DATA[] = {
 
 static const ssz_def_t SIGNING_DATA_CONTAINER = SSZ_CONTAINER("SigningData", SIGNING_DATA);
 
-// the fork data is used to create the domain
-static const ssz_def_t FORK_DATA[] = {
-    SSZ_BYTE_VECTOR("version", 4), // the version of the fork
-    SSZ_BYTES32("state")};         // the state of the Genisis Block
-
-static const ssz_def_t FORK_DATA_CONTAINER = SSZ_CONTAINER("ForkDate", FORK_DATA);
-
 bool eth_calculate_domain(chain_id_t chain_id, uint64_t slot, bytes32_t domain) {
-  uint8_t             buffer[36]  = {0};
   bytes32_t           base_digest = {0};
   const chain_spec_t* chain       = c4_eth_get_chain_spec(chain_id);
-
-  // compute fork_data root hash to the seconf 32 bytes of bffer
   if (!chain) return false;
-  chain->fork_version_func(chain_id, c4_chain_fork_id(chain_id, epoch_for_slot(slot - 1, chain)), buffer); // write fork_version as first 4 bytes into the buffer
-  if (!c4_chain_genesis_validators_root(chain_id, buffer + 4)) false;                                      // add the genesis_validator_root as the the other 32 bytes to the buffer.
 
-  ssz_hash_tree_root(ssz_ob(FORK_DATA_CONTAINER, bytes(buffer, 36)), base_digest); // calculate base_digest
+  fork_id_t fork = c4_chain_fork_id(chain_id, epoch_for_slot(slot - 1, chain));
+  if (!c4_eth_fork_data_root(chain_id, fork, base_digest)) return false;
 
-  // build domain by replacing the first 4 bytes with the sync committee domain which creates the domain-data in the 2nd 32 bytes of buffer
-  memcpy(domain, "\x07\x00\x00\x00", 4); // Domain-Type SYNC_COMMITTEE                // Domain-Type
-  memcpy(domain + 4, base_digest, 28);   // last 28 bytes of the base_digest
+  memcpy(domain, "\x07\x00\x00\x00", 4); // Domain-Type SYNC_COMMITTEE
+  memcpy(domain + 4, base_digest, 28);   // last 28 bytes of the fork-data root
   return true;
 }
 

--- a/src/chains/eth/verifier/sync_committee.c
+++ b/src/chains/eth/verifier/sync_committee.c
@@ -41,7 +41,6 @@
 #define C4_ETH_DENEB_BOOTSTRAP_FIXED_SIZE   24788u
 #define C4_ETH_ELECTRA_BOOTSTRAP_FIXED_SIZE 24820u
 #define C4_ETH_GLOAS_BOOTSTRAP_SIZE         25472u // must equal `C4_GLOAS_BOOTSTRAP_SIZE` in bootstrap_gloas.h
-#define C4_ETH_GLOAS_LCU_SSZ_SIZE           26424u // must equal `C4_GLOAS_LCU_SSZ_SIZE` in lcu_gloas.h
 
 // Fork-specific BeaconState gindices have moved to `beacon_types.c` so all
 // fork-aware selections live in one place. See:
@@ -516,38 +515,8 @@ void c4_eth_unknown_lcu_fork_error(c4_state_t* state, const uint8_t digest[4]) {
 }
 
 /**
- * Payload-only fallback for the Lighthouse SSZ-list encoding, which has no
- * ForkDigest on the wire. Gloas LCUs are a unique fixed size; older forks
- * still share the attested-header slot offset.
- */
-static fork_id_t fork_from_lcu_payload(chain_id_t chain_id, bytes_t data) {
-  if (data.len == C4_ETH_GLOAS_LCU_SSZ_SIZE) return C4_FORK_GLOAS;
-  if (data.len < 8) return C4_FORK_INVALID;
-  uint32_t            offset = uint32_from_le(data.data);
-  uint64_t            slot   = (offset > data.len || data.len - offset < 8)
-                                   ? uint64_from_le(data.data)
-                                   : uint64_from_le(data.data + offset);
-  const chain_spec_t* spec   = c4_eth_get_chain_spec(chain_id);
-  return c4_chain_fork_id(chain_id, epoch_for_slot(slot, spec));
-}
-
-/**
- * Detects the format of light client updates (Standard SSZ or Lighthouse variant).
- * Lighthouse format uses a different offset structure.
- *
- * @param data The raw bytes of light client updates
- * @return true if Lighthouse format, false for standard format
- */
-static bool detect_update_format(bytes_t data) {
-  // Lighthouse detection: check if length is sufficient, second offset is non-zero, and first value is reasonable
-  return data.len > UPDATE_PREFIX_SIZE &&
-         !bytes_all_zero(bytes_slice(data, SSZ_OFFSET_SIZE, SSZ_OFFSET_SIZE)) &&
-         uint32_from_le(data.data) < 1000;
-}
-
-/**
- * Process light client updates with a callback function for each update.
- * This handles both standard SSZ and Lighthouse formats.
+ * Process light client updates with a callback for each Beacon-API entry:
+ * `[uint64 LE length][ForkDigest 4][SSZ payload]`.
  *
  * @param ctx Verification context
  * @param light_client_updates Raw bytes containing one or more light client updates
@@ -555,38 +524,19 @@ static bool detect_update_format(bytes_t data) {
  * @return true if all updates were processed successfully, false otherwise
  */
 INTERNAL bool c4_process_light_client_updates(verify_ctx_t* ctx, bytes_t light_client_updates, bool (*process_update)(verify_ctx_t*, ssz_ob_t*)) {
-  uint64_t length     = 0;
-  bool     success    = true;
-  bool     lighthouse = detect_update_format(light_client_updates);
-  int      idx        = 0;
+  uint64_t length  = 0;
+  bool     success = true;
 
   // Per-update ssz_is_valid only. The enclosing list request stays
   // unvalidated until a list-level check exists.
-  for (uint32_t pos = 0; pos + UPDATE_PREFIX_SIZE < light_client_updates.len; pos += length + SSZ_LENGTH_SIZE, idx++) {
-    uint32_t data_offset        = pos + SSZ_LENGTH_SIZE + SSZ_OFFSET_SIZE;
-    uint32_t data_length_offset = SSZ_OFFSET_SIZE;
-
-    if (lighthouse) {
-      // Check bounds before reading offset
-      if (idx * SSZ_OFFSET_SIZE + SSZ_OFFSET_SIZE > light_client_updates.len) {
-        success = false;
-        c4_state_add_error(&ctx->state, "invalid lighthouse index exceeds data bounds!");
-        break;
-      }
-      pos = uint32_from_le(light_client_updates.data + (idx * SSZ_OFFSET_SIZE));
-      if (pos + UPDATE_PREFIX_SIZE > light_client_updates.len) {
-        success = false;
-        c4_state_add_error(&ctx->state, "invalid offset in lighthouse client update!");
-        break;
-      }
-      data_offset = pos + LIGHTHOUSE_OFFSET_SIZE + SSZ_OFFSET_SIZE;
-    }
+  for (uint32_t pos = 0; pos + UPDATE_PREFIX_SIZE < light_client_updates.len; pos += length + SSZ_LENGTH_SIZE) {
+    uint32_t data_offset = pos + SSZ_LENGTH_SIZE + SSZ_OFFSET_SIZE;
 
     length = uint64_from_le(light_client_updates.data + pos);
 
     // `length` is the digest+payload size. Values below 4 underflow
-    // `length - data_length_offset` into a huge `bytes_t.len`.
-    if (length < data_length_offset ||
+    // `length - SSZ_OFFSET_SIZE` into a huge `bytes_t.len`.
+    if (length < SSZ_OFFSET_SIZE ||
         pos + SSZ_LENGTH_SIZE + length > light_client_updates.len ||
         pos + SSZ_LENGTH_SIZE + length < pos) {
       success = false;
@@ -594,18 +544,13 @@ INTERNAL bool c4_process_light_client_updates(verify_ctx_t* ctx, bytes_t light_c
       break;
     }
 
-    bytes_t          light_client_update_bytes = bytes(light_client_updates.data + data_offset, length - data_length_offset);
+    bytes_t          light_client_update_bytes = bytes(light_client_updates.data + data_offset, length - SSZ_OFFSET_SIZE);
     bytes_t          fork_digest               = bytes(light_client_updates.data + pos + SSZ_LENGTH_SIZE, 4);
-    fork_id_t        fork                      = lighthouse
-                                                     ? fork_from_lcu_payload(ctx->chain_id, light_client_update_bytes)
-                                                     : c4_eth_fork_from_digest(ctx->chain_id, fork_digest.data);
+    fork_id_t        fork                      = c4_eth_fork_from_digest(ctx->chain_id, fork_digest.data);
     const ssz_def_t* light_client_update_def   = eth_get_light_client_update(fork);
 
     if (!light_client_update_def) {
-      if (!lighthouse && fork_digest.len == 4)
-        c4_eth_unknown_lcu_fork_error(&ctx->state, fork_digest.data);
-      else
-        c4_state_add_error(&ctx->state, "light client update: unknown/unsupported fork");
+      c4_eth_unknown_lcu_fork_error(&ctx->state, fork_digest.data);
       success = false;
       break;
     }

--- a/src/chains/eth/verifier/sync_committee.c
+++ b/src/chains/eth/verifier/sync_committee.c
@@ -41,6 +41,7 @@
 #define C4_ETH_DENEB_BOOTSTRAP_FIXED_SIZE   24788u
 #define C4_ETH_ELECTRA_BOOTSTRAP_FIXED_SIZE 24820u
 #define C4_ETH_GLOAS_BOOTSTRAP_SIZE         25472u // must equal `C4_GLOAS_BOOTSTRAP_SIZE` in bootstrap_gloas.h
+#define C4_ETH_GLOAS_LCU_SSZ_SIZE           26424u // must equal `C4_GLOAS_LCU_SSZ_SIZE` in lcu_gloas.h
 
 // Fork-specific BeaconState gindices have moved to `beacon_types.c` so all
 // fork-aware selections live in one place. See:
@@ -505,18 +506,34 @@ fork_id_t c4_eth_get_fork_for_lcb(chain_id_t chain_id, bytes_t data) {
   return C4_FORK_INVALID;
 }
 
-fork_id_t c4_eth_get_fork_for_lcu(chain_id_t chain_id, bytes_t data) {
-  if (data.len < 4) return 0;
-  uint64_t slot   = 0;
-  uint32_t offset = uint32_from_le(data.data);
-  if (offset + 8 > data.len)
-    // this is most likely a gloas bootstrap!
-    // TODO(gloas): this may break if the lower 4 bytes of the slot are smaller than the lcu length.
-    // so in 99% of the cases it will work, but we should find a better way to detect the fork.
-    slot = uint64_from_le(data.data);
-  else
-    slot = uint64_from_le(data.data + offset);
-  const chain_spec_t* spec = c4_eth_get_chain_spec(chain_id);
+fork_id_t c4_eth_get_fork_for_lcu(chain_id_t chain_id, bytes_t fork_digest) {
+  if (!fork_digest.data || fork_digest.len < 4) return C4_FORK_INVALID;
+  return c4_eth_fork_from_digest(chain_id, fork_digest.data);
+}
+
+void c4_eth_unknown_lcu_fork_error(c4_state_t* state, const uint8_t digest[4]) {
+  uint8_t        zero[4] = {0};
+  const uint8_t* d       = digest ? digest : zero;
+  char*          msg     = bprintf(NULL,
+                                   "unrecognized fork digest 0x%x; this Colibri version (%s) does not support the current chain fork - please update the app",
+                                   bytes((uint8_t*) d, 4), c4_client_version);
+  c4_state_add_error(state, msg);
+  safe_free(msg);
+}
+
+/**
+ * Payload-only fallback for the Lighthouse SSZ-list encoding, which has no
+ * ForkDigest on the wire. Gloas LCUs are a unique fixed size; older forks
+ * still share the attested-header slot offset.
+ */
+static fork_id_t fork_from_lcu_payload(chain_id_t chain_id, bytes_t data) {
+  if (data.len == C4_ETH_GLOAS_LCU_SSZ_SIZE) return C4_FORK_GLOAS;
+  if (data.len < 8) return C4_FORK_INVALID;
+  uint32_t            offset = uint32_from_le(data.data);
+  uint64_t            slot   = (offset > data.len || data.len - offset < 8)
+                                   ? uint64_from_le(data.data)
+                                   : uint64_from_le(data.data + offset);
+  const chain_spec_t* spec   = c4_eth_get_chain_spec(chain_id);
   return c4_chain_fork_id(chain_id, epoch_for_slot(slot, spec));
 }
 
@@ -573,19 +590,28 @@ INTERNAL bool c4_process_light_client_updates(verify_ctx_t* ctx, bytes_t light_c
 
     length = uint64_from_le(light_client_updates.data + pos);
 
-    // Check for integer overflow and bounds
-    if (length > UPDATE_PREFIX_SIZE && (pos + SSZ_LENGTH_SIZE + length > light_client_updates.len || pos + SSZ_LENGTH_SIZE + length < pos)) {
+    // `length` is the digest+payload size. Values below 4 underflow
+    // `length - data_length_offset` into a huge `bytes_t.len`.
+    if (length < data_length_offset ||
+        pos + SSZ_LENGTH_SIZE + length > light_client_updates.len ||
+        pos + SSZ_LENGTH_SIZE + length < pos) {
       success = false;
       c4_state_add_error(&ctx->state, "invalid length causes overflow or exceeds bounds!");
       break;
     }
 
     bytes_t          light_client_update_bytes = bytes(light_client_updates.data + data_offset, length - data_length_offset);
-    fork_id_t        fork                      = c4_eth_get_fork_for_lcu(ctx->chain_id, light_client_update_bytes);
+    bytes_t          fork_digest               = bytes(light_client_updates.data + pos + SSZ_LENGTH_SIZE, 4);
+    fork_id_t        fork                      = lighthouse
+                                                     ? fork_from_lcu_payload(ctx->chain_id, light_client_update_bytes)
+                                                     : c4_eth_get_fork_for_lcu(ctx->chain_id, fork_digest);
     const ssz_def_t* light_client_update_def   = eth_get_light_client_update(fork);
 
     if (!light_client_update_def) {
-      c4_state_add_error(&ctx->state, "light client update: unknown/unsupported fork");
+      if (!lighthouse && fork_digest.len == 4)
+        c4_eth_unknown_lcu_fork_error(&ctx->state, fork_digest.data);
+      else
+        c4_state_add_error(&ctx->state, "light client update: unknown/unsupported fork");
       success = false;
       break;
     }

--- a/src/chains/eth/verifier/sync_committee.c
+++ b/src/chains/eth/verifier/sync_committee.c
@@ -506,16 +506,10 @@ fork_id_t c4_eth_get_fork_for_lcb(chain_id_t chain_id, bytes_t data) {
   return C4_FORK_INVALID;
 }
 
-fork_id_t c4_eth_get_fork_for_lcu(chain_id_t chain_id, bytes_t fork_digest) {
-  if (!fork_digest.data || fork_digest.len < 4) return C4_FORK_INVALID;
-  return c4_eth_fork_from_digest(chain_id, fork_digest.data);
-}
-
 void c4_eth_unknown_lcu_fork_error(c4_state_t* state, const uint8_t digest[4]) {
   uint8_t        zero[4] = {0};
   const uint8_t* d       = digest ? digest : zero;
-  char*          msg     = bprintf(NULL,
-                                   "unrecognized fork digest 0x%x; this Colibri version (%s) does not support the current chain fork - please update the app",
+  char*          msg     = bprintf(NULL, C4_ETH_UNKNOWN_LCU_FORK_FMT,
                                    bytes((uint8_t*) d, 4), c4_client_version);
   c4_state_add_error(state, msg);
   safe_free(msg);
@@ -604,7 +598,7 @@ INTERNAL bool c4_process_light_client_updates(verify_ctx_t* ctx, bytes_t light_c
     bytes_t          fork_digest               = bytes(light_client_updates.data + pos + SSZ_LENGTH_SIZE, 4);
     fork_id_t        fork                      = lighthouse
                                                      ? fork_from_lcu_payload(ctx->chain_id, light_client_update_bytes)
-                                                     : c4_eth_get_fork_for_lcu(ctx->chain_id, fork_digest);
+                                                     : c4_eth_fork_from_digest(ctx->chain_id, fork_digest.data);
     const ssz_def_t* light_client_update_def   = eth_get_light_client_update(fork);
 
     if (!light_client_update_def) {

--- a/src/chains/eth/verifier/sync_committee.h
+++ b/src/chains/eth/verifier/sync_committee.h
@@ -40,11 +40,9 @@ extern "C" {
 #define MAX_STATES_SIZE 41
 
 // Light client update format constants
-#define SSZ_OFFSET_SIZE        4
-#define SSZ_LENGTH_SIZE        8
-#define UPDATE_PREFIX_SIZE     (SSZ_OFFSET_SIZE + SSZ_LENGTH_SIZE)
-#define LIGHTHOUSE_HEADER_SIZE 4
-#define LIGHTHOUSE_OFFSET_SIZE 16
+#define SSZ_OFFSET_SIZE    4
+#define SSZ_LENGTH_SIZE    8
+#define UPDATE_PREFIX_SIZE (SSZ_OFFSET_SIZE + SSZ_LENGTH_SIZE)
 
 /**
  * Sync committee validators state for a specific period.
@@ -115,7 +113,7 @@ c4_status_t c4_update_from_sync_data(verify_ctx_t* ctx);
 
 /**
  * Handle and process raw light client updates from Beacon API.
- * Supports both standard SSZ format and Lighthouse variant.
+ * Expects the standard Beacon-API list encoding (length + ForkDigest + payload).
  * Validates and stores sync committees for each period found in the updates.
  *
  * @param ctx Verification context
@@ -126,8 +124,8 @@ bool c4_handle_client_updates(verify_ctx_t* ctx, bytes_t client_updates);
 
 /**
  * Generic iterator for processing light client updates with a callback.
- * Handles both standard SSZ and Lighthouse formats, validates structure,
- * and calls process_update for each individual update.
+ * Parses the Beacon-API list encoding, validates each payload, and calls
+ * process_update for every update.
  *
  * @param ctx Verification context
  * @param light_client_updates Raw SSZ-encoded updates

--- a/src/chains/eth/verifier/sync_committee.h
+++ b/src/chains/eth/verifier/sync_committee.h
@@ -180,15 +180,24 @@ c4_chain_state_t c4_get_chain_state(chain_id_t chain_id);
 void c4_eth_set_trusted_checkpoint(chain_id_t chain_id, bytes32_t checkpoint);
 
 /**
- * Detect the fork for a light client update based on the slot embedded in the payload.
- * Reads the slot from the SSZ-encoded data and determines the fork (Deneb, Electra,
- * Fulu, or Gloas once scheduled).
+ * Detect the fork for a light client update from the 4-byte Beacon-API
+ * `ForkDigest` that precedes the SSZ payload.
  *
  * @param chain_id Chain identifier
- * @param data SSZ-encoded light client update data
- * @return Fork identifier corresponding to the slot in the update payload
+ * @param fork_digest at least 4 bytes of fork digest (payload is not read)
+ * @return matching fork, or `C4_FORK_INVALID` if the digest is unknown
  */
-fork_id_t c4_eth_get_fork_for_lcu(chain_id_t chain_id, bytes_t data);
+fork_id_t c4_eth_get_fork_for_lcu(chain_id_t chain_id, bytes_t fork_digest);
+
+/**
+ * Records a fail-closed error for an unrecognized LCU fork digest and
+ * asks the user to update the app. Callers that have a `c4_state_t`
+ * should use this helper so the log line stays consistent.
+ *
+ * @param state verification or prover state that receives the error
+ * @param digest the 4-byte digest that did not match any known fork
+ */
+void c4_eth_unknown_lcu_fork_error(c4_state_t* state, const uint8_t digest[4]);
 
 /**
  * Detect the fork for a light client bootstrap based on the size of the data.

--- a/src/chains/eth/verifier/sync_committee.h
+++ b/src/chains/eth/verifier/sync_committee.h
@@ -180,19 +180,19 @@ c4_chain_state_t c4_get_chain_state(chain_id_t chain_id);
 void c4_eth_set_trusted_checkpoint(chain_id_t chain_id, bytes32_t checkpoint);
 
 /**
- * Detect the fork for a light client update from the 4-byte Beacon-API
- * `ForkDigest` that precedes the SSZ payload.
+ * Fail-closed message for an unrecognized LCU fork digest. Use with
+ * `THROW_ERROR_WITH` when the caller has a `ctx` and returns `c4_status_t`.
  *
- * @param chain_id Chain identifier
- * @param fork_digest at least 4 bytes of fork digest (payload is not read)
- * @return matching fork, or `C4_FORK_INVALID` if the digest is unknown
+ * ```c
+ * THROW_ERROR_WITH(C4_ETH_UNKNOWN_LCU_FORK_FMT, fork_digest, c4_client_version);
+ * ```
  */
-fork_id_t c4_eth_get_fork_for_lcu(chain_id_t chain_id, bytes_t fork_digest);
+#define C4_ETH_UNKNOWN_LCU_FORK_FMT \
+  "unrecognized fork digest 0x%x; this Colibri version (%s) does not support the current chain fork - please update the app"
 
 /**
- * Records a fail-closed error for an unrecognized LCU fork digest and
- * asks the user to update the app. Callers that have a `c4_state_t`
- * should use this helper so the log line stays consistent.
+ * Records `C4_ETH_UNKNOWN_LCU_FORK_FMT` on `state` when the caller cannot
+ * use `THROW_ERROR_WITH` (non-`c4_status_t` return, or no `ctx`).
  *
  * @param state verification or prover state that receives the error
  * @param digest the 4-byte digest that did not match any known fork

--- a/src/chains/eth/verifier/sync_committee_state.c
+++ b/src/chains/eth/verifier/sync_committee_state.c
@@ -53,6 +53,7 @@
 #include "../util/logger.h"
 #include "../util/plugin.h"
 #include "./sync_committee.h"
+#include "version.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -924,7 +925,7 @@ static c4_status_t c4_check_weak_subjectivity(verify_ctx_t* ctx, c4_sync_validat
 
       bytes_t          client_update_bytes = bytes(client_updates.data + data_offset, length - data_length_offset);
       bytes_t          fork_digest         = bytes(client_updates.data + pos + SSZ_LENGTH_SIZE, 4);
-      fork_id_t        lcu_fork            = c4_eth_get_fork_for_lcu(ctx->chain_id, fork_digest);
+      fork_id_t        lcu_fork            = c4_eth_fork_from_digest(ctx->chain_id, fork_digest.data);
       const ssz_def_t* lcu_def             = eth_get_light_client_update(lcu_fork);
       if (!lcu_def) continue;
 
@@ -1037,12 +1038,10 @@ static c4_status_t c4_try_sync_from_next_period(verify_ctx_t* ctx, uint32_t peri
       THROW_ERROR("Invalid light client update format in edge case sync");
 
     bytes_t          fork_digest       = bytes(light_client_update.data + 8, 4);
-    fork_id_t        fork              = c4_eth_get_fork_for_lcu(ctx->chain_id, fork_digest);
+    fork_id_t        fork              = c4_eth_fork_from_digest(ctx->chain_id, fork_digest.data);
     const ssz_def_t* client_update_def = eth_get_light_client_update(fork);
-    if (!client_update_def) {
-      c4_eth_unknown_lcu_fork_error(&ctx->state, fork_digest.data);
-      return C4_ERROR;
-    }
+    if (!client_update_def)
+      THROW_ERROR_WITH(C4_ETH_UNKNOWN_LCU_FORK_FMT, fork_digest, c4_client_version);
 
     uint64_t length = uint64_from_le(light_client_update.data);
     if (length < SSZ_OFFSET_SIZE ||

--- a/src/chains/eth/verifier/sync_committee_state.c
+++ b/src/chains/eth/verifier/sync_committee_state.c
@@ -917,12 +917,16 @@ static c4_status_t c4_check_weak_subjectivity(verify_ctx_t* ctx, c4_sync_validat
       uint32_t data_offset        = pos + SSZ_LENGTH_SIZE + SSZ_OFFSET_SIZE;
       uint32_t data_length_offset = SSZ_OFFSET_SIZE;
       length                      = uint64_from_le(client_updates.data + pos);
-      if (pos + SSZ_LENGTH_SIZE + length > client_updates.len && length > UPDATE_PREFIX_SIZE) break;
+      if (length < data_length_offset ||
+          pos + SSZ_LENGTH_SIZE + length > client_updates.len ||
+          pos + SSZ_LENGTH_SIZE + length < pos)
+        break;
 
       bytes_t          client_update_bytes = bytes(client_updates.data + data_offset, length - data_length_offset);
-      fork_id_t        lcu_fork            = c4_eth_get_fork_for_lcu(ctx->chain_id, client_update_bytes);
+      bytes_t          fork_digest         = bytes(client_updates.data + pos + SSZ_LENGTH_SIZE, 4);
+      fork_id_t        lcu_fork            = c4_eth_get_fork_for_lcu(ctx->chain_id, fork_digest);
       const ssz_def_t* lcu_def             = eth_get_light_client_update(lcu_fork);
-      if (!lcu_def) break;
+      if (!lcu_def) continue;
 
       ssz_ob_t update          = {.bytes = client_update_bytes, .def = lcu_def};
       ssz_ob_t attested        = ssz_get(&update, "attestedHeader");
@@ -1029,19 +1033,23 @@ static c4_status_t c4_try_sync_from_next_period(verify_ctx_t* ctx, uint32_t peri
   bytes32_t computed_root       = {0};
   if (req_client_update(&ctx->state, period, 1, ctx->chain_id, &light_client_update)) {
     // Parse the SSZ-encoded update
-    fork_id_t        fork              = c4_eth_get_fork_for_lcu(ctx->chain_id, light_client_update);
-    const ssz_def_t* client_update_def = eth_get_light_client_update(fork);
-
-    if (!client_update_def || light_client_update.len < UPDATE_PREFIX_SIZE)
+    if (light_client_update.len < UPDATE_PREFIX_SIZE)
       THROW_ERROR("Invalid light client update format in edge case sync");
 
-    // Navigate to the first update in the list
-    uint32_t offset = uint32_from_le(light_client_update.data);
-    if (offset + UPDATE_PREFIX_SIZE > light_client_update.len)
-      THROW_ERROR("Invalid offset in light client update list");
+    bytes_t          fork_digest       = bytes(light_client_update.data + 8, 4);
+    fork_id_t        fork              = c4_eth_get_fork_for_lcu(ctx->chain_id, fork_digest);
+    const ssz_def_t* client_update_def = eth_get_light_client_update(fork);
+    if (!client_update_def) {
+      c4_eth_unknown_lcu_fork_error(&ctx->state, fork_digest.data);
+      return C4_ERROR;
+    }
 
-    uint64_t length                    = uint64_from_le(light_client_update.data + offset);
-    bytes_t  light_client_update_bytes = bytes(light_client_update.data + offset + UPDATE_PREFIX_SIZE, length - SSZ_OFFSET_SIZE);
+    uint64_t length = uint64_from_le(light_client_update.data);
+    if (length < SSZ_OFFSET_SIZE ||
+        SSZ_LENGTH_SIZE + length > light_client_update.len ||
+        SSZ_LENGTH_SIZE + length < length)
+      THROW_ERROR("Invalid light client update format in edge case sync");
+    bytes_t  light_client_update_bytes = bytes(light_client_update.data + UPDATE_PREFIX_SIZE, length - SSZ_OFFSET_SIZE);
     ssz_ob_t update_ob                 = {.bytes = light_client_update_bytes, .def = client_update_def};
     // One item is not the enclosing list. Leave the list request unvalidated
     // until a list-level SSZ check exists.

--- a/src/cli/verifier.c
+++ b/src/cli/verifier.c
@@ -79,7 +79,7 @@ void init_state(chain_id_t chain_id, uint32_t period_init) {
   }
   bytes_t  fork_digest = bytes(updates.data + 8, 4);
   ssz_ob_t update      = {.bytes = bytes(updates.data + 12, length - 4), .def = NULL};
-  update.def           = eth_get_light_client_update(c4_eth_get_fork_for_lcu(chain_id, fork_digest));
+  update.def           = eth_get_light_client_update(c4_eth_fork_from_digest(chain_id, fork_digest.data));
   if (!update.def) {
     c4_eth_unknown_lcu_fork_error(&ctx.state, fork_digest.data);
     fprintf(stderr, "Error loading light client updates: %s\n", ctx.state.error);

--- a/src/cli/verifier.c
+++ b/src/cli/verifier.c
@@ -72,8 +72,19 @@ void init_state(chain_id_t chain_id, uint32_t period_init) {
     exit(EXIT_FAILURE);
   }
 
-  ssz_ob_t update = {.bytes = bytes(updates.data + 12, updates.len - 12), .def = NULL};
-  update.def      = eth_get_light_client_update(c4_eth_get_fork_for_lcu(chain_id, update.bytes));
+  uint64_t length = uint64_from_le(updates.data);
+  if (length < 4 || 8 + length > updates.len || 8 + length < length) {
+    fprintf(stderr, "Error loading light client updates: invalid length\n");
+    exit(EXIT_FAILURE);
+  }
+  bytes_t  fork_digest = bytes(updates.data + 8, 4);
+  ssz_ob_t update      = {.bytes = bytes(updates.data + 12, length - 4), .def = NULL};
+  update.def           = eth_get_light_client_update(c4_eth_get_fork_for_lcu(chain_id, fork_digest));
+  if (!update.def) {
+    c4_eth_unknown_lcu_fork_error(&ctx.state, fork_digest.data);
+    fprintf(stderr, "Error loading light client updates: %s\n", ctx.state.error);
+    exit(EXIT_FAILURE);
+  }
   if (!ssz_is_valid(update, true, &ctx.state)) {
     fprintf(stderr, "invalid light client updates: %s\n", ctx.state.error ? ctx.state.error : "updates too short");
     exit(EXIT_FAILURE);

--- a/test/unittests/test_eth_chain_spec.c
+++ b/test/unittests/test_eth_chain_spec.c
@@ -22,8 +22,12 @@
  */
 
 #include "beacon_types.h"
+#include "bytes.h"
 #include "chains.h"
+#include "crypto.h"
 #include "el_header.h"
+#include "state.h"
+#include "sync_committee.h"
 #include "unity.h"
 #include <string.h>
 
@@ -218,6 +222,156 @@ void test_min_blob_base_fee(void) {
   TEST_ASSERT_EQUAL_UINT64(1ULL, eth_min_blob_base_fee(CHAIN(999999)));
 }
 
+static void xor_blob_mask(uint8_t out[4], const uint8_t base[32], uint64_t epoch, uint64_t max_blobs) {
+  uint8_t   blob_in[16] = {0};
+  bytes32_t mask        = {0};
+  uint64_to_le(blob_in, epoch);
+  uint64_to_le(blob_in + 8, max_blobs);
+  sha256(bytes(blob_in, 16), mask);
+  for (int i = 0; i < 4; i++)
+    out[i] = (uint8_t) (base[i] ^ mask[i]);
+}
+
+void test_fork_digest_differs_across_forks(void) {
+  uint8_t electra[4] = {0}, fulu[4] = {0}, plat_fulu[4] = {0}, gloas[4] = {0};
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_MAINNET, C4_FORK_ELECTRA, electra));
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_MAINNET, C4_FORK_FULU, fulu));
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_PLATABERGET, C4_FORK_FULU, plat_fulu));
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_PLATABERGET, C4_FORK_GLOAS, gloas));
+
+  TEST_ASSERT_NOT_EQUAL_INT(0, memcmp(electra, fulu, 4));
+  TEST_ASSERT_NOT_EQUAL_INT(0, memcmp(plat_fulu, gloas, 4));
+
+  TEST_ASSERT_EQUAL_INT(C4_FORK_ELECTRA, c4_eth_fork_from_digest(C4_CHAIN_MAINNET, electra));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_FULU, c4_eth_fork_from_digest(C4_CHAIN_MAINNET, fulu));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_GLOAS, c4_eth_fork_from_digest(C4_CHAIN_PLATABERGET, gloas));
+}
+
+// BPO digests are built from `fork_data_root` + SHA256(epoch || max_blobs), not
+// by reading the lookup cache. A cache that stored only compute(FULU) would
+// fail these lookups.
+static void assert_bpo_maps_to_fulu(chain_id_t chain_id, uint64_t bpo1_epoch, uint64_t bpo1_max,
+                                    uint64_t bpo2_epoch, uint64_t bpo2_max) {
+  bytes32_t base = {0};
+  TEST_ASSERT_TRUE(c4_eth_fork_data_root(chain_id, C4_FORK_FULU, base));
+
+  uint8_t bpo1[4] = {0}, bpo2[4] = {0}, fulu[4] = {0};
+  xor_blob_mask(bpo1, base, bpo1_epoch, bpo1_max);
+  xor_blob_mask(bpo2, base, bpo2_epoch, bpo2_max);
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(chain_id, C4_FORK_FULU, fulu));
+
+  TEST_ASSERT_NOT_EQUAL_INT(0, memcmp(fulu, bpo1, 4));
+  TEST_ASSERT_NOT_EQUAL_INT(0, memcmp(fulu, bpo2, 4));
+  TEST_ASSERT_NOT_EQUAL_INT(0, memcmp(bpo1, bpo2, 4));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_FULU, c4_eth_fork_from_digest(chain_id, bpo1));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_FULU, c4_eth_fork_from_digest(chain_id, bpo2));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_FULU, c4_eth_get_fork_for_lcu(chain_id, bytes(bpo1, 4)));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_FULU, c4_eth_get_fork_for_lcu(chain_id, bytes(bpo2, 4)));
+}
+
+void test_fork_digest_bpo_maps_to_fulu(void) {
+  assert_bpo_maps_to_fulu(C4_CHAIN_MAINNET, 412672ULL, 15ULL, 419072ULL, 21ULL);
+  assert_bpo_maps_to_fulu(C4_CHAIN_SEPOLIA, 274176ULL, 15ULL, 275712ULL, 21ULL);
+}
+
+void test_fork_digest_unknown_is_invalid_and_suggests_upgrade(void) {
+  uint8_t unknown[4] = {0xde, 0xad, 0xbe, 0xef};
+  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_fork_from_digest(C4_CHAIN_MAINNET, unknown));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_get_fork_for_lcu(C4_CHAIN_MAINNET, bytes(unknown, 4)));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_get_fork_for_lcu(C4_CHAIN_MAINNET, NULL_BYTES));
+  TEST_ASSERT_NOT_EQUAL_INT(C4_FORK_MAX, c4_eth_fork_from_digest(C4_CHAIN_MAINNET, unknown));
+  TEST_ASSERT_NOT_EQUAL_INT(C4_FORK_GLOAS, c4_eth_get_fork_for_lcu(C4_CHAIN_MAINNET, bytes(unknown, 4)));
+
+  c4_state_t state = {0};
+  c4_eth_unknown_lcu_fork_error(&state, unknown);
+  TEST_ASSERT_NOT_NULL(state.error);
+  TEST_ASSERT_NOT_NULL(strstr(state.error, "unrecognized fork digest"));
+  TEST_ASSERT_NOT_NULL(strstr(state.error, "please update the app"));
+  TEST_ASSERT_NOT_NULL(strstr(state.error, "deadbeef"));
+  safe_free(state.error);
+}
+
+void test_fork_digest_too_short_and_unknown_chain(void) {
+  uint8_t three[3] = {0x01, 0x02, 0x03};
+  uint8_t four[4]  = {0x01, 0x02, 0x03, 0x04};
+  uint8_t unused[4] = {0};
+
+  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_get_fork_for_lcu(C4_CHAIN_MAINNET, bytes(three, 3)));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_get_fork_for_lcu(C4_CHAIN_MAINNET, bytes(three, 0)));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_fork_from_digest(C4_CHAIN_MAINNET, NULL));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_fork_from_digest(CHAIN(999999), four));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_get_fork_for_lcu(CHAIN(999999), bytes(four, 4)));
+  bytes32_t root = {0};
+  TEST_ASSERT_FALSE(c4_eth_compute_fork_digest(CHAIN(999999), C4_FORK_ELECTRA, unused));
+  TEST_ASSERT_FALSE(c4_eth_compute_fork_digest(C4_CHAIN_MAINNET, C4_FORK_ELECTRA, NULL));
+  TEST_ASSERT_FALSE(c4_eth_fork_data_root(CHAIN(999999), C4_FORK_FULU, root));
+}
+
+void test_fork_digest_gnosis_empty_blob_schedule_uses_electra_max_2(void) {
+  const chain_spec_t* spec = c4_eth_get_chain_spec(C4_CHAIN_GNOSIS);
+  TEST_ASSERT_NOT_NULL(spec);
+  TEST_ASSERT_NULL_MESSAGE(spec->blob_params, "Gnosis has an empty CL BLOB_SCHEDULE");
+  TEST_ASSERT_EQUAL_UINT64(2ULL, spec->max_blobs_per_block_electra);
+
+  uint64_t electra_epoch = spec->fork_epochs[C4_FORK_ELECTRA - 1];
+  TEST_ASSERT_EQUAL_UINT64(1337856ULL, electra_epoch);
+
+  bytes32_t fulu_base = {0}, electra_base = {0};
+  TEST_ASSERT_TRUE(c4_eth_fork_data_root(C4_CHAIN_GNOSIS, C4_FORK_FULU, fulu_base));
+  TEST_ASSERT_TRUE(c4_eth_fork_data_root(C4_CHAIN_GNOSIS, C4_FORK_ELECTRA, electra_base));
+
+  uint8_t electra[4] = {0}, fulu[4] = {0}, fulu_xor2[4] = {0}, fulu_xor9[4] = {0};
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_GNOSIS, C4_FORK_ELECTRA, electra));
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_GNOSIS, C4_FORK_FULU, fulu));
+  xor_blob_mask(fulu_xor2, fulu_base, electra_epoch, 2ULL);
+  xor_blob_mask(fulu_xor9, fulu_base, electra_epoch, 9ULL);
+
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(electra_base, electra, 4);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(fulu_xor2, fulu, 4);
+  TEST_ASSERT_NOT_EQUAL_INT(0, memcmp(electra, fulu, 4));
+  TEST_ASSERT_NOT_EQUAL_INT(0, memcmp(fulu_xor2, fulu_xor9, 4));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_ELECTRA, c4_eth_fork_from_digest(C4_CHAIN_GNOSIS, electra));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_FULU, c4_eth_fork_from_digest(C4_CHAIN_GNOSIS, fulu_xor2));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_fork_from_digest(C4_CHAIN_GNOSIS, fulu_xor9));
+
+  const chain_spec_t* chiado = c4_eth_get_chain_spec(C4_CHAIN_GNOSIS_CHIADO);
+  TEST_ASSERT_NOT_NULL(chiado);
+  TEST_ASSERT_NULL(chiado->blob_params);
+  TEST_ASSERT_EQUAL_UINT64(2ULL, chiado->max_blobs_per_block_electra);
+}
+
+void test_fork_digest_unscheduled_gloas_on_mainnet(void) {
+  TEST_ASSERT_FALSE(c4_chain_schedules_fork(C4_CHAIN_MAINNET, C4_FORK_GLOAS));
+
+  uint8_t gloas[4] = {0}, electra[4] = {0}, fulu[4] = {0};
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_MAINNET, C4_FORK_GLOAS, gloas));
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_MAINNET, C4_FORK_ELECTRA, electra));
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_MAINNET, C4_FORK_FULU, fulu));
+  TEST_ASSERT_NOT_EQUAL_INT(0, memcmp(gloas, electra, 4));
+  TEST_ASSERT_NOT_EQUAL_INT(0, memcmp(gloas, fulu, 4));
+
+  bytes32_t base = {0};
+  TEST_ASSERT_TRUE(c4_eth_fork_data_root(C4_CHAIN_MAINNET, C4_FORK_GLOAS, base));
+  uint8_t expected[4] = {0};
+  xor_blob_mask(expected, base, 419072ULL, 21ULL);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, gloas, 4);
+
+  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_fork_from_digest(C4_CHAIN_MAINNET, gloas));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_get_fork_for_lcu(C4_CHAIN_MAINNET, bytes(gloas, 4)));
+  TEST_ASSERT_NOT_EQUAL_INT(C4_FORK_MAX, c4_eth_fork_from_digest(C4_CHAIN_MAINNET, gloas));
+}
+
+void test_fork_max_bounds_lookup(void) {
+  uint8_t unused[4]  = {0};
+  uint8_t garbage[4] = {1, 2, 3, 4};
+  uint8_t at_max[4]  = {0};
+  TEST_ASSERT_EQUAL_INT(C4_FORK_GLOAS, C4_FORK_MAX);
+  TEST_ASSERT_FALSE(c4_eth_compute_fork_digest(C4_CHAIN_MAINNET, (fork_id_t) (C4_FORK_MAX + 1), unused));
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_PLATABERGET, C4_FORK_MAX, at_max));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_GLOAS, c4_eth_fork_from_digest(C4_CHAIN_PLATABERGET, at_max));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_fork_from_digest(CHAIN(999999), garbage));
+}
+
 int main(void) {
   UNITY_BEGIN();
   RUN_TEST(test_plataberget_genesis_validators_root);
@@ -232,5 +386,12 @@ int main(void) {
   RUN_TEST(test_chain_schedules_fork);
   RUN_TEST(test_blob_base_fee_update_fraction);
   RUN_TEST(test_min_blob_base_fee);
+  RUN_TEST(test_fork_digest_differs_across_forks);
+  RUN_TEST(test_fork_digest_bpo_maps_to_fulu);
+  RUN_TEST(test_fork_digest_unknown_is_invalid_and_suggests_upgrade);
+  RUN_TEST(test_fork_digest_too_short_and_unknown_chain);
+  RUN_TEST(test_fork_digest_gnosis_empty_blob_schedule_uses_electra_max_2);
+  RUN_TEST(test_fork_digest_unscheduled_gloas_on_mainnet);
+  RUN_TEST(test_fork_max_bounds_lookup);
   return UNITY_END();
 }

--- a/test/unittests/test_eth_chain_spec.c
+++ b/test/unittests/test_eth_chain_spec.c
@@ -265,8 +265,6 @@ static void assert_bpo_maps_to_fulu(chain_id_t chain_id, uint64_t bpo1_epoch, ui
   TEST_ASSERT_NOT_EQUAL_INT(0, memcmp(bpo1, bpo2, 4));
   TEST_ASSERT_EQUAL_INT(C4_FORK_FULU, c4_eth_fork_from_digest(chain_id, bpo1));
   TEST_ASSERT_EQUAL_INT(C4_FORK_FULU, c4_eth_fork_from_digest(chain_id, bpo2));
-  TEST_ASSERT_EQUAL_INT(C4_FORK_FULU, c4_eth_get_fork_for_lcu(chain_id, bytes(bpo1, 4)));
-  TEST_ASSERT_EQUAL_INT(C4_FORK_FULU, c4_eth_get_fork_for_lcu(chain_id, bytes(bpo2, 4)));
 }
 
 void test_fork_digest_bpo_maps_to_fulu(void) {
@@ -277,10 +275,9 @@ void test_fork_digest_bpo_maps_to_fulu(void) {
 void test_fork_digest_unknown_is_invalid_and_suggests_upgrade(void) {
   uint8_t unknown[4] = {0xde, 0xad, 0xbe, 0xef};
   TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_fork_from_digest(C4_CHAIN_MAINNET, unknown));
-  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_get_fork_for_lcu(C4_CHAIN_MAINNET, bytes(unknown, 4)));
-  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_get_fork_for_lcu(C4_CHAIN_MAINNET, NULL_BYTES));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_fork_from_digest(C4_CHAIN_MAINNET, NULL));
   TEST_ASSERT_NOT_EQUAL_INT(C4_FORK_MAX, c4_eth_fork_from_digest(C4_CHAIN_MAINNET, unknown));
-  TEST_ASSERT_NOT_EQUAL_INT(C4_FORK_GLOAS, c4_eth_get_fork_for_lcu(C4_CHAIN_MAINNET, bytes(unknown, 4)));
+  TEST_ASSERT_NOT_EQUAL_INT(C4_FORK_GLOAS, c4_eth_fork_from_digest(C4_CHAIN_MAINNET, unknown));
 
   c4_state_t state = {0};
   c4_eth_unknown_lcu_fork_error(&state, unknown);
@@ -292,15 +289,11 @@ void test_fork_digest_unknown_is_invalid_and_suggests_upgrade(void) {
 }
 
 void test_fork_digest_too_short_and_unknown_chain(void) {
-  uint8_t three[3] = {0x01, 0x02, 0x03};
-  uint8_t four[4]  = {0x01, 0x02, 0x03, 0x04};
+  uint8_t four[4]   = {0x01, 0x02, 0x03, 0x04};
   uint8_t unused[4] = {0};
 
-  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_get_fork_for_lcu(C4_CHAIN_MAINNET, bytes(three, 3)));
-  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_get_fork_for_lcu(C4_CHAIN_MAINNET, bytes(three, 0)));
   TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_fork_from_digest(C4_CHAIN_MAINNET, NULL));
   TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_fork_from_digest(CHAIN(999999), four));
-  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_get_fork_for_lcu(CHAIN(999999), bytes(four, 4)));
   bytes32_t root = {0};
   TEST_ASSERT_FALSE(c4_eth_compute_fork_digest(CHAIN(999999), C4_FORK_ELECTRA, unused));
   TEST_ASSERT_FALSE(c4_eth_compute_fork_digest(C4_CHAIN_MAINNET, C4_FORK_ELECTRA, NULL));
@@ -357,7 +350,6 @@ void test_fork_digest_unscheduled_gloas_on_mainnet(void) {
   TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, gloas, 4);
 
   TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_fork_from_digest(C4_CHAIN_MAINNET, gloas));
-  TEST_ASSERT_EQUAL_INT(C4_FORK_INVALID, c4_eth_get_fork_for_lcu(C4_CHAIN_MAINNET, bytes(gloas, 4)));
   TEST_ASSERT_NOT_EQUAL_INT(C4_FORK_MAX, c4_eth_fork_from_digest(C4_CHAIN_MAINNET, gloas));
 }
 

--- a/test/unittests/test_lcu_gloas.c
+++ b/test/unittests/test_lcu_gloas.c
@@ -71,8 +71,8 @@ static void build_dummy_lc_header(uint8_t out[C4_GLOAS_LCU_HEADER_SIZE],
 // SyncAggregate: BitVector[512] (64 B) + ByteVector[96] = 160 B fixed.
 static void build_dummy_sync_aggregate(uint8_t out[C4_GLOAS_LCU_SYNC_AGGREGATE_SIZE]) {
   memset(out, 0, C4_GLOAS_LCU_SYNC_AGGREGATE_SIZE);
-  for (uint32_t i = 0; i < 64; i++) out[i] = (uint8_t) (0xa0 + i);       // bits
-  for (uint32_t i = 0; i < 96; i++) out[64 + i] = (uint8_t) (0xb0 + i);  // signature
+  for (uint32_t i = 0; i < 64; i++) out[i] = (uint8_t) (0xa0 + i);      // bits
+  for (uint32_t i = 0; i < 96; i++) out[64 + i] = (uint8_t) (0xb0 + i); // signature
 }
 
 // -----------------------------------------------------------------------------
@@ -169,12 +169,12 @@ void test_gloas_lcu_assemble_layout_and_validity(void) {
 }
 
 void test_gloas_lcu_assemble_size_mismatches_rejected(void) {
-  uint8_t attested_ok[C4_GLOAS_LCU_HEADER_SIZE]           = {0};
-  uint8_t finalized_ok[C4_GLOAS_LCU_HEADER_SIZE]          = {0};
-  uint8_t nsc_ok[C4_GLOAS_LCU_SYNC_COMMITTEE_SIZE]        = {0};
-  uint8_t sc_branch_ok[C4_GLOAS_LCU_NEXT_SC_BRANCH_SIZE]  = {0};
+  uint8_t attested_ok[C4_GLOAS_LCU_HEADER_SIZE]            = {0};
+  uint8_t finalized_ok[C4_GLOAS_LCU_HEADER_SIZE]           = {0};
+  uint8_t nsc_ok[C4_GLOAS_LCU_SYNC_COMMITTEE_SIZE]         = {0};
+  uint8_t sc_branch_ok[C4_GLOAS_LCU_NEXT_SC_BRANCH_SIZE]   = {0};
   uint8_t fin_branch_ok[C4_GLOAS_LCU_FINALITY_BRANCH_SIZE] = {0};
-  uint8_t sync_agg_ok[C4_GLOAS_LCU_SYNC_AGGREGATE_SIZE]   = {0};
+  uint8_t sync_agg_ok[C4_GLOAS_LCU_SYNC_AGGREGATE_SIZE]    = {0};
 
   bytes_t out = NULL_BYTES;
 
@@ -341,17 +341,17 @@ void test_gloas_lcu_wrap_roundtrip_fork_digest(void) {
   TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_PLATABERGET, C4_FORK_GLOAS, digest));
   bytes_t wire = c4_gloas_lcu_wrap_beacon_response(bytes(lcu_bytes, sizeof(lcu_bytes)), digest);
   TEST_ASSERT_NOT_NULL(wire.data);
-  TEST_ASSERT_EQUAL_INT(C4_FORK_GLOAS, c4_eth_get_fork_for_lcu(C4_CHAIN_PLATABERGET, bytes(wire.data + 8, 4)));
+  TEST_ASSERT_EQUAL_INT(C4_FORK_GLOAS, c4_eth_fork_from_digest(C4_CHAIN_PLATABERGET, wire.data + 8));
   safe_free(wire.data);
 }
 
 static bytes_t assemble_dummy_gloas_lcu(void) {
-  uint8_t attested_header[C4_GLOAS_LCU_HEADER_SIZE]            = {0};
-  uint8_t finalized_header[C4_GLOAS_LCU_HEADER_SIZE]           = {0};
+  uint8_t attested_header[C4_GLOAS_LCU_HEADER_SIZE]             = {0};
+  uint8_t finalized_header[C4_GLOAS_LCU_HEADER_SIZE]            = {0};
   uint8_t next_sync_committee[C4_GLOAS_LCU_SYNC_COMMITTEE_SIZE] = {0};
-  uint8_t next_sc_branch[C4_GLOAS_LCU_NEXT_SC_BRANCH_SIZE]     = {0};
-  uint8_t finality_branch[C4_GLOAS_LCU_FINALITY_BRANCH_SIZE]   = {0};
-  uint8_t sync_aggregate[C4_GLOAS_LCU_SYNC_AGGREGATE_SIZE]     = {0};
+  uint8_t next_sc_branch[C4_GLOAS_LCU_NEXT_SC_BRANCH_SIZE]      = {0};
+  uint8_t finality_branch[C4_GLOAS_LCU_FINALITY_BRANCH_SIZE]    = {0};
+  uint8_t sync_aggregate[C4_GLOAS_LCU_SYNC_AGGREGATE_SIZE]      = {0};
   build_dummy_lc_header(attested_header, 0x11);
   build_dummy_lc_header(finalized_header, 0x22);
   build_dummy_sync_aggregate(sync_aggregate);
@@ -385,11 +385,11 @@ void test_lighthouse_payload_size_26424_is_gloas(void) {
   // Lighthouse list encoding has no ForkDigest: a 4-byte offset table followed
   // by length+payload. `fork_from_lcu_payload` must key off the unique 26424
   // Gloas size rather than a digest lookup.
-  const uint32_t offset     = 4;
-  const uint64_t length     = 4u + (uint64_t) C4_GLOAS_LCU_SSZ_SIZE;
-  const uint32_t data_off   = offset + LIGHTHOUSE_OFFSET_SIZE + SSZ_OFFSET_SIZE;
-  const uint32_t total      = data_off + C4_GLOAS_LCU_SSZ_SIZE;
-  uint8_t*       wire       = (uint8_t*) safe_calloc(1, total);
+  const uint32_t offset   = 4;
+  const uint64_t length   = 4u + (uint64_t) C4_GLOAS_LCU_SSZ_SIZE;
+  const uint32_t data_off = offset + LIGHTHOUSE_OFFSET_SIZE + SSZ_OFFSET_SIZE;
+  const uint32_t total    = data_off + C4_GLOAS_LCU_SSZ_SIZE;
+  uint8_t*       wire     = (uint8_t*) safe_calloc(1, total);
   uint32_to_le(wire, offset);
   uint64_to_le(wire + offset, length);
   memcpy(wire + data_off, lcu.data, lcu.len);

--- a/test/unittests/test_lcu_gloas.c
+++ b/test/unittests/test_lcu_gloas.c
@@ -31,7 +31,6 @@
 #include "c4_assert.h"
 #include "lcu_gloas.h"
 #include "ssz.h"
-#include "sync_committee.h"
 #include "unity.h"
 #include <string.h>
 
@@ -345,68 +344,6 @@ void test_gloas_lcu_wrap_roundtrip_fork_digest(void) {
   safe_free(wire.data);
 }
 
-static bytes_t assemble_dummy_gloas_lcu(void) {
-  uint8_t attested_header[C4_GLOAS_LCU_HEADER_SIZE]             = {0};
-  uint8_t finalized_header[C4_GLOAS_LCU_HEADER_SIZE]            = {0};
-  uint8_t next_sync_committee[C4_GLOAS_LCU_SYNC_COMMITTEE_SIZE] = {0};
-  uint8_t next_sc_branch[C4_GLOAS_LCU_NEXT_SC_BRANCH_SIZE]      = {0};
-  uint8_t finality_branch[C4_GLOAS_LCU_FINALITY_BRANCH_SIZE]    = {0};
-  uint8_t sync_aggregate[C4_GLOAS_LCU_SYNC_AGGREGATE_SIZE]      = {0};
-  build_dummy_lc_header(attested_header, 0x11);
-  build_dummy_lc_header(finalized_header, 0x22);
-  build_dummy_sync_aggregate(sync_aggregate);
-
-  bytes_t lcu = NULL_BYTES;
-  TEST_ASSERT_TRUE(c4_gloas_lcu_assemble(
-      bytes(attested_header, sizeof(attested_header)),
-      bytes(next_sync_committee, sizeof(next_sync_committee)),
-      bytes(next_sc_branch, sizeof(next_sc_branch)),
-      bytes(finalized_header, sizeof(finalized_header)),
-      bytes(finality_branch, sizeof(finality_branch)),
-      bytes(sync_aggregate, sizeof(sync_aggregate)),
-      0x100,
-      &lcu));
-  return lcu;
-}
-
-static const ssz_def_t* g_lighthouse_lcu_def;
-
-static bool capture_lighthouse_lcu_def(verify_ctx_t* ctx, ssz_ob_t* update) {
-  (void) ctx;
-  g_lighthouse_lcu_def = update->def;
-  TEST_ASSERT_EQUAL_UINT32(C4_GLOAS_LCU_SSZ_SIZE, update->bytes.len);
-  return true;
-}
-
-void test_lighthouse_payload_size_26424_is_gloas(void) {
-  bytes_t lcu = assemble_dummy_gloas_lcu();
-  TEST_ASSERT_EQUAL_UINT32(C4_GLOAS_LCU_SSZ_SIZE, lcu.len);
-
-  // Lighthouse list encoding has no ForkDigest: a 4-byte offset table followed
-  // by length+payload. `fork_from_lcu_payload` must key off the unique 26424
-  // Gloas size rather than a digest lookup.
-  const uint32_t offset   = 4;
-  const uint64_t length   = 4u + (uint64_t) C4_GLOAS_LCU_SSZ_SIZE;
-  const uint32_t data_off = offset + LIGHTHOUSE_OFFSET_SIZE + SSZ_OFFSET_SIZE;
-  const uint32_t total    = data_off + C4_GLOAS_LCU_SSZ_SIZE;
-  uint8_t*       wire     = (uint8_t*) safe_calloc(1, total);
-  uint32_to_le(wire, offset);
-  uint64_to_le(wire + offset, length);
-  memcpy(wire + data_off, lcu.data, lcu.len);
-
-  g_lighthouse_lcu_def = NULL;
-  verify_ctx_t ctx     = {0};
-  ctx.chain_id         = C4_CHAIN_PLATABERGET;
-  TEST_ASSERT_TRUE_MESSAGE(c4_process_light_client_updates(&ctx, bytes(wire, total), capture_lighthouse_lcu_def),
-                           ctx.state.error ? ctx.state.error : "lighthouse Gloas LCU must parse");
-  TEST_ASSERT_EQUAL_PTR(eth_get_light_client_update(C4_FORK_GLOAS), g_lighthouse_lcu_def);
-  TEST_ASSERT_EQUAL_STRING("GloasLightClientUpdate", g_lighthouse_lcu_def->name);
-
-  c4_state_free(&ctx.state);
-  safe_free(wire);
-  safe_free(lcu.data);
-}
-
 void test_gloas_lcu_wrap_beacon_response_rejects_invalid(void) {
   uint8_t lcu_bytes[C4_GLOAS_LCU_SSZ_SIZE] = {0};
   uint8_t fork_digest[4]                   = {0xde, 0xad, 0xbe, 0xef};
@@ -429,7 +366,6 @@ int main(void) {
   RUN_TEST(test_gloas_lcu_assemble_size_mismatches_rejected);
   RUN_TEST(test_gloas_lcu_wrap_beacon_response_prefix);
   RUN_TEST(test_gloas_lcu_wrap_roundtrip_fork_digest);
-  RUN_TEST(test_lighthouse_payload_size_26424_is_gloas);
   RUN_TEST(test_gloas_lcu_wrap_beacon_response_rejects_invalid);
   return UNITY_END();
 }

--- a/test/unittests/test_lcu_gloas.c
+++ b/test/unittests/test_lcu_gloas.c
@@ -31,6 +31,7 @@
 #include "c4_assert.h"
 #include "lcu_gloas.h"
 #include "ssz.h"
+#include "sync_committee.h"
 #include "unity.h"
 #include <string.h>
 
@@ -307,12 +308,11 @@ void test_gloas_lcu_wrap_beacon_response_prefix(void) {
   for (uint32_t i = 0; i < C4_GLOAS_LCU_SSZ_SIZE; i++)
     lcu_bytes[i] = (uint8_t) (i & 0xff);
 
-  // Arbitrary 4-byte fork_version. The wrapper copies these bytes verbatim
-  // and never inspects them; the concrete Gloas value depends on the chain
-  // (`mainnet_fork_version` -> 0x07000000, plataberget -> 0x80733183, ...).
-  uint8_t fork_version[4] = {0xde, 0xad, 0xbe, 0xef};
-  bytes_t wire            = c4_gloas_lcu_wrap_beacon_response(
-      bytes(lcu_bytes, sizeof(lcu_bytes)), fork_version);
+  // Arbitrary 4-byte ForkDigest. The wrapper copies these bytes verbatim
+  // and never inspects them; the concrete Gloas digest depends on the chain.
+  uint8_t fork_digest[4] = {0xde, 0xad, 0xbe, 0xef};
+  bytes_t wire           = c4_gloas_lcu_wrap_beacon_response(
+      bytes(lcu_bytes, sizeof(lcu_bytes)), fork_digest);
   TEST_ASSERT_NOT_NULL_MESSAGE(wire.data, "wrap must produce a buffer");
   TEST_ASSERT_EQUAL_MESSAGE(C4_GLOAS_LCU_WIRE_SIZE, wire.len,
                             "wire response = 12 + LCU_SSZ_SIZE bytes");
@@ -324,9 +324,9 @@ void test_gloas_lcu_wrap_beacon_response_prefix(void) {
     TEST_ASSERT_EQUAL_UINT8_MESSAGE(expected, wire.data[i],
                                     "length prefix LE byte mismatch");
   }
-  // fork_version at offset 8..12.
-  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(fork_version, wire.data + 8, 4,
-                                        "fork_version at offset 8");
+  // ForkDigest at offset 8..12.
+  TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(fork_digest, wire.data + 8, 4,
+                                        "fork_digest at offset 8");
   // Payload starts at offset 12.
   TEST_ASSERT_EQUAL_UINT8_ARRAY_MESSAGE(
       lcu_bytes, wire.data + C4_GLOAS_LCU_WIRE_PREFIX_SIZE,
@@ -335,19 +335,91 @@ void test_gloas_lcu_wrap_beacon_response_prefix(void) {
   safe_free(wire.data);
 }
 
+void test_gloas_lcu_wrap_roundtrip_fork_digest(void) {
+  uint8_t lcu_bytes[C4_GLOAS_LCU_SSZ_SIZE] = {0};
+  uint8_t digest[4]                        = {0};
+  TEST_ASSERT_TRUE(c4_eth_compute_fork_digest(C4_CHAIN_PLATABERGET, C4_FORK_GLOAS, digest));
+  bytes_t wire = c4_gloas_lcu_wrap_beacon_response(bytes(lcu_bytes, sizeof(lcu_bytes)), digest);
+  TEST_ASSERT_NOT_NULL(wire.data);
+  TEST_ASSERT_EQUAL_INT(C4_FORK_GLOAS, c4_eth_get_fork_for_lcu(C4_CHAIN_PLATABERGET, bytes(wire.data + 8, 4)));
+  safe_free(wire.data);
+}
+
+static bytes_t assemble_dummy_gloas_lcu(void) {
+  uint8_t attested_header[C4_GLOAS_LCU_HEADER_SIZE]            = {0};
+  uint8_t finalized_header[C4_GLOAS_LCU_HEADER_SIZE]           = {0};
+  uint8_t next_sync_committee[C4_GLOAS_LCU_SYNC_COMMITTEE_SIZE] = {0};
+  uint8_t next_sc_branch[C4_GLOAS_LCU_NEXT_SC_BRANCH_SIZE]     = {0};
+  uint8_t finality_branch[C4_GLOAS_LCU_FINALITY_BRANCH_SIZE]   = {0};
+  uint8_t sync_aggregate[C4_GLOAS_LCU_SYNC_AGGREGATE_SIZE]     = {0};
+  build_dummy_lc_header(attested_header, 0x11);
+  build_dummy_lc_header(finalized_header, 0x22);
+  build_dummy_sync_aggregate(sync_aggregate);
+
+  bytes_t lcu = NULL_BYTES;
+  TEST_ASSERT_TRUE(c4_gloas_lcu_assemble(
+      bytes(attested_header, sizeof(attested_header)),
+      bytes(next_sync_committee, sizeof(next_sync_committee)),
+      bytes(next_sc_branch, sizeof(next_sc_branch)),
+      bytes(finalized_header, sizeof(finalized_header)),
+      bytes(finality_branch, sizeof(finality_branch)),
+      bytes(sync_aggregate, sizeof(sync_aggregate)),
+      0x100,
+      &lcu));
+  return lcu;
+}
+
+static const ssz_def_t* g_lighthouse_lcu_def;
+
+static bool capture_lighthouse_lcu_def(verify_ctx_t* ctx, ssz_ob_t* update) {
+  (void) ctx;
+  g_lighthouse_lcu_def = update->def;
+  TEST_ASSERT_EQUAL_UINT32(C4_GLOAS_LCU_SSZ_SIZE, update->bytes.len);
+  return true;
+}
+
+void test_lighthouse_payload_size_26424_is_gloas(void) {
+  bytes_t lcu = assemble_dummy_gloas_lcu();
+  TEST_ASSERT_EQUAL_UINT32(C4_GLOAS_LCU_SSZ_SIZE, lcu.len);
+
+  // Lighthouse list encoding has no ForkDigest: a 4-byte offset table followed
+  // by length+payload. `fork_from_lcu_payload` must key off the unique 26424
+  // Gloas size rather than a digest lookup.
+  const uint32_t offset     = 4;
+  const uint64_t length     = 4u + (uint64_t) C4_GLOAS_LCU_SSZ_SIZE;
+  const uint32_t data_off   = offset + LIGHTHOUSE_OFFSET_SIZE + SSZ_OFFSET_SIZE;
+  const uint32_t total      = data_off + C4_GLOAS_LCU_SSZ_SIZE;
+  uint8_t*       wire       = (uint8_t*) safe_calloc(1, total);
+  uint32_to_le(wire, offset);
+  uint64_to_le(wire + offset, length);
+  memcpy(wire + data_off, lcu.data, lcu.len);
+
+  g_lighthouse_lcu_def = NULL;
+  verify_ctx_t ctx     = {0};
+  ctx.chain_id         = C4_CHAIN_PLATABERGET;
+  TEST_ASSERT_TRUE_MESSAGE(c4_process_light_client_updates(&ctx, bytes(wire, total), capture_lighthouse_lcu_def),
+                           ctx.state.error ? ctx.state.error : "lighthouse Gloas LCU must parse");
+  TEST_ASSERT_EQUAL_PTR(eth_get_light_client_update(C4_FORK_GLOAS), g_lighthouse_lcu_def);
+  TEST_ASSERT_EQUAL_STRING("GloasLightClientUpdate", g_lighthouse_lcu_def->name);
+
+  c4_state_free(&ctx.state);
+  safe_free(wire);
+  safe_free(lcu.data);
+}
+
 void test_gloas_lcu_wrap_beacon_response_rejects_invalid(void) {
   uint8_t lcu_bytes[C4_GLOAS_LCU_SSZ_SIZE] = {0};
-  uint8_t fork_version[4]                  = {0xde, 0xad, 0xbe, 0xef};
+  uint8_t fork_digest[4]                   = {0xde, 0xad, 0xbe, 0xef};
 
   // NULL data pointer.
   bytes_t null_input = {.data = NULL, .len = C4_GLOAS_LCU_SSZ_SIZE};
-  bytes_t r          = c4_gloas_lcu_wrap_beacon_response(null_input, fork_version);
+  bytes_t r          = c4_gloas_lcu_wrap_beacon_response(null_input, fork_digest);
   TEST_ASSERT_NULL_MESSAGE(r.data, "NULL data pointer must be rejected");
   TEST_ASSERT_EQUAL_UINT32_MESSAGE(0, r.len, "returned bytes_t must be zero on failure");
 
   // Wrong LCU length -> NULL_BYTES.
   bytes_t short_lcu = {.data = lcu_bytes, .len = C4_GLOAS_LCU_SSZ_SIZE - 1};
-  r                 = c4_gloas_lcu_wrap_beacon_response(short_lcu, fork_version);
+  r                 = c4_gloas_lcu_wrap_beacon_response(short_lcu, fork_digest);
   TEST_ASSERT_NULL_MESSAGE(r.data, "wrong LCU length must be rejected");
 }
 
@@ -356,6 +428,8 @@ int main(void) {
   RUN_TEST(test_gloas_lcu_assemble_layout_and_validity);
   RUN_TEST(test_gloas_lcu_assemble_size_mismatches_rejected);
   RUN_TEST(test_gloas_lcu_wrap_beacon_response_prefix);
+  RUN_TEST(test_gloas_lcu_wrap_roundtrip_fork_digest);
+  RUN_TEST(test_lighthouse_payload_size_26424_is_gloas);
   RUN_TEST(test_gloas_lcu_wrap_beacon_response_rejects_invalid);
   return UNITY_END();
 }

--- a/test/unittests/test_ssz_gloas.c
+++ b/test/unittests/test_ssz_gloas.c
@@ -254,7 +254,7 @@ void test_gloas_update_union_layout(void) {
   TEST_ASSERT_EQUAL_PTR_MESSAGE(d + 2, g, "Gloas update must be at update-union index 2");
 
   // The container names embedded in the union are the on-wire discriminators
-  // used by the `ssz_dump` output and by `c4_eth_get_fork_for_lcu` callers.
+  // used by the `ssz_dump` output and by `c4_eth_fork_from_digest` callers.
   TEST_ASSERT_EQUAL_STRING("DenepLightClientUpdate", d->name);
   TEST_ASSERT_EQUAL_STRING("ElectraLightClientUpdate", e->name);
   TEST_ASSERT_EQUAL_STRING("GloasLightClientUpdate", g->name);


### PR DESCRIPTION
## Summary
- Replace the slot-offset LCU fork heuristic with a spec-accurate match of the 4-byte Beacon-API `ForkDigest` (plus BPO variants of the same `fork_id`).
- Add CL `BLOB_SCHEDULE` / `c4_eth_compute_fork_digest` (Fulu XOR) and fail closed on unknown digests with a shared upgrade hint instead of parsing as Gloas.
- Thread the wire digest through prover, verifier, period store, CLI, and the Gloas Beacon-API wrapper.

## Test plan
- [ ] `./build/default/test/unittests/test_eth_chain_spec` (digest/BPO/Gnosis/unscheduled Gloas)
- [ ] `./build/default/test/unittests/test_lcu_gloas` (wrapper roundtrip + Lighthouse 26424)
- [ ] `./build/default/test/unittests/test_eth_sync`
- [ ] CI cmake + unit tests on this PR